### PR TITLE
Fix orphaned docblock and lock in the unconditional cache clear

### DIFF
--- a/core/Maintenance/Task/InstallUpdateHandler.php
+++ b/core/Maintenance/Task/InstallUpdateHandler.php
@@ -282,6 +282,30 @@ class InstallUpdateHandler implements TaskHandlerInterface
     }
 
     /**
+     * Unconditional, version-agnostic: wipes the entire storage/temp/
+     * twig_cache tree (every Core\View\TwigFactory version subdirectory,
+     * not just the one matching $history->versionTo) on every single
+     * install this handler completes — a stable release exactly like a
+     * development-mode branch/commit install, never gated on whether the
+     * version string actually changed. TwigFactory's per-version cache
+     * directory (storage/temp/twig_cache/{version}) already makes a
+     * genuinely new VERSION self-healing on its own, but this explicit
+     * sweep is the belt to that belt-and-suspenders: it doesn't depend on
+     * VERSION having changed at all, so it also covers re-installing the
+     * exact same version/commit (nothing left over from a half-applied
+     * previous attempt) and any future deploy path that might not bump
+     * VERSION for some reason. Runs right after installFiles() (which
+     * deliberately never touches storage/) and before VersionFile::write(),
+     * so it always targets whatever was compiled under the *previous*
+     * version — never the one about to be written. TwigFactory recreates
+     * whichever subdirectory a request actually needs, lazily, on demand.
+     */
+    private function clearCompiledTemplateCache(string $storagePath): void
+    {
+        $this->removeDirectory($storagePath . '/temp/twig_cache');
+    }
+
+    /**
      * GitHub's branch/commit zipball always wraps its contents in a single
      * top-level "{owner}-{repo}-{sha}/" directory — unlike scripts/
      * release.sh's artifact, which zips the repo contents directly at the
@@ -290,24 +314,6 @@ class InstallUpdateHandler implements TaskHandlerInterface
      * never have this stripping applied even if it coincidentally had a
      * single top-level entry).
      */
-    /**
-     * Core\View\TwigFactory compiles templates to storage/temp/twig_cache
-     * with auto_reload off in production, so it never re-checks a compiled
-     * template's freshness against its .twig source on disk. installFiles()
-     * deliberately never touches storage/ (live uploads/keys/config), so
-     * without this the server keeps executing every pre-update .twig file
-     * exactly as compiled before the update, indefinitely — a real
-     * production incident: a template-only change (e.g. a nav/layout
-     * partial) installs successfully but never visibly takes effect until
-     * someone clears this directory by hand. TwigFactory recreates it
-     * lazily (`is_dir()` check) on the next request, so removing it here is
-     * enough — nothing needs to pre-create it.
-     */
-    private function clearCompiledTemplateCache(string $storagePath): void
-    {
-        $this->removeDirectory($storagePath . '/temp/twig_cache');
-    }
-
     private function resolveBranchArchiveRoot(string $extractedDir): string
     {
         $entries = array_values(array_diff(scandir($extractedDir) ?: [], ['.', '..']));

--- a/tests/Core/Maintenance/Task/InstallUpdateHandlerTest.php
+++ b/tests/Core/Maintenance/Task/InstallUpdateHandlerTest.php
@@ -247,6 +247,39 @@ class InstallUpdateHandlerTest extends TestCase
         $this->assertDirectoryDoesNotExist($cacheDir);
     }
 
+    public function testClearCompiledTemplateCacheWipesEveryVersionSubdirectoryUnconditionally(): void
+    {
+        // Core\View\TwigFactory namespaces its cache by installed version
+        // (storage/temp/twig_cache/{version}) — a stable release directory
+        // and a development-mode "dev-{sha}" one can legitimately coexist
+        // (e.g. someone switched auto_update_level back and forth). The
+        // clear must not be scoped to "whichever version we're installing
+        // right now": it sweeps the whole tree, so nothing accumulates and
+        // a re-install of the exact same version is never served leftover
+        // compiled output from a previous, possibly-interrupted attempt.
+        $cacheRoot = $this->storagePath . '/temp/twig_cache';
+        mkdir($cacheRoot . '/1.0.22', 0755, true);
+        mkdir($cacheRoot . '/dev-a1b2c3d', 0755, true);
+        file_put_contents($cacheRoot . '/1.0.22/abcdef1234.php', '<?php // stable release, compiled');
+        file_put_contents($cacheRoot . '/dev-a1b2c3d/1234abcdef.php', '<?php // dev build, compiled');
+
+        $this->invokeClearCompiledTemplateCache($this->storagePath);
+
+        $this->assertDirectoryDoesNotExist($cacheRoot);
+    }
+
+    public function testClearCompiledTemplateCacheHasNoSourceTypeOrVersionParameter(): void
+    {
+        // Structural guarantee behind "even for a development commit
+        // install": the method has no way to special-case source_type
+        // ('release' vs 'branch') or compare versions, because it isn't
+        // given either — handle() calls it identically on both paths.
+        $method = new \ReflectionMethod(InstallUpdateHandler::class, 'clearCompiledTemplateCache');
+
+        $this->assertCount(1, $method->getParameters());
+        $this->assertSame('storagePath', $method->getParameters()[0]->getName());
+    }
+
     public function testClearCompiledTemplateCacheIsANoOpWhenTheCacheDirDoesNotExistYet(): void
     {
         // A fresh install (or a storage/temp already cleared) has no


### PR DESCRIPTION
## Description

Answering "clean the cache on every deployment, not only on a version jump, even for a development commit": `clearCompiledTemplateCache()` already did exactly this — it runs unconditionally right after `installFiles()`, identically for `source_type: 'release'` and `source_type: 'branch'` (development mode), and is never gated on comparing old vs. new version. It sweeps the entire `storage/temp/twig_cache` tree, so no version subdirectory — stable or `dev-{sha}` — survives an install.

Two things were missing, both fixed here:
1. A real defect from the earlier commit: the docblock explaining `resolveBranchArchiveRoot()`'s GitHub-zipball-unwrapping had been left orphaned above `clearCompiledTemplateCache()` instead, leaving `resolveBranchArchiveRoot()` itself undocumented. Restored to the correct methods.
2. Test coverage proving the "unconditional, not version-gated" guarantee explicitly, rather than leaving it implicit: one test seeds *two* coexisting version subdirectories (a stable release and a dev build) and asserts a single call wipes both; another asserts the method's signature has no `source_type`/version parameter to gate on in the first place.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist (no behavior change — same private method, same call site, doc/test only)
- [x] All code and comments are in English
- [x] All UI-facing text is in French (no UI text in this change)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 14/14 in `InstallUpdateHandlerTest`, full suite green)
- [ ] PHPStan passes (`vendor/bin/phpstan analyse core/ --level=6`) — PHPStan cannot be installed in this network-restricted sandbox; CI will confirm


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo61SR4PG4rButKcDHbeTF)_