### PR TITLE
Add scout year offset (effective-age single source of truth)

### DIFF
--- a/core/Database/Connection.php
+++ b/core/Database/Connection.php
@@ -52,7 +52,7 @@ class Connection
     /**
      * Test the connection. Returns true on success, error message string on failure.
      */
-    public function testConnection(): true|string
+    public function testConnection(): bool|string
     {
         try {
             $this->getPdo();

--- a/core/Http/Controller/MemberController.php
+++ b/core/Http/Controller/MemberController.php
@@ -6,9 +6,14 @@ namespace Core\Http\Controller;
 
 use Core\Http\Request;
 use Core\Http\Response;
+use Core\Journal\JournalService;
+use Core\Member\EffectiveAge;
 use Core\Member\MemberNotFoundException;
+use Core\Member\MemberProfile;
 use Core\Member\MemberService;
+use Core\Member\MemberYearService;
 use Core\Security\AuthSession;
+use Core\Security\CsrfGuard;
 use Core\Security\Role;
 use Twig\Environment;
 
@@ -16,7 +21,9 @@ class MemberController extends AbstractController
 {
     public function __construct(
         protected Environment $twig,
-        private MemberService $memberService
+        private MemberService $memberService,
+        private MemberYearService $memberYearService,
+        private JournalService $journalService
     ) {
     }
 
@@ -56,6 +63,74 @@ class MemberController extends AbstractController
             'member' => $profile,
             'show_contact' => $showContact,
             'show_addresses' => $showAddresses,
+            'show_site_data' => $isChiefOrAbove,
+            'effective_age' => $this->computeEffectiveAge($profile),
         ]);
+    }
+
+    /**
+     * POST /members/{id}/scout-year-offset — update a member's scout year
+     * offset (AJAX, JSON). role_min: chief, enforced by the router.
+     *
+     * @param array<string, string> $params
+     */
+    public function updateScoutYearOffset(Request $request, array $params): Response
+    {
+        $memberYearId = (int) $params['id'];
+
+        $json = json_decode($request->getRawBody(), true);
+        if (!is_array($json)) {
+            return $this->json(['success' => false, 'error' => 'Requête invalide.'], 400);
+        }
+
+        if (!CsrfGuard::validateToken((string) ($json['_csrf_token'] ?? ''))) {
+            return $this->json(['success' => false, 'error' => 'Jeton CSRF invalide.'], 403);
+        }
+
+        $offset = isset($json['offset']) ? (int) $json['offset'] : null;
+        if (!in_array($offset, [-1, 0, 1], true)) {
+            return $this->json(['success' => false, 'error' => 'Décalage invalide.'], 400);
+        }
+
+        try {
+            $profile = $this->memberService->getMemberProfile($memberYearId);
+        } catch (MemberNotFoundException $e) {
+            return $this->json(['success' => false, 'error' => 'Membre introuvable.'], 404);
+        }
+
+        $oldOffset = $profile->scoutYearOffset;
+        $this->memberService->updateScoutYearOffset($memberYearId, $offset);
+
+        if ($oldOffset !== $offset) {
+            $this->journalService->log(
+                'core',
+                'member_scout_year_offset_changed',
+                'info',
+                'Décalage année scoute modifié pour un membre',
+                ['member_year_id' => $memberYearId, 'old_offset' => $oldOffset, 'new_offset' => $offset],
+                AuthSession::getUserAccountId()
+            );
+        }
+
+        $effectiveAge = $this->memberYearService->getEffectiveAge(
+            MemberYearService::extractBirthYear($profile->birthDate),
+            $offset,
+            MemberYearService::referenceYearFromScoutYearLabel($profile->scoutYearLabel)
+        );
+
+        return $this->json([
+            'success' => true,
+            'branch_year_label' => $effectiveAge->getBranchYearLabel(),
+            'branch_color' => $effectiveAge->branchColor,
+        ]);
+    }
+
+    private function computeEffectiveAge(MemberProfile $profile): EffectiveAge
+    {
+        return $this->memberYearService->getEffectiveAge(
+            MemberYearService::extractBirthYear($profile->birthDate),
+            $profile->scoutYearOffset,
+            MemberYearService::referenceYearFromScoutYearLabel($profile->scoutYearLabel)
+        );
     }
 }

--- a/core/Import/MemberYearRepository.php
+++ b/core/Import/MemberYearRepository.php
@@ -248,6 +248,15 @@ class MemberYearRepository
     }
 
     /**
+     * Update a member year's scout year offset (-1, 0, or +1).
+     */
+    public function updateScoutYearOffset(int $memberYearId, int $offset): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE member_years SET scout_year_offset = ? WHERE id = ?');
+        $stmt->execute([$offset, $memberYearId]);
+    }
+
+    /**
      * Find a member year by ID.
      *
      * @return array<string, mixed>|null

--- a/core/Member/EffectiveAge.php
+++ b/core/Member/EffectiveAge.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Core\Member;
+
+/**
+ * Result of MemberYearService::getEffectiveAge(): a member's effective age and,
+ * when that age falls within one of the four Les Scouts "animés" branches, the
+ * branch and the 1-based year within that branch.
+ *
+ * Branch fields are null when the effective age (or the birth year it was
+ * computed from) is unknown or falls outside every branch range — e.g. staff
+ * members, or a member with no birth date on file.
+ */
+final class EffectiveAge
+{
+    public function __construct(
+        public readonly ?int $age,
+        public readonly ?string $branchKey,
+        public readonly ?string $branchName,
+        public readonly ?string $branchColor,
+        public readonly ?int $yearInBranch,
+        public readonly ?int $totalYearsInBranch
+    ) {
+    }
+
+    public function isInKnownBranch(): bool
+    {
+        return $this->branchKey !== null;
+    }
+
+    /**
+     * French display label, e.g. "2e année louveteaux". Empty string when the
+     * age isn't in any known branch.
+     */
+    public function getBranchYearLabel(): string
+    {
+        if ($this->branchName === null || $this->yearInBranch === null) {
+            return '';
+        }
+
+        $ordinal = $this->yearInBranch === 1 ? '1ère année' : $this->yearInBranch . 'e année';
+
+        return $ordinal . ' ' . mb_strtolower($this->branchName);
+    }
+}

--- a/core/Member/MemberProfile.php
+++ b/core/Member/MemberProfile.php
@@ -31,7 +31,8 @@ class MemberProfile
         public readonly array $functions,
         public readonly string $scoutYearLabel,
         public readonly ?string $handicap = null,
-        public readonly ?string $supplementaryInsurance = null
+        public readonly ?string $supplementaryInsurance = null,
+        public readonly int $scoutYearOffset = 0
     ) {
     }
 

--- a/core/Member/MemberService.php
+++ b/core/Member/MemberService.php
@@ -183,7 +183,17 @@ class MemberService
             supplementaryInsurance: $row['supplementary_insurance'] ?? null,
             addresses: $addresses,
             functions: $functions,
-            scoutYearLabel: $scoutYearLabel
+            scoutYearLabel: $scoutYearLabel,
+            scoutYearOffset: (int) ($row['scout_year_offset'] ?? 0)
         );
+    }
+
+    /**
+     * Update a member's scout year offset (-1, 0, or +1). Plain operational
+     * flag, not personal data — no encryption involved.
+     */
+    public function updateScoutYearOffset(int $memberYearId, int $offset): void
+    {
+        $this->memberYearRepo->updateScoutYearOffset($memberYearId, $offset);
     }
 }

