### PR TITLE
Fix mobile calendar bar overflow, unclickable upcoming events, oversized form checks

### DIFF
--- a/core/View/templates/partials/month_grid.html.twig
+++ b/core/View/templates/partials/month_grid.html.twig
@@ -29,7 +29,7 @@
 {% set month_bar_count = 0 %}
 {% for week in weeks %}{% set month_bar_count = month_bar_count + week.bars|length %}{% endfor %}
 {% for week in weeks %}
-    <div class="calendar-week" style="grid-template-rows: auto repeat({{ week.row_count }}, 1.35rem);">
+    <div class="calendar-week" style="grid-template-rows: auto repeat({{ week.row_count }}, var(--calendar-bar-height));">
         {% for day in week.days %}
             <div class="calendar-day-cell{{ days_clickable ? ' calendar-day-cell--clickable' : '' }}{{ not day.in_month ? ' is-padding' : '' }}{{ day.is_today ? ' is-today' : '' }}"
                  style="grid-column: {{ loop.index }}; grid-row: 1 / span {{ week.row_count + 1 }};"
@@ -49,6 +49,7 @@
                  style="grid-column: {{ bar.col_start }} / span {{ bar.col_span }}; grid-row: {{ bar.row + 2 }}; background-color: {{ bar.event.color }};"
                  title="{{ bar.event.tooltip ?? bar.event.label }}"
                  {%- if events_clickable %} tabindex="0" role="button" aria-label="{{ bar.event.label }}"{% endif %}
+                 data-color="{{ bar.event.color }}"
                  {%- for key, value in bar.event.data %} data-{{ key }}="{{ value }}"{% endfor %}>
                 {{ bar.event.label }}
             </div>

--- a/modules/calendar/views/public.html.twig
+++ b/modules/calendar/views/public.html.twig
@@ -40,7 +40,15 @@
     {% else %}
         <ul class="list-group mb-4">
             {% for event in upcoming_events %}
-                <li class="list-group-item d-flex justify-content-between align-items-start">
+                {# Same GridEvent shape/data-* attributes as a grid bar (see
+                   partials/month_grid.html.twig) so both feed the same
+                   showEventDetails() below — color travels via data-color
+                   since, unlike a bar, this <li> has no colored background
+                   of its own to read the color back off of. #}
+                <li class="list-group-item d-flex justify-content-between align-items-start calendar-upcoming-event-item"
+                    tabindex="0" role="button" aria-label="{{ event.label }}"
+                    data-color="{{ event.color }}"
+                    {%- for key, value in event.data %} data-{{ key }}="{{ value }}"{% endfor %}>
                     <div>
                         <div class="fw-semibold">{{ event.label }}</div>
                         <div class="text-body-secondary small d-flex align-items-center gap-1">
@@ -125,40 +133,51 @@ function formatDateFr(isoDate) {
     return `${d}/${m}/${y}`;
 }
 
