### PR TITLE
Declare breadcrumbs on every module page and fix invisible active-menu text

### DIFF
--- a/core/View/templates/partials/nav.html.twig
+++ b/core/View/templates/partials/nav.html.twig
@@ -54,7 +54,12 @@
                                 {% if page.isSeparator %}
                                     <li class="list-group-item p-0"><hr class="my-1"></li>
                                 {% elseif page.isDynamic %}
-                                    <li class="list-group-item list-group-item-action border-0 ps-4{% if current_path == page.url %} active{% endif %}" style="min-height:44px;">
+                                    {# No Bootstrap `active` class here: `.list-group-item.active` paints a
+                                       solid --bs-primary background (not !important), while the `text-primary`
+                                       below is a color utility and IS !important — together that's blue text
+                                       on a blue background, invisible. Bold blue text on the plain list
+                                       background is the highlight instead. #}
+                                    <li class="list-group-item list-group-item-action border-0 ps-4" style="min-height:44px;">
                                         <a href="{{ page.url }}" class="d-flex align-items-center gap-2 text-decoration-none{% if current_path == page.url %} fw-semibold text-primary{% else %} text-dark{% endif %}"{{ current_path == page.url ? ' aria-current="page"' : '' }}>
                                             <div class="rounded-circle bg-primary-subtle d-flex align-items-center justify-content-center"
                                                  style="width:32px;height:32px;min-width:32px;">
@@ -69,7 +74,10 @@
                                         </a>
                                     </li>
                                 {% else %}
-                                    <li class="list-group-item list-group-item-action border-0 ps-4 d-flex align-items-center{% if active_page_url|default('') == page.url %} active{% endif %}" style="min-height:44px;">
+                                    {# Same reasoning as the dynamic-entry branch above: no Bootstrap
+                                       `active` class, since it would paint the same blue background that
+                                       the (!important) text-primary color below turns invisible against. #}
+                                    <li class="list-group-item list-group-item-action border-0 ps-4 d-flex align-items-center" style="min-height:44px;">
                                         <a href="{{ page.url }}" class="text-decoration-none d-block{% if active_page_url|default('') == page.url %} fw-semibold text-primary{% else %} text-dark{% endif %}"{{ active_page_url|default('') == page.url ? ' aria-current="page"' : '' }}>{{ page.label }}</a>
                                     </li>
                                 {% endif %}

--- a/modules/banner/module.json
+++ b/modules/banner/module.json
@@ -12,7 +12,8 @@
       "action": "index",
       "menu": "espace_admin",
       "role_min": "admin",
-      "label": "Bannière"
+      "label": "Bannière",
+      "breadcrumb": { "label": "Bannière", "parents": ["Espace admin"] }
     },
     {
       "path": "/config/banner/add",

--- a/modules/calendar/module.json
+++ b/modules/calendar/module.json
@@ -12,7 +12,8 @@
       "action": "index",
       "menu": "notre_unite",
       "role_min": "public",
-      "label": "Calendrier"
+      "label": "Calendrier",
+      "breadcrumb": { "label": "Calendrier", "parents": ["Notre unité"] }
     },
     {
       "path": "/calendar/feed/{token}.ics",
@@ -57,7 +58,8 @@
       "action": "index",
       "menu": "espace_chefs",
       "role_min": "chief",
-      "label": "Calendrier"
+      "label": "Calendrier",
+      "breadcrumb": { "label": "Calendrier", "parents": ["Espace des chefs"] }
     },
     {
       "path": "/chefs/calendar/event-create",
@@ -93,7 +95,8 @@
       "action": "index",
       "menu": "configuration",
       "role_min": "superadmin",
-      "label": "Calendrier"
+      "label": "Calendrier",
+      "breadcrumb": { "label": "Calendrier", "parents": ["Configuration"] }
     },
     {
       "path": "/config/calendar/defaults",

--- a/modules/finance/module.json
+++ b/modules/finance/module.json
@@ -12,7 +12,8 @@
       "action": "index",
       "menu": "espace_chefs",
       "role_min": "intendant",
-      "label": "Finances"
+      "label": "Finances",
+      "breadcrumb": { "label": "Finances", "parents": ["Espace des chefs"] }
     },
     {
       "path": "/finance/receivables",
@@ -192,7 +193,8 @@
       "action": "index",
       "menu": "configuration",
       "role_min": "superadmin",
-      "label": "Finances"
+      "label": "Finances",
+      "breadcrumb": { "label": "Finances", "parents": ["Configuration"] }
     },
     {
       "path": "/config/finance/accounts",

--- a/modules/gallery/module.json
+++ b/modules/gallery/module.json
@@ -13,7 +13,8 @@
       "menu": "espace_animes",
       "role_min": "identified",
       "label": "Galerie",
-      "menu_order": 6
+      "menu_order": 6,
+      "breadcrumb": { "label": "Galerie", "parents": ["Espace des animés"] }
     },
     {
       "path": "/gallery/manage",
@@ -22,7 +23,8 @@
       "action": "manage",
       "menu": "espace_chefs",
       "role_min": "chief",
-      "label": "Galerie"
+      "label": "Galerie",
+      "breadcrumb": { "label": "Galerie", "parents": ["Espace des chefs"] }
     },
     {
       "path": "/gallery/create",
@@ -148,7 +150,8 @@
       "action": "index",
       "menu": "configuration",
       "role_min": "superadmin",
-      "label": "Galerie"
+      "label": "Galerie",
+      "breadcrumb": { "label": "Galerie", "parents": ["Configuration"] }
     },
     {
       "path": "/config/gallery",

--- a/modules/llm_connector/module.json
+++ b/modules/llm_connector/module.json
@@ -11,7 +11,8 @@
       "action": "index",
       "menu": "configuration",
       "role_min": "superadmin",
-      "label": "Intelligence artificielle"
+      "label": "Intelligence artificielle",
+      "breadcrumb": { "label": "Intelligence artificielle", "parents": ["Configuration"] }
     },
     {
       "path": "/config/llm/providers",

--- a/modules/mass_mail/module.json
+++ b/modules/mass_mail/module.json
@@ -39,7 +39,8 @@
       "action": "index",
       "menu": "espace_chefs",
       "role_min": "chief",
-      "label": "Envoi de mails"
+      "label": "Envoi de mails",
+      "breadcrumb": { "label": "Envoi de mails", "parents": ["Espace des chefs"] }
     },
     {
       "path": "/mass-mail",
@@ -129,7 +130,8 @@
       "action": "index",
       "menu": "configuration",
       "role_min": "superadmin",
-      "label": "Envoi de mails"
+      "label": "Envoi de mails",
+      "breadcrumb": { "label": "Envoi de mails", "parents": ["Configuration"] }
     },
     {
       "path": "/config/mass-mail/lists",

--- a/modules/member_stats/module.json
+++ b/modules/member_stats/module.json
@@ -11,7 +11,8 @@
       "action": "index",
       "menu": "espace_chefs",
       "label": "Statistiques",
-      "role_min": "chief"
+      "role_min": "chief",
+      "breadcrumb": { "label": "Statistiques", "parents": ["Espace des chefs"] }
     }
   ],
   "settings": [],