--- a/core/Member/MemberYearService.php
+++ b/core/Member/MemberYearService.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Core\Member;
+
+/**
+ * Single source of truth for a member's effective age, branch, and year within
+ * that branch, for a given scout year.
+ *
+ * Every existing and future feature that needs to know "which branch-year is
+ * this member in" must call getEffectiveAge() — never recompute a branch/year
+ * from birth year alone. scout_year_offset lets a chief shift a member's
+ * effective age by one year (ahead or behind) relative to what their birth
+ * year would normally give, e.g. for a member who skipped or repeated a year.
+ *
+ * This service never touches encrypted data: birth year decryption stays in
+ * the Repository layer (SECURITY.md §5); callers pass already-decrypted values.
+ */
+class MemberYearService
+{
+    /**
+     * The four Les Scouts "animés" branches, in federation-fixed age order.
+     * These age ranges are federation domain knowledge and are NOT stored in
+     * the database — the age_branches table holds the branch catalogue itself
+     * (desk codes, labels, sort order) which this key matches by name.
+     *
+     * @var array<int, array{key: string, name: string, age_min: int, age_max: int, color: string}>
+     */
+    public const BRANCHES = [
+        ['key' => 'baladin',   'name' => 'Baladins',   'age_min' => 6,  'age_max' => 7,  'color' => '#378ADD'],
+        ['key' => 'louveteau', 'name' => 'Louveteaux', 'age_min' => 8,  'age_max' => 11, 'color' => '#639922'],
+        ['key' => 'eclaireur', 'name' => 'Éclaireurs', 'age_min' => 12, 'age_max' => 15, 'color' => '#1D9E75'],
+        ['key' => 'pionnier',  'name' => 'Pionniers',  'age_min' => 16, 'age_max' => 17, 'color' => '#D85A30'],
+    ];
+
+    /**
+     * Compute a member's effective age and branch-year for a scout year.
+     *
+     *     effective_age = referenceYear − birthYear + scoutYearOffset
+     *
+     * @param ?int $birthYear      Calendar year of birth, already decrypted by the
+     *                             caller's Repository. Null when unknown (e.g. no
+     *                             birth date on file) — the result then carries a
+     *                             null age and no branch.
+     * @param int  $scoutYearOffset -1, 0, or +1 (member_years.scout_year_offset).
+     * @param int  $referenceYear  The scout year's reference calendar year — its
+     *                             START year (see referenceYearFromScoutYearLabel()).
+     *                             Deliberately NOT today's date, so a member's
+     *                             branch never shifts mid-year.
+     */
+    public function getEffectiveAge(?int $birthYear, int $scoutYearOffset, int $referenceYear): EffectiveAge
+    {
+        if ($birthYear === null) {
+            return new EffectiveAge(null, null, null, null, null, null);
+        }
+
+        $age = $referenceYear - $birthYear + $scoutYearOffset;
+
+        foreach (self::BRANCHES as $branch) {
+            if ($age >= $branch['age_min'] && $age <= $branch['age_max']) {
+                return new EffectiveAge(
+                    age: $age,
+                    branchKey: $branch['key'],
+                    branchName: $branch['name'],
+                    branchColor: $branch['color'],
+                    yearInBranch: $age - $branch['age_min'] + 1,
+                    totalYearsInBranch: $branch['age_max'] - $branch['age_min'] + 1
+                );
+            }
+        }
+
+        return new EffectiveAge($age, null, null, null, null, null);
+    }
+
+    /**
+     * Extract a calendar birth year from a decrypted birth date string.
+     * Handles both "YYYY-MM-DD" and "DD/MM/YYYY". Returns null when the value
+     * is empty or unparseable.
+     */
+    public static function extractBirthYear(?string $birthDate): ?int
+    {
+        if ($birthDate === null || $birthDate === '') {
+            return null;
+        }
+        if (preg_match('/(?<!\d)(19\d{2}|20\d{2})(?!\d)/', $birthDate, $m) === 1) {
+            return (int) $m[1];
+        }
+        return null;
+    }
+
+    /**
+     * The reference calendar year for a scout year is its START year: a scout
+     * year "2025-2026" runs from September 2025, and Les Scouts defines each
+     * branch's cohorts by that start year. This must NOT depend on today's
+     * date, so the same scout year always yields the same branch-year — for
+     * the current scout year as well as when looking at a past one.
+     */
+    public static function referenceYearFromScoutYearLabel(string $label): int
+    {
+        if (preg_match('/(\d{4})/', $label, $m) === 1) {
+            return (int) $m[1];
+        }
+        return (int) date('Y');
+    }
+}

--- a/core/View/templates/members/show.html.twig
+++ b/core/View/templates/members/show.html.twig
@@ -124,6 +124,83 @@
         </div>
     </div>
 
+    {# Données du site — chief/admin only #}
+    {% if show_site_data %}
+        <div class="card mb-3" id="scout-year-offset-card" data-member-year-id="{{ member.memberYearId }}">
+            <div class="card-body">
+                <h2 class="h5 d-flex align-items-center gap-2 mb-3"><i class="bi bi-globe"></i> Données du site</h2>
+
+                <label class="form-label fw-semibold mb-1">Décalage année scoute</label>
+                <p class="text-body-secondary small mb-2">
+                    Ajuster si ce membre est en avance ou en retard d'un an.
+                </p>
+
+                <div class="btn-group" role="group" aria-label="Décalage année scoute">
+                    <button type="button"
+                            class="btn btn-outline-secondary offset-btn{{ member.scoutYearOffset == -1 ? ' active' : '' }}"
+                            style="min-height:44px;" data-offset="-1">−1 an</button>
+                    <button type="button"
+                            class="btn btn-outline-secondary offset-btn{{ member.scoutYearOffset == 0 ? ' active' : '' }}"
+                            style="min-height:44px;" data-offset="0">Normal</button>
+                    <button type="button"
+                            class="btn btn-outline-secondary offset-btn{{ member.scoutYearOffset == 1 ? ' active' : '' }}"
+                            style="min-height:44px;" data-offset="1">+1 an</button>
+                </div>
+
+                <div class="mt-3">
+                    <span class="badge rounded-pill text-bg-light border d-inline-flex align-items-center gap-2">
+                        <span class="rounded-circle d-inline-block" id="scout-year-offset-dot"
+                              style="width:10px;height:10px;background-color:{{ effective_age.branchColor|default('#adb5bd') }};"></span>
+                        <span id="scout-year-offset-label">{{ effective_age.getBranchYearLabel()|default('') != '' ? effective_age.getBranchYearLabel() : '—' }}</span>
+                    </span>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+
     {# Module sections will be injected here in future iterations #}
     {# Each module can add cards to the member page via a hook #}
+{% endblock %}
+
+{% block scripts %}
+<script nonce="{{ csp_nonce }}">
+(() => {
+    const card = document.getElementById('scout-year-offset-card');
+    if (!card) return;
+
+    const memberYearId = card.dataset.memberYearId;
+    const buttons = card.querySelectorAll('.offset-btn');
+    const dot = document.getElementById('scout-year-offset-dot');
+    const label = document.getElementById('scout-year-offset-label');
+    const csrf = document.querySelector('meta[name="csrf-token"]')?.content;
+
+    buttons.forEach(btn => {
+        btn.addEventListener('click', async () => {
+            const offset = parseInt(btn.dataset.offset, 10);
+
+            buttons.forEach(b => b.disabled = true);
+            try {
+                const res = await fetch(`/members/${memberYearId}/scout-year-offset`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ offset, _csrf_token: csrf })
+                });
+                const data = await res.json();
+
+                if (data.success) {
+                    buttons.forEach(b => b.classList.toggle('active', parseInt(b.dataset.offset, 10) === offset));
+                    label.textContent = data.branch_year_label || '—';
+                    if (data.branch_color) {
+                        dot.style.backgroundColor = data.branch_color;
+                    }
+                } else {
+                    alert(data.error);
+                }
+            } finally {
+                buttons.forEach(b => b.disabled = false);
+            }
+        });
+    });
+})();
+</script>
 {% endblock %}

--- a/modules/member_stats/src/Controller/MemberStatsController.php
+++ b/modules/member_stats/src/Controller/MemberStatsController.php
@@ -7,6 +7,7 @@ namespace Modules\MemberStats\Controller;
 use Core\Http\Controller\AbstractController;
 use Core\Http\Request;
 use Core\Http\Response;
+use Core\Member\MemberYearService;
 use Core\ScoutYear\ScoutYearResolver;
 use Core\ScoutYear\ScoutYearSession;
 use Core\Security\AuthSession;
@@ -35,7 +36,7 @@ class MemberStatsController extends AbstractController
 
         // Ages are computed from the scout year's start year (not today's date),
         // so the figures are stable and correct for past years too.
-        $referenceYear = MemberStatsService::referenceYearFromLabel($effectiveYear->label);
+        $referenceYear = MemberYearService::referenceYearFromScoutYearLabel($effectiveYear->label);
 
         $stats = $this->statsService->getStatistics($effectiveYear->id, $referenceYear);
 