-document.querySelectorAll('.calendar-event-bar--clickable').forEach(bar => {
-    bar.addEventListener('click', () => {
-        const data = bar.dataset;
-        document.getElementById('event-details-title').textContent = data.title;
-        document.getElementById('event-details-calendar-dot').style.backgroundColor = bar.style.backgroundColor;
-        document.getElementById('event-details-calendar-label').textContent = data.calendarLabel;
+// Shared by both the month-grid bars and the "Prochains évènements" list
+// items below — both emit the identical data-* bag (see
+// partials/month_grid.html.twig and the <li> loop above), so there is only
+// ever one place that knows how to fill this modal.
+function showEventDetails(data) {
+    document.getElementById('event-details-title').textContent = data.title;
+    document.getElementById('event-details-calendar-dot').style.backgroundColor = data.color;
+    document.getElementById('event-details-calendar-label').textContent = data.calendarLabel;
 
-        let dates = formatDateFr(data.startDate);
-        if (data.endDate && data.endDate !== data.startDate) {
-            dates += ' — ' + formatDateFr(data.endDate);
+    let dates = formatDateFr(data.startDate);
+    if (data.endDate && data.endDate !== data.startDate) {
+        dates += ' — ' + formatDateFr(data.endDate);
+    }
+    document.getElementById('event-details-dates').textContent = dates;
+
+    const timeRow = document.getElementById('event-details-time-row');
+    if (data.startTime) {
+        let time = data.startTime;
+        if (data.endTime) time += ' - ' + data.endTime;
+        document.getElementById('event-details-time').textContent = time;
+        timeRow.classList.remove('d-none');
+    } else {
+        timeRow.classList.add('d-none');
+    }
+
+    const locationRow = document.getElementById('event-details-location-row');
+    if (data.location) {
+        document.getElementById('event-details-location').textContent = data.location;
+        locationRow.classList.remove('d-none');
+    } else {
+        locationRow.classList.add('d-none');
+    }
+
+    document.getElementById('event-details-description').textContent = data.description || '';
+
+    eventDetailsModal.show();
+}
+
+document.querySelectorAll('.calendar-event-bar--clickable, .calendar-upcoming-event-item').forEach(trigger => {
+    trigger.addEventListener('click', () => showEventDetails(trigger.dataset));
+    trigger.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            showEventDetails(trigger.dataset);
         }
-        document.getElementById('event-details-dates').textContent = dates;
-
-        const timeRow = document.getElementById('event-details-time-row');
-        if (data.startTime) {
-            let time = data.startTime;
-            if (data.endTime) time += ' - ' + data.endTime;
-            document.getElementById('event-details-time').textContent = time;
-            timeRow.classList.remove('d-none');
-        } else {
-            timeRow.classList.add('d-none');
-        }
-
-        const locationRow = document.getElementById('event-details-location-row');
-        if (data.location) {
-            document.getElementById('event-details-location').textContent = data.location;
-            locationRow.classList.remove('d-none');
-        } else {
-            locationRow.classList.add('d-none');
-        }
-
-        document.getElementById('event-details-description').textContent = data.description || '';
-
-        eventDetailsModal.show();
     });
 });
 </script>

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -84,13 +84,30 @@
         justify-content: center;
     }
 
-    /* Bootstrap switches & checkboxes: enlarge touch area */
-    .form-check-input {
-        min-width: 44px;
+    /* Bootstrap switches & checkboxes: AGENTS.md's 44px rule is about the
+       tappable ZONE, not the drawn control. This block used to grow the
+       input itself to 44x44 (min-width/min-height directly on
+       .form-check-input) — that turned a checkbox into an oversized square
+       next to ~14px of label text, and a switch's 3rem/44px box into an
+       almost-square lozenge instead of Bootstrap's pill. That was the
+       actual reported bug. The control now keeps its native Bootstrap size
+       (~1em checkbox/radio, 2em-wide switch pill); the 44px zone moves to
+       .form-check-label instead — a real <label for="...">, which the
+       browser already activates its control from anywhere inside its box,
+       so growing the label (not just decorative padding around it) is what
+       makes the extra height actually tappable, not just visually taller.
+       inline-flex + align-items:center keeps the label an inline-level box
+       (still wraps next to the float-positioned .form-check-input the way
+       Bootstrap lays it out) while vertically centering its text inside
+       the taller box — the checkbox/label pair's own relative alignment
+       (.form-check-input's margin-top:.25em against the label's first
+       line) is untouched by this, only the row's overall height changes. */
+    .form-check {
         min-height: 44px;
     }
-    .form-switch .form-check-input {
-        min-width: 3rem;
+    .form-check-label {
+        display: inline-flex;
+        align-items: center;
         min-height: 44px;
     }
 
@@ -122,12 +139,12 @@
         min-height: revert;
         min-width: revert;
     }
-    .form-check-input {
-        min-width: revert;
+    .form-check {
         min-height: revert;
     }
-    .form-switch .form-check-input {
-        min-width: revert;
+    .form-check-label {
+        display: revert;
+        align-items: revert;
         min-height: revert;
     }
 }

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -87,6 +87,12 @@
     font-size: 0.7rem;
 }
 .calendar-week {
+    /* Single source of truth for bar-row height — partials/month_grid.html.twig
+       reads this same variable for grid-template-rows, so the CSS bar height
+       and the grid track height can never drift apart again (they did: a
+       real bug, found and fixed — see the pointer:coarse note on
+       .calendar-event-bar--clickable below for what that looked like). */
+    --calendar-bar-height: 1.35rem;
     display: grid;
     grid-template-columns: repeat(7, 1fr);
     border-left: 1px solid var(--bs-border-color, #dee2e6);
@@ -144,7 +150,10 @@
     padding: 0 0.3rem;
     border-radius: 0.25rem;
     font-size: 0.68rem;
-    line-height: 1.25rem;
+    /* Derived from the same --calendar-bar-height the grid row height comes
+       from (minus the 1px top/bottom margin above) — never a value of its
+       own, or the two drift apart again. */
+    line-height: calc(var(--calendar-bar-height) - 2px);
     color: #fff;
     white-space: nowrap;
     overflow: hidden;
@@ -163,21 +172,40 @@
     cursor: pointer;
 }
 
-/* On touch devices, enlarge event bars for reliable tap targets */
+/* "Prochains évènements" list item (modules/calendar/views/public.html.twig)
+   — opens the same #eventDetailsModal as a grid bar, via the same
+   showEventDetails() data-* contract. Not part of the grid itself, so it
+   gets its own hook class rather than reusing .calendar-event-bar--clickable. */
+.calendar-upcoming-event-item {
+    cursor: pointer;
+}
+
+/* Touch-target exception to AGENTS.md's 44px minimum, deliberate and
+   documented (not an oversight): a month grid packs several event bars
+   into one ~22px grid row inside a 7-column day cell, back-to-back with a
+   1px margin and no slack above/below to widen an invisible hit area into
+   without covering a stacked sibling event, nor sideways without spilling
+   into the next day's column. The previous approach grew the bar itself to
+   44px on touch (line-height:2rem + min-height:44px) — but the grid row
+   height (see --calendar-bar-height above) never grew to match, so the
+   44px-tall bar simply overflowed its ~22px track and covered the
+   neighbouring row/day below it. That was the actual reported bug. The bar
+   now keeps its real, compact height as its tap target on every pointer
+   type — a small font-size bump is still worth it for legibility, but the
+   box itself no longer grows.
+   Cell height / MonthGridBuilder's maxVisibleRows: unaffected by this —
+   that cap was always a fixed PHP-side constant (3), never derived from
+   any CSS value; this fix only makes the grid's own rendered row height
+   finally match what that cap was always meant to look like. */
 @media (pointer: coarse) {
     .calendar-event-bar {
-        line-height: 2rem;
         font-size: 0.72rem;
         padding: 0.15rem 0.4rem;
-    }
-    .calendar-event-bar--clickable {
-        min-height: 44px;
-        display: flex;
-        align-items: center;
     }
 }
 
 @media (min-width: 768px) {
+    .calendar-week { --calendar-bar-height: 1.5rem; }
     .calendar-day-number { min-height: 1.75rem; padding: 0.3rem 0.5rem; font-size: 0.85rem; }
     .calendar-event-bar { font-size: 0.75rem; }
 }

--- a/tests/Core/View/TouchTargetCssTest.php
+++ b/tests/Core/View/TouchTargetCssTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\View;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * public/assets/css/app.css's "MOBILE TOUCH-TARGET BASELINE" block
+ * (AGENTS.md's 44px minimum tap zone on coarse-pointer devices). Real bug:
+ * .form-check-input itself used to get min-width/min-height:44px, which
+ * grows the drawn CONTROL (a checkbox became a 44x44 square next to ~14px
+ * of label text, a switch an almost-square lozenge instead of a pill) —
+ * the 44px rule is about the tappable zone, not the visible box. These
+ * assertions read the raw stylesheet (no browser in PHPUnit) to pin the
+ * structural shape of the fix; the actual rendered pixel sizes/label
+ * centering/tap-anywhere-on-the-label behavior were verified with a
+ * throwaway Playwright script against the real files (not committed —
+ * this repo has no JS test runner, see AGENTS.md).
+ */
+class TouchTargetCssTest extends TestCase
+{
+    private string $css;
+
+    protected function setUp(): void
+    {
+        $this->css = file_get_contents(dirname(__DIR__, 3) . '/public/assets/css/app.css');
+    }
+
+    private function coarsePointerBlock(): string
+    {
+        preg_match('/@media \(pointer: coarse\) \{(.*?)\n\}\n\n\/\* Restore compact/s', $this->css, $m);
+        $this->assertNotEmpty($m, 'Could not locate the @media (pointer: coarse) touch-target block');
+        return $m[1];
+    }
+
+    private function revertBlock(): string
+    {
+        preg_match('/@media \(min-width: 992px\) \{(.*?)\n\}/s', $this->css, $m);
+        $this->assertNotEmpty($m, 'Could not locate the @media (min-width: 992px) revert block');
+        return $m[1];
+    }
+
+    public function testFormCheckInputHasNoSizeOverrideOnCoarsePointers(): void
+    {
+        $block = $this->coarsePointerBlock();
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/\.form-check-input\s*\{[^}]*(min-width|min-height)/s',
+            $block
+        );
+        $this->assertDoesNotMatchRegularExpression(
+            '/\.form-switch \.form-check-input\s*\{/',
+            $block
+        );
+    }
+
+    public function testFormCheckLabelCarriesTheTapZoneInstead(): void
+    {
+        $block = $this->coarsePointerBlock();
+
+        $this->assertMatchesRegularExpression(
+            '/\.form-check-label\s*\{[^}]*min-height:\s*44px/s',
+            $block
+        );
+        $this->assertMatchesRegularExpression(
+            '/\.form-check-label\s*\{[^}]*align-items:\s*center/s',
+            $block
+        );
+    }
+
+    public function testOtherCoarsePointerRulesStillTargetGenuinelyInteractiveElements(): void
+    {
+        // .btn-sm / .form-control-sm / .form-select-sm / .pagination
+        // .page-link / .list-group-item-action are the interactive element
+        // itself (a button, an input, a link) — legitimately grown
+        // directly, unlike .form-check-input which decorates a label's
+        // real click target.
+        $block = $this->coarsePointerBlock();
+
+        foreach (['.btn-sm', '.form-control-sm', '.form-select-sm', '.pagination .page-link', '.list-group-item-action'] as $selector) {
+            $this->assertStringContainsString($selector, $block);
+        }
+    }
+
+    public function testRevertBlockStaysConsistentWithWhatTheCoarsePointerBlockActuallyOverrides(): void
+    {
+        // No orphaned .form-check-input revert now that the coarse-pointer
+        // block no longer touches it — and a matching revert for
+        // .form-check-label, which now does.
+        $revert = $this->revertBlock();
+
+        $this->assertDoesNotMatchRegularExpression('/\.form-check-input\s*\{/', $revert);
+        $this->assertMatchesRegularExpression('/\.form-check-label\s*\{[^}]*display:\s*revert/s', $revert);
+        $this->assertMatchesRegularExpression('/\.form-check-label\s*\{[^}]*min-height:\s*revert/s', $revert);
+    }
+}

--- a/tests/Modules/Calendar/Controller/CalendarPublicControllerTest.php
+++ b/tests/Modules/Calendar/Controller/CalendarPublicControllerTest.php
@@ -208,6 +208,98 @@ class CalendarPublicControllerTest extends TestCase
         $this->assertMatchesRegularExpression('/grid-column:\s*3\s*\/\s*span\s*3/', $response->getBody());
     }
 
+    public function testMonthGridRowHeightUsesTheSharedCssVariableNotAHardcodedValue(): void
+    {
+        // Real bug: month_grid.html.twig hardcoded 1.35rem for the grid row
+        // height while components.css grew the bar to 44px on touch devices
+        // — the two drifted apart and bars overflowed their track. Both now
+        // read the same --calendar-bar-height custom property.
+        $calendar = $this->calendarService->addCalendar('Test', 'public');
+        $this->eventRepository->create($calendar->id, 'Réunion', '2026-03-11', null, null, null, null, null, null);
+
+        $request = new Request('GET', '/calendar', ['month' => '2026-03'], [], [], []);
+        $response = $this->controller->index($request, []);
+
+        $body = $response->getBody();
+        $this->assertMatchesRegularExpression(
+            '/grid-template-rows:\s*auto repeat\(\d+,\s*var\(--calendar-bar-height\)\);/',
+            $body
+        );
+        $this->assertStringNotContainsString('1.35rem', $body);
+    }
+
+    public function testMonthGridShowsOverflowBadgeWhenADayExceedsTheRowCap(): void
+    {
+        // MonthGridBuilder caps visible rows at 3 (DEFAULT_MAX_VISIBLE_ROWS)
+        // regardless of any CSS/viewport value — 5 same-day events means 2
+        // hidden behind the "+2" overflow badge.
+        $calendar = $this->calendarService->addCalendar('Test', 'public');
+        for ($i = 1; $i <= 5; $i++) {
+            $this->eventRepository->create($calendar->id, "Event {$i}", '2026-03-11', null, null, null, null, null, null);
+        }
+
+        $request = new Request('GET', '/calendar', ['month' => '2026-03'], [], [], []);
+        $response = $this->controller->index($request, []);
+
+        $body = $response->getBody();
+        $this->assertStringContainsString('calendar-day-overflow', $body);
+        $this->assertStringContainsString('+2', $body);
+    }
+
+    public function testUpcomingEventListItemsCarryTheSameDataAttributesAsGridBars(): void
+    {
+        // Real bug: the "Prochains évènements" <li> items had no data-*
+        // attributes and no click handler at all, so clicking one did
+        // nothing — the modal only ever opened from a grid bar. Both now
+        // emit the identical data-* bag (color included, since a <li> has
+        // no colored background to read it back off of like a bar does).
+        $calendar = $this->calendarService->addCalendar('Anniversaires', 'public');
+        $this->eventRepository->create($calendar->id, 'Grand jeu', '2099-01-01', null, '14:00:00', '16:00:00', 'Local scout', 'Une belle description', null);
+
+        $request = new Request('GET', '/calendar', [], [], [], []);
+        $response = $this->controller->index($request, []);
+
+        $body = $response->getBody();
+        $this->assertStringContainsString('calendar-upcoming-event-item', $body);
+        $this->assertMatchesRegularExpression('/class="[^"]*calendar-upcoming-event-item[^"]*"\s+tabindex="0" role="button"/', $body);
+        $this->assertStringContainsString('data-title="Grand jeu"', $body);
+        $this->assertStringContainsString('data-calendar-label="Anniversaires"', $body);
+        $this->assertStringContainsString('data-start-time="14:00"', $body);
+        $this->assertStringContainsString('data-end-time="16:00"', $body);
+        $this->assertStringContainsString('data-location="Local scout"', $body);
+        $this->assertStringContainsString('data-description="Une belle description"', $body);
+        $this->assertMatchesRegularExpression('/data-color="#?[0-9a-fA-F]{3,6}"/', $body);
+    }
+
+    public function testUpcomingEventListItemLeavesTimeAndLocationDataAttributesEmptyWhenAbsent(): void
+    {
+        $calendar = $this->calendarService->addCalendar('Anniversaires', 'public');
+        $this->eventRepository->create($calendar->id, 'Réunion silencieuse', '2099-01-01', null, null, null, null, null, null);
+
+        $request = new Request('GET', '/calendar', [], [], [], []);
+        $response = $this->controller->index($request, []);
+
+        $body = $response->getBody();
+        $this->assertStringContainsString('data-start-time=""', $body);
+        $this->assertStringContainsString('data-location=""', $body);
+    }
+
+    public function testEventDetailsModalJsIsSharedByGridBarsAndUpcomingEventItems(): void
+    {
+        $request = new Request('GET', '/calendar', [], [], [], []);
+        $response = $this->controller->index($request, []);
+
+        $body = $response->getBody();
+        // One fill function, one query selecting both trigger sources — not
+        // two copies of the modal-filling logic.
+        $this->assertSame(1, substr_count($body, 'function showEventDetails('));
+        $this->assertStringContainsString(
+            "document.querySelectorAll('.calendar-event-bar--clickable, .calendar-upcoming-event-item')",
+            $body
+        );
+        $this->assertStringContainsString("data.color", $body);
+    }
+
     public function testIndexDoesNotShowChiefOnlyCalendarToPublicVisitor(): void
     {
         $calendar = $this->calendarService->addCalendar('Réservé', 'chief');


### PR DESCRIPTION
## Description

Three unrelated mobile bugs, all traced to naive/incorrect application of AGENTS.md's 44px touch-target rule or missing JS wiring:

**1. Event bars overflowing their grid cell (both calendar pages)**
`partials/month_grid.html.twig` hardcoded `grid-template-rows: ... 1.35rem` in Twig, while `components.css`'s `pointer:coarse` block separately grew the bar to 44px on touch — the two values could drift apart, and a 44px-tall bar overflowed its ~22px grid row. Both now read a single `--calendar-bar-height` CSS variable (mobile value on `.calendar-week`, larger value from the 768px breakpoint), consumed by both the Twig `grid-template-rows` and the bar's own `line-height`. The bar keeps its real, compact height as its tap target on every pointer type — packing several bars back-to-back in a 7-column day cell leaves no safe room to grow a hit area into without covering a sibling event or the next day's column, so this is a documented, deliberate exception to the 44px rule (see the comment in `components.css`). `MonthGridBuilder`'s row cap is a fixed PHP-side constant, untouched — the grid's rendered height just finally matches what that cap always meant.

**2. "Prochains évènements" list not opening the event detail modal**
The click handler only targeted grid bars; the list `<li>` items had no `data-*` attributes and no listener. They now emit the same `data-*` bag as a grid bar (same `{% for key, value in event.data %}` loop, plus an explicit `data-color` since a `<li>` has no colored background to read a color back off of, unlike a bar's inline style). One shared `showEventDetails()` function fills the modal for both sources — no duplicated fill logic. List items get `role="button"`, `tabindex="0"`, and Enter/Space keyboard activation, matching (and slightly fixing) the bars. `chief.html.twig` has no equivalent list, so it needed no change.

**3. Oversized checkboxes/switches/radios on mobile**
`app.css`'s touch-target block put `min-width`/`min-height: 44px` directly on `.form-check-input`, growing the drawn control itself (a checkbox became a 44×44 square next to ~14px of text; a switch became an almost-square lozenge instead of a pill). The 44px rule is about the tappable zone, not the visible box. The control now keeps its native Bootstrap size; the 44px zone moved to `.form-check-label` (a real `<label>`, which the browser already activates its control from anywhere inside its box), via `inline-flex` + `align-items: center` so the label stays inline (still wraps next to the floated checkbox) while vertically centering its text. The `@media (min-width: 992px)` revert block was updated to match (no orphaned `.form-check-input` revert). Verified with a throwaway Playwright script against the real stylesheets (not committed — no JS test runner in this repo): native control sizes restored, switch stays a pill, label is a real 44px-tall tap target (clicking near its edge toggles the control), inline checkbox groups still lay out side by side, desktop (≥992px, `pointer:fine`) unaffected.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [ ] PHPStan passes (`vendor/bin/phpstan analyse core/ --level=6`) — not installed in this environment, not run


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo61SR4PG4rButKcDHbeTF)_