--- a/modules/news/module.json
+++ b/modules/news/module.json
@@ -12,7 +12,8 @@
       "action": "index",
       "menu": "notre_unite",
       "role_min": "public",
-      "label": "Actualités"
+      "label": "Actualités",
+      "breadcrumb": { "label": "Actualités", "parents": ["Notre unité"] }
     },
     {
       "path": "/news/manage",
@@ -21,7 +22,8 @@
       "action": "manage",
       "menu": "espace_chefs",
       "role_min": "chief",
-      "label": "Actualités"
+      "label": "Actualités",
+      "breadcrumb": { "label": "Actualités", "parents": ["Espace des chefs"] }
     },
     {
       "path": "/news/create",

--- a/modules/retro/module.json
+++ b/modules/retro/module.json
@@ -12,7 +12,8 @@
       "action": "index",
       "menu": "espace_admin",
       "role_min": "admin",
-      "label": "Rétrospectives — Config"
+      "label": "Rétrospectives — Config",
+      "breadcrumb": { "label": "Rétrospectives — Config", "parents": ["Espace admin"] }
     },
     {
       "path": "/config/retro",
@@ -30,7 +31,8 @@
       "action": "index",
       "menu": "espace_chefs",
       "role_min": "intendant",
-      "label": "Rétrospectives"
+      "label": "Rétrospectives",
+      "breadcrumb": { "label": "Rétrospectives", "parents": ["Espace des chefs"] }
     },
     {
       "path": "/retro/create",

--- a/modules/sos_staff/module.json
+++ b/modules/sos_staff/module.json
@@ -13,7 +13,8 @@
       "menu": "espace_admin",
       "role_min": "admin",
       "label": "SOS Staff d'U",
-      "menu_order": 50
+      "menu_order": 50,
+      "breadcrumb": { "label": "SOS Staff d'U", "parents": ["Espace admin"] }
     },
     {
       "path": "/admin/sos/default-number",
@@ -58,7 +59,8 @@
       "action": "index",
       "menu": "configuration",
       "role_min": "superadmin",
-      "label": "SOS Staff d'U"
+      "label": "SOS Staff d'U",
+      "breadcrumb": { "label": "SOS Staff d'U", "parents": ["Configuration"] }
     },
     {
       "path": "/config/sos/ovh/credentials",

--- a/modules/trombinoscope/module.json
+++ b/modules/trombinoscope/module.json
@@ -13,7 +13,8 @@
       "menu": "espace_animes",
       "role_min": "identified",
       "label": "Trombinoscope",
-      "menu_order": 5
+      "menu_order": 5,
+      "breadcrumb": { "label": "Trombinoscope", "parents": ["Espace des animés"] }
     }
   ],
   "settings": [],