--- a/modules/member_stats/src/Repository/MemberStatsRepository.php
+++ b/modules/member_stats/src/Repository/MemberStatsRepository.php
@@ -40,7 +40,7 @@ class MemberStatsRepository
     }
 
     /**
-     * @return array<int, array{branch_label: string, branch_sort_order: int, birth_date: ?string, gender: ?string}>
+     * @return array<int, array{branch_label: string, branch_sort_order: int, birth_date: ?string, gender: ?string, scout_year_offset: int}>
      */
     public function getMemberBranchData(int $scoutYearId): array
     {
@@ -53,6 +53,7 @@ class MemberStatsRepository
             'SELECT my.id AS member_year_id,
                     my.birth_date_encrypted,
                     my.gender_encrypted,
+                    my.scout_year_offset,
                     f.role AS function_role,
                     ab.label AS branch_label,
                     ab.sort_order AS branch_sort_order
@@ -89,6 +90,7 @@ class MemberStatsRepository
                 'branch_sort_order' => (int) $r['branch_sort_order'],
                 'birth_date' => $this->decryptNullable($r['birth_date_encrypted']),
                 'gender' => $this->decryptNullable($r['gender_encrypted']),
+                'scout_year_offset' => (int) $r['scout_year_offset'],
             ];
         }
 

--- a/modules/member_stats/src/Service/MemberStatsService.php
+++ b/modules/member_stats/src/Service/MemberStatsService.php
@@ -4,58 +4,32 @@ declare(strict_types=1);
 
 namespace Modules\MemberStats\Service;
 