--- a/tests/Core/View/NavRenderingTest.php
+++ b/tests/Core/View/NavRenderingTest.php
@@ -176,6 +176,54 @@ class NavRenderingTest extends TestCase
         );
     }
 
+    public function testActiveStaticEntryTextIsVisibleNotBlueOnBlue(): void
+    {
+        // Bootstrap's .list-group-item.active paints a solid --bs-primary
+        // background WITHOUT !important, while the "active" state below
+        // also applies text-primary — a color utility that IS !important
+        // (Bootstrap 5) — to the label text. Combining both (as the mobile
+        // offcanvas used to) makes the label blue-on-blue: present in the
+        // markup, invisible on screen. The fix drops the Bootstrap `active`
+        // class from the <li> and relies on the bold blue text alone.
+        $html = $this->renderNav(Role::INTENDANT, true, '/chefs/staffs');
+
+        $this->assertMatchesRegularExpression(
+            '/<li class="list-group-item list-group-item-action border-0 ps-4 d-flex align-items-center" style="min-height:44px;">\s*<a href="\/chefs\/staffs" class="text-decoration-none d-block fw-semibold text-primary"/',
+            $html
+        );
+        $this->assertStringNotContainsString(
+            'list-group-item list-group-item-action border-0 ps-4 d-flex align-items-center active',
+            $html
+        );
+    }
+
+    public function testDynamicActiveEntryTextIsVisibleNotBlueOnBlue(): void
+    {
+        $builder = new MenuBuilder(Role::IDENTIFIED);
+        $builder->addPage(MenuBuilder::MENU_ESPACE_ANIMES, 'Baloo', '/members/1', 'identified', 10, true, 'Meute Akela');
+        $menus = $builder->build();
+
+        $html = $this->twig->render('partials/nav.html.twig', [
+            'menus' => $menus,
+            'current_path' => '/members/1',
+            'is_authenticated' => true,
+            'current_user_display_name' => 'test@example.com',
+            'current_user_role_label' => 'Identifié',
+            'site_name' => 'Test Scout',
+            'active_menu_id' => MenuBuilder::MENU_ESPACE_ANIMES,
+            'active_page_url' => '',
+        ]);
+
+        $this->assertStringContainsString(
+            'class="d-flex align-items-center gap-2 text-decoration-none fw-semibold text-primary"',
+            $html
+        );
+        $this->assertStringNotContainsString(
+            'list-group-item list-group-item-action border-0 ps-4 active',
+            $html
+        );
+    }
+
     public function testUserCardShownWhenAuthenticated(): void
     {
         $html = $this->renderNav(Role::ADMIN, true);


### PR DESCRIPTION
## Description

**Breadcrumb coverage gap**: every module page (Calendar — public/chief/config, Gallery, Finance, Trombinoscope, Mass Mail, News, Retro, Member Stats, SOS Staff d'U, Banner config, LLM connector config — including every SectionPicker-based page) declared no `breadcrumb` at all, so the fil d'Ariane stopped at the home icon on all of them. Added `breadcrumb.label`/`parents` to every real (labeled, GET) route across all 11 modules — no new mechanism, `module.json`'s optional field already existed, it just wasn't used anywhere yet.

Parents still never get an invented link — `partials/breadcrumb_bar.html.twig` already falls back to plain text whenever a parent's menu has no real page to offer, unchanged. Several previously-empty menu categories (Espace des chefs, Espace des animés, Espace admin) now legitimately have real pages, so their breadcrumb parents become clickable as a natural consequence of that, not a special case.

**Separate, pre-existing bug fixed**: the mobile offcanvas menu's active/current entry was invisible. Its `<li>` carried Bootstrap's `active` class (solid `--bs-primary` background, not `!important`) while its label used the `text-primary` color utility (Bootstrap 5 color utilities *are* `!important`) — blue text on a blue background, present in the DOM, invisible on screen. Dropped the Bootstrap `active` class from both the static and dynamic mobile entry branches in `nav.html.twig`; the existing bold-blue-text treatment is the highlight on its own.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist (no new attack surface — `module.json` breadcrumb declarations are developer-authored, not user input; the nav text-color fix is presentational only)
- [x] All code and comments are in English
- [x] All UI-facing text is in French (breadcrumb labels reuse each route's existing French `label`)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 1226/1226 non-DB suite, 273/273 `Modules` suite, 18/18 `NavRenderingTest`; every module manifest re-validated via `ModuleManifest::fromFile()`)
- [ ] PHPStan passes (`vendor/bin/phpstan analyse core/ --level=6`) — PHPStan cannot be installed in this network-restricted sandbox; CI will confirm


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo61SR4PG4rButKcDHbeTF)_