+use Core\Member\MemberYearService;
 use Modules\MemberStats\Repository\MemberStatsRepository;
 
 /**
  * Turns raw (decrypted) per-member rows into anonymous aggregate counts for the
  * statistics page.
  *
- * Branch age ranges are federation domain knowledge and are NOT stored in the
- * database. Each member is mapped to one of the four "animés" branches by
- * matching their branch label, then placed into a year-within-branch computed
- * from their birth year and the branch age range. Only aggregate counts leave
- * this service — never individual member data.
+ * Branch and year-within-branch are derived exclusively via
+ * Core\Member\MemberYearService::getEffectiveAge() — the single source of
+ * truth for "which branch-year is this member in" — from each member's birth
+ * year and their scout_year_offset. Only aggregate counts leave this service —
+ * never individual member data.
  */
 class MemberStatsService
 {
-    /**
-     * The four Les Scouts "animés" branches, in display order (which matches
-     * age_branches.sort_order for these canonical branches). Each member's
-     * year within the branch is derived from age = referenceYear - birthYear.
-     *
-     * @var array<int, array{key: string, name: string, age_min: int, age_max: int, color: string}>
-     */
-    private const BRANCHES = [
-        ['key' => 'baladin',   'name' => 'Baladins',   'age_min' => 6,  'age_max' => 7,  'color' => '#378ADD'],
-        ['key' => 'louveteau', 'name' => 'Louveteaux', 'age_min' => 8,  'age_max' => 11, 'color' => '#639922'],
-        ['key' => 'eclaireur', 'name' => 'Éclaireurs', 'age_min' => 12, 'age_max' => 15, 'color' => '#1D9E75'],
-        ['key' => 'pionnier',  'name' => 'Pionniers',  'age_min' => 16, 'age_max' => 17, 'color' => '#D85A30'],
-    ];
-
-    public function __construct(private MemberStatsRepository $repository)
-    {
-    }
-
-    /**
-     * The reference calendar year for a scout year is its START year: a scout
-     * year "2025-2026" runs from September 2025, and Les Scouts defines each
-     * branch's cohorts by that start year (e.g. baladins in 2025-2026 are the
-     * children born in 2018 and 2019). This must NOT depend on today's date, so
-     * the same scout year always yields the same figures.
-     */
-    public static function referenceYearFromLabel(string $label): int
-    {
-        if (preg_match('/(\d{4})/', $label, $m) === 1) {
-            return (int) $m[1];
-        }
-        return (int) date('Y');
+    public function __construct(
+        private MemberStatsRepository $repository,
+        private MemberYearService $memberYearService = new MemberYearService()
+    ) {
     }
 
     /**
      * Build the aggregated statistics view model for a scout year.
      *
      * @param int $referenceYear Calendar year used to convert birth year → age
-     *                           (typically the current year).
+     *                           (typically the scout year's start year).
      * @return array{
      *     totals: array{total: int, male: int, female: int, other: int},
      *     max_count: int,
@@ -69,7 +43,7 @@ class MemberStatsService
     {
         // Initialise an empty count grid: branch key → year index (1-based) → bucket.
         $counts = [];
-        foreach (self::BRANCHES as $branch) {
+        foreach (MemberYearService::BRANCHES as $branch) {
             $years = $branch['age_max'] - $branch['age_min'] + 1;
             for ($y = 1; $y <= $years; $y++) {
                 $counts[$branch['key']][$y] = ['total' => 0, 'male' => 0, 'female' => 0, 'other' => 0];
@@ -78,22 +52,17 @@ class MemberStatsService
 
         $rows = $this->repository->getMemberBranchData($scoutYearId);
         foreach ($rows as $row) {
-            $branch = $this->matchBranch($row['branch_label']);
-            if ($branch === null) {
-                continue; // not one of the four animés branches (e.g. Staff d'U, Route)
+            $birthYear = MemberYearService::extractBirthYear($row['birth_date']);
+            $effectiveAge = $this->memberYearService->getEffectiveAge($birthYear, $row['scout_year_offset'], $referenceYear);
+
+            if (!$effectiveAge->isInKnownBranch()) {
+                continue; // no usable birth year, or effective age outside the four animés branches
             }
 
-            $birthYear = $this->extractYear($row['birth_date']);
-            if ($birthYear === null) {
-                continue; // cannot place a member without a usable birth year
-            }
-
-            $age = $referenceYear - $birthYear;
-            $yearIndex = $this->clampYearIndex($age, $branch);
             $bucket = $this->classifyGender($row['gender']);
 
-            $counts[$branch['key']][$yearIndex]['total']++;
-            $counts[$branch['key']][$yearIndex][$bucket]++;
+            $counts[$effectiveAge->branchKey][$effectiveAge->yearInBranch]['total']++;
+            $counts[$effectiveAge->branchKey][$effectiveAge->yearInBranch][$bucket]++;
         }
 
         return $this->buildViewModel($counts, $referenceYear);
@@ -113,7 +82,7 @@ class MemberStatsService
         $maxCount = 0;
         $branches = [];
 
-        foreach (self::BRANCHES as $branch) {
+        foreach (MemberYearService::BRANCHES as $branch) {
             $rows = [];
             $years = $branch['age_max'] - $branch['age_min'] + 1;
             for ($y = 1; $y <= $years; $y++) {
@@ -149,55 +118,6 @@ class MemberStatsService
             'max_count' => $maxCount,
             'branches' => $branches,
         ];
-    }
-
-    /**
-     * Match a Desk branch label to one of the four animés branch definitions.
-     * Uses the same substring approach as the core AgeBranchRepository.
-     *
-     * @return array{key: string, name: string, age_min: int, age_max: int, color: string}|null
-     */
-    private function matchBranch(string $label): ?array
-    {
-        $normalized = mb_strtolower(trim($label));
-        foreach (self::BRANCHES as $branch) {
-            if (str_contains($normalized, $branch['key'])) {
-                return $branch;
-            }
-        }
-        // 'éclaireur' with accent still contains 'eclaireur' only after stripping
-        // the accent, so handle the accented form explicitly.
-        if (str_contains($normalized, 'éclaireur')) {
-            return self::BRANCHES[2];
-        }
-        return null;
-    }
-
-    /**
-     * Clamp a member's age to the branch range and return the 1-based year index.
-     *
-     * @param array{key: string, name: string, age_min: int, age_max: int, color: string} $branch
-     */
-    private function clampYearIndex(int $age, array $branch): int
-    {
-        $index = $age - $branch['age_min'] + 1;
-        $years = $branch['age_max'] - $branch['age_min'] + 1;
-        return max(1, min($years, $index));
-    }
-
-    /**
-     * Extract a plausible 4-digit birth year from a decrypted date string.
-     * Handles both "YYYY-MM-DD" and "DD/MM/YYYY".
-     */
-    private function extractYear(?string $birthDate): ?int
-    {
-        if ($birthDate === null || $birthDate === '') {
-            return null;
-        }
-        if (preg_match('/(?<!\d)(19\d{2}|20\d{2})(?!\d)/', $birthDate, $m) === 1) {
-            return (int) $m[1];
-        }
-        return null;
     }
 
     private function classifyGender(?string $gender): string

--- a/public/index.php
+++ b/public/index.php
@@ -56,6 +56,7 @@ use Core\Import\MemberRepository;
 use Core\Import\MemberYearRepository;
 use Core\Member\Controller\MemberSearchController;
 use Core\Member\MemberService;
+use Core\Member\MemberYearService;
 use Core\Member\Repository\MemberSearchRepository;
 use Core\Member\Service\MemberSearchService;
 use Core\Member\SectionService;
@@ -329,6 +330,7 @@ $importService = new DeskImportService(
 );
 $roleResolver = new RoleResolver($memberYearRepo, $encryptionService, $pdo);
 $memberService = new MemberService($memberYearRepo, $encryptionService, $connection);
+$memberYearService = new MemberYearService();
 $memberSearchService = new MemberSearchService(new MemberSearchRepository($connection, $encryptionService));
 $sectionService = new SectionService($connection, $encryptionService);
 
@@ -509,6 +511,7 @@ $router->addRoute('POST', '/account/passkey/delete', AccountController::class, '
 
 // Member pages
 $router->addRoute('GET', '/members/{id}', MemberController::class, 'show', 'identified');
+$router->addRoute('POST', '/members/{id}/scout-year-offset', MemberController::class, 'updateScoutYearOffset', 'chief');
 
 // Configuration mode
 $router->addRoute('POST', '/config-mode/activate', ConfigModeController::class, 'activate', 'superadmin');
@@ -633,7 +636,7 @@ $authController->setWebAuthnService($webAuthnService);
 $frontController->registerController(AuthController::class, $authController);
 $frontController->registerController(AccountController::class, new AccountController($twig, $userAccountRepo, $webAuthnCredentialRepo, $webAuthnService));
 $frontController->registerController(ImportController::class, new ImportController($twig, $importService, $scoutYearResolver, $importJournalRepo, $functionRepo, $storagePath));
-$frontController->registerController(MemberController::class, new MemberController($twig, $memberService));
+$frontController->registerController(MemberController::class, new MemberController($twig, $memberService, $memberYearService, $journalService));
 $frontController->registerController(StaffsController::class, new StaffsController($twig, $sectionService, $memberService, $scoutYearResolver, $journalService));
 $frontController->registerController(ConfigModeController::class, new ConfigModeController($twig));
 $editableContentController = new EditableContentController($twig, $editableContentService);
@@ -655,7 +658,8 @@ $frontController->registerController(PlaceholderController::class, new Placehold
 // Module controllers with dependencies (only wired when the module is enabled).
 if (in_array('member_stats', $moduleManager->getEnabledModuleIds(), true)) {
     $memberStatsService = new \Modules\MemberStats\Service\MemberStatsService(
-        new \Modules\MemberStats\Repository\MemberStatsRepository($connection, $encryptionService)
+        new \Modules\MemberStats\Repository\MemberStatsRepository($connection, $encryptionService),
+        $memberYearService
     );
     $frontController->registerController(
         \Modules\MemberStats\Controller\MemberStatsController::class,

--- a/schema/core.sql
+++ b/schema/core.sql
@@ -130,6 +130,10 @@ CREATE TABLE member_years (
     unit_mail_consent BOOLEAN NOT NULL DEFAULT FALSE,
     fee_category_id INT UNSIGNED,
     unit_code VARCHAR(50),
+    -- Chief-adjustable shift applied on top of the birth-year-derived age when
+    -- computing branch/year (see MemberYearService::getEffectiveAge). Operational
+    -- flag, not personal data — stored in clear.
+    scout_year_offset TINYINT NOT NULL DEFAULT 0,
     -- Handicap is health data (GDPR special category) → encrypted at rest.
     handicap_encrypted BLOB,
     -- Assurance complémentaire is administrative → stored in clear like formation_level.

--- a/tests/Core/Http/Controller/MemberControllerScoutYearOffsetTest.php
+++ b/tests/Core/Http/Controller/MemberControllerScoutYearOffsetTest.php
@@ -73,12 +73,13 @@ class MemberControllerScoutYearOffsetTest extends TestCase
 
         $stmt = $this->pdo->prepare(
             'INSERT INTO member_years (member_id, scout_year_id, first_name_encrypted, last_name_encrypted, birth_date_encrypted)
-             VALUES (?, ?, ?, ?)'
+             VALUES (?, ?, ?, ?, ?)'
         );
         $stmt->execute([
             $memberId,
             $this->scoutYearId,
             $this->encryption->encrypt('John'),
+            $this->encryption->encrypt('Doe'),
             $this->encryption->encrypt($birthDate),
         ]);
 
@@ -116,7 +117,8 @@ class MemberControllerScoutYearOffsetTest extends TestCase
     public function testValidOffsetIsPersistedAndReturnsBranchYearLabel(): void
     {
         $token = $this->startSessionWithCsrfToken();
-        // 2014-01-01 → raw age 11 in 2025 → louveteaux 4e année. Offset -1 moves it to 10.
+        // 2014-01-01 → raw age 11 in 2025 (louveteaux 4e année). Offset -1 moves
+        // the effective age to 10 → louveteaux 3e année.
         $memberYearId = $this->createMemberYear('2014-01-01');
 
         $response = $this->controller->updateScoutYearOffset(
@@ -126,7 +128,7 @@ class MemberControllerScoutYearOffsetTest extends TestCase
 
         $decoded = json_decode($response->getBody(), true);
         $this->assertTrue($decoded['success']);
-        $this->assertSame('4e année louveteaux', $decoded['branch_year_label']);
+        $this->assertSame('3e année louveteaux', $decoded['branch_year_label']);
         $this->assertSame('#639922', $decoded['branch_color']);
 
         $stmt = $this->pdo->prepare('SELECT scout_year_offset FROM member_years WHERE id = ?');

--- a/tests/Core/Http/Controller/MemberControllerScoutYearOffsetTest.php
+++ b/tests/Core/Http/Controller/MemberControllerScoutYearOffsetTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Http\Controller;
+
+use Core\Database\Connection;
+use Core\Http\Controller\MemberController;
+use Core\Http\Request;
+use Core\Import\MemberYearRepository;
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Member\MemberService;
+use Core\Member\MemberYearService;
+use Core\Security\AuthSession;
+use Core\Security\EncryptionService;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Twig\Environment;
+
+/**
+ * MemberController::updateScoutYearOffset — the AJAX save behind the "Décalage
+ * année scoute" control: CSRF, offset validation, persistence, and journaling.
+ *
+ * @group database
+ */
+class MemberControllerScoutYearOffsetTest extends TestCase
+{
+    private \PDO $pdo;
+    private MemberController $controller;
+    private MemberService $memberService;
+    private EncryptionService $encryption;
+    private int $scoutYearId;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        $_SESSION = [];
+
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        $this->encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $memberYearRepo = new MemberYearRepository($this->pdo);
+        $this->memberService = new MemberService($memberYearRepo, $this->encryption, Connection::withPdo($this->pdo));
+        $journalService = new JournalService(new JournalRepository($this->pdo));
+
+        $this->controller = new MemberController(
+            $this->createMock(Environment::class),
+            $this->memberService,
+            new MemberYearService(),
+            $journalService
+        );
+
+        // Scout year 2025-2026 → reference year 2025.
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        $this->scoutYearId = (int) $this->pdo->lastInsertId();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    /**
+     * Creates a member_year with the given birth date. Reference year is 2025,
+     * so a birth date of 2014-01-01 gives a raw age of 11 (louveteaux 4e année).
+     */
+    private function createMemberYear(string $birthDate): int
+    {
+        $this->pdo->exec("INSERT INTO members (desk_id) VALUES ('TEST_" . uniqid() . "')");
+        $memberId = (int) $this->pdo->lastInsertId();
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO member_years (member_id, scout_year_id, first_name_encrypted, last_name_encrypted, birth_date_encrypted)
+             VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $memberId,
+            $this->scoutYearId,
+            $this->encryption->encrypt('John'),
+            $this->encryption->encrypt($birthDate),
+        ]);
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    private function startSessionWithCsrfToken(): string
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            ini_set('session.use_cookies', '0');
+            ini_set('session.cache_limiter', '');
+            session_start();
+        }
+        $token = bin2hex(random_bytes(32));
+        $_SESSION['_csrf_token'] = $token;
+        AuthSession::login(1, 'chief@test.example', 'chief');
+
+        return $token;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function jsonRequest(array $data): Request
+    {
+        $request = $this->getMockBuilder(Request::class)
+            ->setConstructorArgs(['POST', '/members/1/scout-year-offset', [], [], [], []])
+            ->onlyMethods(['getRawBody'])
+            ->getMock();
+        $request->method('getRawBody')->willReturn(json_encode($data));
+
+        return $request;
+    }
+
+    public function testValidOffsetIsPersistedAndReturnsBranchYearLabel(): void
+    {
+        $token = $this->startSessionWithCsrfToken();
+        // 2014-01-01 → raw age 11 in 2025 → louveteaux 4e année. Offset -1 moves it to 10.
+        $memberYearId = $this->createMemberYear('2014-01-01');
+
+        $response = $this->controller->updateScoutYearOffset(
+            $this->jsonRequest(['offset' => -1, '_csrf_token' => $token]),
+            ['id' => (string) $memberYearId]
+        );
+
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertTrue($decoded['success']);
+        $this->assertSame('4e année louveteaux', $decoded['branch_year_label']);
+        $this->assertSame('#639922', $decoded['branch_color']);
+
+        $stmt = $this->pdo->prepare('SELECT scout_year_offset FROM member_years WHERE id = ?');
+        $stmt->execute([$memberYearId]);
+        $this->assertSame(-1, (int) $stmt->fetchColumn());
+    }
+
+    public function testBoundaryOffsetMovesAMemberIntoTheNextBranch(): void
+    {
+        $token = $this->startSessionWithCsrfToken();
+        // 2014-01-01 → raw age 11 (louveteaux 4e) → offset +1 → effective age 12 → éclaireurs 1ère année.
+        $memberYearId = $this->createMemberYear('2014-01-01');
+
+        $response = $this->controller->updateScoutYearOffset(
+            $this->jsonRequest(['offset' => 1, '_csrf_token' => $token]),
+            ['id' => (string) $memberYearId]
+        );
+
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertTrue($decoded['success']);
+        $this->assertSame('1ère année éclaireurs', $decoded['branch_year_label']);
+    }
+
+    public function testInvalidCsrfTokenIsRejected(): void
+    {
+        $this->startSessionWithCsrfToken();
+        $memberYearId = $this->createMemberYear('2014-01-01');
+
+        $response = $this->controller->updateScoutYearOffset(
+            $this->jsonRequest(['offset' => -1, '_csrf_token' => 'wrong-token']),
+            ['id' => (string) $memberYearId]
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertFalse($decoded['success']);
+    }
+
+    public function testOutOfRangeOffsetIsRejected(): void
+    {
+        $token = $this->startSessionWithCsrfToken();
+        $memberYearId = $this->createMemberYear('2014-01-01');
+
+        $response = $this->controller->updateScoutYearOffset(
+            $this->jsonRequest(['offset' => 2, '_csrf_token' => $token]),
+            ['id' => (string) $memberYearId]
+        );
+
+        $this->assertSame(400, $response->getStatusCode());
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertFalse($decoded['success']);
+
+        $stmt = $this->pdo->prepare('SELECT scout_year_offset FROM member_years WHERE id = ?');
+        $stmt->execute([$memberYearId]);
+        $this->assertSame(0, (int) $stmt->fetchColumn());
+    }
+
+    public function testNonExistentMemberYearReturns404(): void
+    {
+        $token = $this->startSessionWithCsrfToken();
+
+        $response = $this->controller->updateScoutYearOffset(
+            $this->jsonRequest(['offset' => 1, '_csrf_token' => $token]),
+            ['id' => '999999']
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testOffsetChangeIsJournaled(): void
+    {
+        $token = $this->startSessionWithCsrfToken();
+        $memberYearId = $this->createMemberYear('2014-01-01');
+
+        $this->controller->updateScoutYearOffset(
+            $this->jsonRequest(['offset' => 1, '_csrf_token' => $token]),
+            ['id' => (string) $memberYearId]
+        );
+
+        $stmt = $this->pdo->prepare("SELECT * FROM event_log WHERE event_type = 'member_scout_year_offset_changed'");
+        $stmt->execute();
+        $entries = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        $this->assertCount(1, $entries);
+        $this->assertSame('core', $entries[0]['category']);
+        // No personal data in the journal — only the FK and the offset values.
+        $context = json_decode($entries[0]['context'], true);
+        $this->assertSame($memberYearId, $context['member_year_id']);
+        $this->assertSame(0, $context['old_offset']);
+        $this->assertSame(1, $context['new_offset']);
+    }
+
+    public function testNoOffsetChangeDoesNotJournal(): void
+    {
+        $token = $this->startSessionWithCsrfToken();
+        $memberYearId = $this->createMemberYear('2014-01-01');
+
+        // Default offset is already 0.
+        $this->controller->updateScoutYearOffset(
+            $this->jsonRequest(['offset' => 0, '_csrf_token' => $token]),
+            ['id' => (string) $memberYearId]
+        );
+
+        $stmt = $this->pdo->prepare("SELECT COUNT(*) FROM event_log WHERE event_type = 'member_scout_year_offset_changed'");
+        $stmt->execute();
+        $this->assertSame(0, (int) $stmt->fetchColumn());
+    }
+}

--- a/tests/Core/Http/Controller/MemberControllerTest.php
+++ b/tests/Core/Http/Controller/MemberControllerTest.php
@@ -6,8 +6,11 @@ namespace Tests\Core\Http\Controller;
 
 use Core\Http\Controller\MemberController;
 use Core\Http\Request;
+use Core\Journal\JournalService;
 use Core\Member\MemberNotFoundException;
+use Core\Member\MemberProfile;
 use Core\Member\MemberService;
+use Core\Member\MemberYearService;
 use Core\Security\AuthSession;
 use PHPUnit\Framework\TestCase;
 use Tests\DatabaseTestHelper;
@@ -71,7 +74,7 @@ class MemberControllerTest extends TestCase
             return '';
         }));
         $twig->addFilter(new \Twig\TwigFilter('display_name', function ($member) {
-            if ($member instanceof \Core\Member\MemberProfile) {
+            if ($member instanceof MemberProfile) {
                 return $member->getDisplayName();
             }
             if (is_array($member)) {
@@ -81,7 +84,7 @@ class MemberControllerTest extends TestCase
         }));
 
         $memberService = $this->createMock(MemberService::class);
-        $this->controller = new MemberController($twig, $memberService);
+        $this->controller = $this->newController($twig, $memberService);
     }
 
     protected function tearDown(): void
@@ -89,21 +92,62 @@ class MemberControllerTest extends TestCase
         $_SESSION = [];
     }
 
+    private function newController(Environment $twig, MemberService $memberService): MemberController
+    {
+        return new MemberController(
+            $twig,
+            $memberService,
+            new MemberYearService(),
+            $this->createMock(JournalService::class)
+        );
+    }
+
+    /**
+     * Real MemberProfile fixture — this DTO has no benefit from mocking (plain
+     * readonly properties), and computeEffectiveAge() in the controller reads
+     * birthDate/scoutYearOffset/scoutYearLabel directly, which a mock leaves
+     * uninitialized.
+     *
+     * @param array<string, mixed> $overrides
+     */
+    private function makeProfile(array $overrides = []): MemberProfile
+    {
+        $defaults = [
+            'memberYearId' => 1,
+            'memberId' => 1,
+            'deskId' => 'T001',
+            'firstName' => 'John',
+            'lastName' => 'Doe',
+            'totem' => null,
+            'quali' => null,
+            'gender' => null,
+            'birthDate' => null,
+            'phone' => null,
+            'mobile' => null,
+            'email' => null,
+            'patrol' => null,
+            'formationLevel' => null,
+            'federationMailConsent' => false,
+            'unitMailConsent' => false,
+            'addresses' => [],
+            'functions' => [],
+            'scoutYearLabel' => '2025-2026',
+        ];
+
+        $args = array_merge($defaults, $overrides);
+
+        return new MemberProfile(...$args);
+    }
+
     public function testShowPageRendersForLinkedMemberSelf(): void
     {
-        // Mock member service to return a profile
-        $profile = $this->createMock(\Core\Member\MemberProfile::class);
-        $profile->method('getDisplayName')->willReturn('Baloo');
-        $profile->method('getMainSectionName')->willReturn('Meute Akela');
+        $profile = $this->makeProfile(['totem' => 'Baloo']);
 
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('canAccess')->willReturn(true);
         $memberService->method('getMemberProfile')->willReturn($profile);
 
-        $controller = new MemberController(
-            $this->createMock(Environment::class),
-            $memberService
-        );
+        $controller = $this->newController($this->createMock(Environment::class), $memberService);
 
         $request = new Request('GET', '/members/1', [], [], [], []);
         $response = $controller->show($request, ['id' => '1']);
@@ -121,17 +165,13 @@ class MemberControllerTest extends TestCase
             'linked_members' => [],
         ];
 
-        $profile = $this->createMock(\Core\Member\MemberProfile::class);
-        $profile->method('getDisplayName')->willReturn('Mowgli');
+        $profile = $this->makeProfile(['totem' => 'Mowgli']);
 
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('canAccess')->willReturn(true);
         $memberService->method('getMemberProfile')->willReturn($profile);
 
-        $controller = new MemberController(
-            $this->createMock(Environment::class),
-            $memberService
-        );
+        $controller = $this->newController($this->createMock(Environment::class), $memberService);
 
         $request = new Request('GET', '/members/2', [], [], [], []);
         $response = $controller->show($request, ['id' => '2']);
@@ -145,10 +185,7 @@ class MemberControllerTest extends TestCase
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('canAccess')->willReturn(false);
 
-        $controller = new MemberController(
-            $this->createMock(Environment::class),
-            $memberService
-        );
+        $controller = $this->newController($this->createMock(Environment::class), $memberService);
 
         $request = new Request('GET', '/members/999', [], [], [], []);
         $response = $controller->show($request, ['id' => '999']);
@@ -164,10 +201,7 @@ class MemberControllerTest extends TestCase
         $memberService->method('getMemberProfile')
             ->willThrowException(new MemberNotFoundException());
 
-        $controller = new MemberController(
-            $this->createMock(Environment::class),
-            $memberService
-        );
+        $controller = $this->newController($this->createMock(Environment::class), $memberService);
 
         $request = new Request('GET', '/members/99999', [], [], [], []);
         $response = $controller->show($request, ['id' => '99999']);
@@ -178,8 +212,7 @@ class MemberControllerTest extends TestCase
 
     public function testContactInfoIsVisibleToSelf(): void
     {
-        $profile = $this->createMock(\Core\Member\MemberProfile::class);
-        $profile->method('getDisplayName')->willReturn('Baloo');
+        $profile = $this->makeProfile(['totem' => 'Baloo']);
 
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('canAccess')->willReturn(true);
@@ -196,7 +229,7 @@ class MemberControllerTest extends TestCase
             )
             ->willReturn('<html></html>');
 
-        $controller = new MemberController($twig, $memberService);
+        $controller = $this->newController($twig, $memberService);
 
         $request = new Request('GET', '/members/1', [], [], [], []);
         $response = $controller->show($request, ['id' => '1']);
@@ -214,8 +247,7 @@ class MemberControllerTest extends TestCase
             'linked_members' => [],
         ];
 
-        $profile = $this->createMock(\Core\Member\MemberProfile::class);
-        $profile->method('getDisplayName')->willReturn('Mowgli');
+        $profile = $this->makeProfile(['totem' => 'Mowgli']);
 
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('canAccess')->willReturn(true);
@@ -232,7 +264,7 @@ class MemberControllerTest extends TestCase
             )
             ->willReturn('<html></html>');
 
-        $controller = new MemberController($twig, $memberService);
+        $controller = $this->newController($twig, $memberService);
 
         $request = new Request('GET', '/members/2', [], [], [], []);
         $response = $controller->show($request, ['id' => '2']);
@@ -245,9 +277,7 @@ class MemberControllerTest extends TestCase
         // Mock canAccess to return true for the email match but not for chief role
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('canAccess')->willReturn(true);
-        $memberService->method('getMemberProfile')->willReturn(
-            $this->createMock(\Core\Member\MemberProfile::class)
-        );
+        $memberService->method('getMemberProfile')->willReturn($this->makeProfile());
 
         $twig = $this->createMock(Environment::class);
         $twig->expects($this->once())
@@ -260,7 +290,7 @@ class MemberControllerTest extends TestCase
             )
             ->willReturn('<html></html>');
 
-        $controller = new MemberController($twig, $memberService);
+        $controller = $this->newController($twig, $memberService);
 
         $request = new Request('GET', '/members/1', [], [], [], []);
         $response = $controller->show($request, ['id' => '1']);
@@ -270,9 +300,7 @@ class MemberControllerTest extends TestCase
 
     public function testPageHandlesMembersWithMinimalDataGracefully(): void
     {
-        $profile = $this->createMock(\Core\Member\MemberProfile::class);
-        $profile->method('getDisplayName')->willReturn('John');
-        $profile->method('getMainSectionName')->willReturn(null);
+        $profile = $this->makeProfile(['firstName' => 'John']);
 
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('canAccess')->willReturn(true);
@@ -283,7 +311,7 @@ class MemberControllerTest extends TestCase
             ->method('render')
             ->willReturn('<html></html>');
 
-        $controller = new MemberController($twig, $memberService);
+        $controller = $this->newController($twig, $memberService);
 
         $request = new Request('GET', '/members/1', [], [], [], []);
         $response = $controller->show($request, ['id' => '1']);

--- a/tests/Core/Http/Controller/MemberScoutYearOffsetRbacTest.php
+++ b/tests/Core/Http/Controller/MemberScoutYearOffsetRbacTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Http\Controller;
+
+use Core\Config\AppConfig;
+use Core\Http\Controller\AbstractController;
+use Core\Http\FrontController;
+use Core\Http\Request;
+use Core\Http\Response;
+use Core\Http\Router;
+use Core\Security\AuthSession;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+
+/**
+ * RBAC boundary for POST /members/{id}/scout-year-offset (mirrors the
+ * public/index.php route: role_min "chief"). The "Décalage année scoute"
+ * control is chief/admin only: chief → 200, intendant → 403.
+ */
+class MemberScoutYearOffsetRbacTest extends TestCase
+{
+    private AppConfig $config;
+
+    protected function setUp(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        $_SESSION = [];
+
+        $configFile = sys_get_temp_dir() . '/test_app_config_' . uniqid() . '.php';
+        file_put_contents($configFile, "<?php\nreturn ['site_name' => 'Test', 'debug' => false];");
+        $this->config = new AppConfig($configFile);
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    private function buildFrontController(): FrontController
+    {
+        $router = new Router();
+        // Mirrors the module route registered in public/index.php.
+        $router->addRoute('POST', '/members/{id}/scout-year-offset', ScoutYearOffsetStubController::class, 'update', 'chief');
+
+        $twig = $this->createMock(Environment::class);
+        $fc = new FrontController($router, $twig, $this->config);
+        $fc->registerController(ScoutYearOffsetStubController::class, new ScoutYearOffsetStubController($twig));
+
+        return $fc;
+    }
+
+    private function startTestSession(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            ini_set('session.use_cookies', '0');
+            ini_set('session.cache_limiter', '');
+            session_start();
+        }
+    }
+
+    public function testChiefIsAllowed(): void
+    {
+        $this->startTestSession();
+        AuthSession::login(1, 'chief@test.com', 'chief');
+
+        $response = $this->buildFrontController()->handle(new Request('POST', '/members/1/scout-year-offset', [], [], [], []));
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAdminIsAllowed(): void
+    {
+        $this->startTestSession();
+        AuthSession::login(1, 'admin@test.com', 'admin');
+
+        $response = $this->buildFrontController()->handle(new Request('POST', '/members/1/scout-year-offset', [], [], [], []));
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    public function testIntendantIsDenied(): void
+    {
+        $this->startTestSession();
+        AuthSession::login(1, 'intendant@test.com', 'intendant');
+
+        $response = $this->buildFrontController()->handle(new Request('POST', '/members/1/scout-year-offset', [], [], [], []));
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function testIdentifiedIsDenied(): void
+    {
+        $this->startTestSession();
+        AuthSession::login(1, 'member@test.com', 'identified');
+
+        $response = $this->buildFrontController()->handle(new Request('POST', '/members/1/scout-year-offset', [], [], [], []));
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    public function testUnauthenticatedRedirectsToLogin(): void
+    {
+        $this->startTestSession();
+
+        $response = $this->buildFrontController()->handle(new Request('POST', '/members/1/scout-year-offset', [], [], [], []));
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/login', $response->getHeaders()['Location']);
+    }
+}
+
+class ScoutYearOffsetStubController extends AbstractController
+{
+    /**
+     * @param array<string, string> $params
+     */
+    public function update(Request $request, array $params): Response
+    {
+        return $this->json(['success' => true]);
+    }
+}

--- a/tests/Core/Member/MemberYearServiceTest.php
+++ b/tests/Core/Member/MemberYearServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Member;
+
+use Core\Member\MemberYearService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * MemberYearService::getEffectiveAge() is the single source of truth for
+ * "which branch-year is this member in" — offset -1/0/+1 and the branch
+ * boundaries themselves are exercised here.
+ */
+class MemberYearServiceTest extends TestCase
+{
+    private const REFERENCE_YEAR = 2026;
+
+    private MemberYearService $service;
+
+    protected function setUp(): void
+    {
+        $this->service = new MemberYearService();
+    }
+
+    public function testNormalOffsetUsesRawAge(): void
+    {
+        // Born 2017 → age 9 in 2026 → louveteaux, 2e année.
+        $result = $this->service->getEffectiveAge(2017, 0, self::REFERENCE_YEAR);
+
+        $this->assertSame(9, $result->age);
+        $this->assertSame('louveteau', $result->branchKey);
+        $this->assertSame('Louveteaux', $result->branchName);
+        $this->assertSame(2, $result->yearInBranch);
+        $this->assertSame(4, $result->totalYearsInBranch);
+        $this->assertSame('2e année louveteaux', $result->getBranchYearLabel());
+    }
+
+    public function testMinusOneOffsetShiftsAMemberDownAYear(): void
+    {
+        // Born 2014 → raw age 12 (would be éclaireurs 1ère année), offset -1 →
+        // effective age 11 → louveteaux, 4e année.
+        $result = $this->service->getEffectiveAge(2014, -1, self::REFERENCE_YEAR);
+
+        $this->assertSame(11, $result->age);
+        $this->assertSame('louveteau', $result->branchKey);
+        $this->assertSame(4, $result->yearInBranch);
+        $this->assertSame('4e année louveteaux', $result->getBranchYearLabel());
+    }
+
+    public function testPlusOneOffsetShiftsAMemberUpAYear(): void
+    {
+        // Born 2018 → raw age 8 (louveteaux 1ère année), offset +1 → effective
+        // age 9 → louveteaux, 2e année.
+        $result = $this->service->getEffectiveAge(2018, 1, self::REFERENCE_YEAR);
+
+        $this->assertSame(9, $result->age);
+        $this->assertSame('louveteau', $result->branchKey);
+        $this->assertSame(2, $result->yearInBranch);
+    }
+
+    public function testPlusOneOffsetCanPushAMemberIntoTheNextBranch(): void
+    {
+        // Born 2015 → raw age 11 (louveteaux 4e année), offset +1 → effective
+        // age 12 → éclaireurs, 1ère année.
+        $result = $this->service->getEffectiveAge(2015, 1, self::REFERENCE_YEAR);
+
+        $this->assertSame(12, $result->age);
+        $this->assertSame('eclaireur', $result->branchKey);
+        $this->assertSame(1, $result->yearInBranch);
+        $this->assertSame('1ère année éclaireurs', $result->getBranchYearLabel());
+    }
+
+    public function testBranchLowerBoundary(): void
+    {
+        // Baladins starts at age 6.
+        $result = $this->service->getEffectiveAge(2020, 0, self::REFERENCE_YEAR);
+
+        $this->assertSame(6, $result->age);
+        $this->assertSame('baladin', $result->branchKey);
+        $this->assertSame(1, $result->yearInBranch);
+    }
+
+    public function testBranchUpperBoundary(): void
+    {
+        // Pionniers ends at age 17.
+        $result = $this->service->getEffectiveAge(2009, 0, self::REFERENCE_YEAR);
+
+        $this->assertSame(17, $result->age);
+        $this->assertSame('pionnier', $result->branchKey);
+        $this->assertSame(2, $result->yearInBranch);
+        $this->assertSame(2, $result->totalYearsInBranch);
+    }
+
+    public function testAgeBelowEveryBranchHasNoBranch(): void
+    {
+        // Age 5: below Baladins.
+        $result = $this->service->getEffectiveAge(2021, 0, self::REFERENCE_YEAR);
+
+        $this->assertSame(5, $result->age);
+        $this->assertNull($result->branchKey);
+        $this->assertFalse($result->isInKnownBranch());
+        $this->assertSame('', $result->getBranchYearLabel());
+    }
+
+    public function testAgeAboveEveryBranchHasNoBranch(): void
+    {
+        // Age 18: above Pionniers.
+        $result = $this->service->getEffectiveAge(2008, 0, self::REFERENCE_YEAR);
+
+        $this->assertSame(18, $result->age);
+        $this->assertNull($result->branchKey);
+        $this->assertFalse($result->isInKnownBranch());
+    }
+
+    public function testMinusOneOffsetCanPushAMemberBelowEveryBranch(): void
+    {
+        // Born 2020 → raw age 6 (baladins 1ère année), offset -1 → effective
+        // age 5 → below every branch.
+        $result = $this->service->getEffectiveAge(2020, -1, self::REFERENCE_YEAR);
+
+        $this->assertSame(5, $result->age);
+        $this->assertFalse($result->isInKnownBranch());
+    }
+
+    public function testNullBirthYearYieldsNullAgeAndNoBranch(): void
+    {
+        $result = $this->service->getEffectiveAge(null, 0, self::REFERENCE_YEAR);
+
+        $this->assertNull($result->age);
+        $this->assertNull($result->branchKey);
+        $this->assertSame('', $result->getBranchYearLabel());
+    }
+
+    public function testExtractBirthYearHandlesBothDateFormats(): void
+    {
+        $this->assertSame(2018, MemberYearService::extractBirthYear('2018-05-12'));
+        $this->assertSame(2018, MemberYearService::extractBirthYear('12/05/2018'));
+        $this->assertNull(MemberYearService::extractBirthYear(null));
+        $this->assertNull(MemberYearService::extractBirthYear(''));
+        $this->assertNull(MemberYearService::extractBirthYear('inconnu'));
+    }
+
+    public function testReferenceYearFromScoutYearLabelIsTheStartYear(): void
+    {
+        $this->assertSame(2025, MemberYearService::referenceYearFromScoutYearLabel('2025-2026'));
+        $this->assertSame(2023, MemberYearService::referenceYearFromScoutYearLabel('2023-2024'));
+        $this->assertSame((int) date('Y'), MemberYearService::referenceYearFromScoutYearLabel('sans année'));
+    }
+}

--- a/tests/DatabaseTestHelper.php
+++ b/tests/DatabaseTestHelper.php
@@ -104,6 +104,7 @@ class DatabaseTestHelper
             unit_mail_consent INTEGER NOT NULL DEFAULT 0,
             fee_category_id INTEGER,
             unit_code TEXT,
+            scout_year_offset INTEGER NOT NULL DEFAULT 0,
             handicap_encrypted BLOB,
             supplementary_insurance TEXT,
             is_active INTEGER NOT NULL DEFAULT 1,

--- a/tests/Modules/MemberStats/Service/MemberStatsServiceTest.php
+++ b/tests/Modules/MemberStats/Service/MemberStatsServiceTest.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Modules\MemberStats\Service;
 
-use Core\Database\Connection;
-use Core\Security\EncryptionService;
+use Core\Member\MemberYearService;
 use Modules\MemberStats\Repository\MemberStatsRepository;
 use Modules\MemberStats\Service\MemberStatsService;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Aggregation logic: mapping members to branch-year cells from their birth year,
- * gender bucketing, totals, and bar-scaling max — all with a stubbed repository
- * so no encryption/database is involved.
+ * Aggregation logic: mapping members to branch-year cells via
+ * MemberYearService::getEffectiveAge() (birth year + scout_year_offset),
+ * gender bucketing, totals, and bar-scaling max — all with a stubbed
+ * repository so no encryption/database is involved.
  */
 class MemberStatsServiceTest extends TestCase
 {
     private const REFERENCE_YEAR = 2026;
 
     /**
-     * @param array<int, array{branch_label: string, branch_sort_order: int, birth_date: ?string, gender: ?string}> $rows
+     * @param array<int, array{branch_label: string, branch_sort_order: int, birth_date: ?string, gender: ?string, scout_year_offset: int}> $rows
      */
     private function service(array $rows): MemberStatsService
     {
@@ -37,22 +37,23 @@ class MemberStatsServiceTest extends TestCase
             }
         };
 
-        return new MemberStatsService($repo);
+        return new MemberStatsService($repo, new MemberYearService());
     }
 
     /**
      * @param string $label
      * @param string $birthDate
      * @param string|null $gender
-     * @return array{branch_label: string, branch_sort_order: int, birth_date: ?string, gender: ?string}
+     * @return array{branch_label: string, branch_sort_order: int, birth_date: ?string, gender: ?string, scout_year_offset: int}
      */
-    private function row(string $label, string $birthDate, ?string $gender, int $sort = 10): array
+    private function row(string $label, string $birthDate, ?string $gender, int $sort = 10, int $offset = 0): array
     {
         return [
             'branch_label' => $label,
             'branch_sort_order' => $sort,
             'birth_date' => $birthDate,
             'gender' => $gender,
+            'scout_year_offset' => $offset,
         ];
     }
 
@@ -111,7 +112,7 @@ class MemberStatsServiceTest extends TestCase
             $this->row('Éclaireurs', '2014-01-01', 'X'), // age 12 → y1 other
             $this->row('Pionniers', '2010-01-01', 'M'),  // age 16 → y1 male
             $this->row('Pionniers', '2009-06-06', 'F'),  // age 17 → y2 female
-            $this->row("Staff d'U", '1990-01-01', 'M'),  // not an animés branch → skipped
+            $this->row("Staff d'U", '1990-01-01', 'M'),  // age 36 → outside every branch → skipped
             $this->row('Baladins', '', 'M'),             // no birth date → skipped
             $this->row('Baladins', 'inconnu', 'F'),      // unparseable → skipped
         ];
@@ -139,15 +140,50 @@ class MemberStatsServiceTest extends TestCase
         $this->assertSame(['total' => 1, 'male' => 0, 'female' => 1, 'other' => 0], $this->cell($pionniers[1]));
     }
 
-    public function testAgeOutsideBranchRangeIsClamped(): void
+    public function testAgeOutsideAnyBranchRangeIsExcluded(): void
     {
-        // A "Baladins" member born 2005 (age 21) clamps into the last Baladins year.
+        // Born 2005 → age 21 in 2026: outside every branch (Baladins..Pionniers
+        // cover 6-17). Branch/year now comes exclusively from getEffectiveAge(),
+        // so an out-of-range effective age is excluded rather than clamped into
+        // whatever branch the Desk export happened to label the row with.
         $rows = [$this->row('Baladins', '2005-01-01', 'M')];
         $stats = $this->service($rows)->getStatistics(1, self::REFERENCE_YEAR);
 
         $baladins = $stats['branches'][0]['rows'];
         $this->assertSame(0, $baladins[0]['total']);
-        $this->assertSame(1, $baladins[1]['total']); // clamped to 2e année
+        $this->assertSame(0, $baladins[1]['total']);
+        $this->assertSame(0, $stats['totals']['total']);
+    }
+
+    public function testScoutYearOffsetShiftsAMemberIntoTheAdjacentBranch(): void
+    {
+        // Born 2014 → raw age 12 (éclaireurs 1ère année). A chief-applied -1
+        // offset moves the effective age to 11 → louveteaux 4e année.
+        $rows = [$this->row('Éclaireurs', '2014-01-01', 'F', offset: -1)];
+        $stats = $this->service($rows)->getStatistics(1, self::REFERENCE_YEAR);
+
+        $louveteaux = $stats['branches'][1]['rows'];
+        $this->assertSame(1, $louveteaux[3]['total']); // 4e année
+        $this->assertSame(1, $louveteaux[3]['female']);
+
+        $eclaireurs = $stats['branches'][2]['rows'];
+        $this->assertSame(0, $eclaireurs[0]['total']);
+
+        $this->assertSame(1, $stats['totals']['total']);
+    }
+
+    public function testScoutYearOffsetCanBringAnOutOfRangeMemberBackIntoABranch(): void
+    {
+        // Born 2020 → raw age 6 (baladins 1ère année). A -1 offset would push
+        // this particular member below every branch on its own, but a +1
+        // offset on a member who would otherwise be excluded brings them back
+        // in: born 2021 → raw age 5 (below every branch), offset +1 → age 6 →
+        // baladins 1ère année.
+        $rows = [$this->row('Baladins', '2021-01-01', 'M', offset: 1)];
+        $stats = $this->service($rows)->getStatistics(1, self::REFERENCE_YEAR);
+
+        $baladins = $stats['branches'][0]['rows'];
+        $this->assertSame(1, $baladins[0]['total']);
         $this->assertSame(1, $stats['totals']['total']);
     }
 
@@ -164,15 +200,15 @@ class MemberStatsServiceTest extends TestCase
     {
         // "2025-2026" → 2025, so figures do not drift with today's date and are
         // correct when viewing a past scout year.
-        $this->assertSame(2025, MemberStatsService::referenceYearFromLabel('2025-2026'));
-        $this->assertSame(2023, MemberStatsService::referenceYearFromLabel('2023-2024'));
-        $this->assertSame((int) date('Y'), MemberStatsService::referenceYearFromLabel('sans année'));
+        $this->assertSame(2025, MemberYearService::referenceYearFromScoutYearLabel('2025-2026'));
+        $this->assertSame(2023, MemberYearService::referenceYearFromScoutYearLabel('2023-2024'));
+        $this->assertSame((int) date('Y'), MemberYearService::referenceYearFromScoutYearLabel('sans année'));
     }
 
     public function testBirthYearLabelsUseTheScoutYearStartYear(): void
     {
         // For scout year 2025-2026 (reference 2025), baladins are born 2019 & 2018.
-        $referenceYear = MemberStatsService::referenceYearFromLabel('2025-2026');
+        $referenceYear = MemberYearService::referenceYearFromScoutYearLabel('2025-2026');
         $stats = $this->service([])->getStatistics(1, $referenceYear);
 
         $baladins = $stats['branches'][0]['rows'];


### PR DESCRIPTION
## Summary
- New `member_years.scout_year_offset` (plain `TINYINT`, not encrypted — operational flag, not personal data) lets a chief/admin shift a member ±1 year relative to their birth-year-derived age.
- New core `Core\Member\MemberYearService::getEffectiveAge()` is the single source of truth for `effective_age = referenceYear − birthYear + scoutYearOffset` → branch + year-within-branch, using the four fixed Les Scouts age ranges (Baladins 6-7/2, Louveteaux 8-11/4, Éclaireurs 12-15/4, Pionniers 16-17/2).
- Member page (`Espace des animés`) gains a "Données du site" section, chief/admin only: segmented control ("−1 an" / "Normal" / "+1 an") + a result pill (branch color dot + "Ne année <branche>"), saved via AJAX (`POST /members/{id}/scout-year-offset`, `role_min: chief`), CSRF-protected, journaled via `JournalService` (FK + offsets only, no personal data).
- Refactored `modules/member_stats` (Service/Repository/Controller) to delegate branch/year derivation to `MemberYearService::getEffectiveAge()` instead of its own local age-range/branch-matching logic, so the offset now also feeds the statistics page.
- Repo-wide search confirmed no other place independently derives branch/year from birth date.

## Test plan
- [x] `./vendor/bin/phpunit` — 520 tests, 1182 assertions, all green (includes 17 new tests: `MemberYearServiceTest` unit tests covering offset -1/0/+1 and branch boundaries, `MemberControllerScoutYearOffsetTest` for the AJAX save incl. CSRF/validation/journaling, `MemberScoutYearOffsetRbacTest` for the RBAC boundary chief=200/intendant=403).
- [x] `./vendor/bin/phpstan analyse` — no errors.
- [x] Manual Twig render smoke test: control + pill render correctly for chief with `−1 an` active and "4e année louveteaux"; entirely absent from the markup for non-chief roles.