### PR TITLE
Fix PHPStan level-6 failure on UnitLogoService::FILENAMES

### DIFF
--- a/core/Photo/UnitLogoService.php
+++ b/core/Photo/UnitLogoService.php
@@ -35,7 +35,15 @@ use Core\Config\SettingService;
  */
 class UnitLogoService
 {
-    /** @var array<string, string> */
+    // Keys here are a real PHP array literal, not markup: PHP coerces any
+    // key that's a canonical decimal-integer string ('16', '32', ... '512')
+    // to an int key at parse time — only '512-maskable' stays a string key.
+    // The @var below reflects that mix (int|string), not array<string,
+    // string> — every lookup already passes a string $size (resolveIconContent(),
+    // isValidSize()), which PHP/PHPStan both resolve against an int|string
+    // key set without issue; only the annotation itself needed to match
+    // the actual literal's shape.
+    /** @var array<int|string, string> */
     private const FILENAMES = [
         '16' => 'favicon-16.png',
         '32' => 'favicon-32.png',


### PR DESCRIPTION
## Description

CI's `vendor/bin/phpstan analyse core/ --level=6` was failing on merge with:

```
PHPDoc tag @var for constant Core\Photo\UnitLogoService::FILENAMES with type
array<string, string> is not subtype of value array{16: 'favicon-16.png', ...}.
```

Root cause: PHP coerces array literal keys that are canonical decimal-integer strings (`'16'`, `'32'`, `'48'`, `'64'`, `'180'`, `'192'`, `'512'`) to real `int` keys at parse time — only `'512-maskable'` stays a string key. The `@var array<string, string>` annotation asserted every key was a string, which doesn't match that actual mixed `int|string` shape, so PHPStan correctly rejected it as unsound.

This is a pure docblock fix — every real lookup (`resolveIconContent()`, `isValidSize()`) already passes a `string $size` and resolves correctly against an `int|string`-keyed array both at runtime and under PHPStan's own type rules; nothing about program behavior changes.

Verified locally: `php phpstan.phar analyse core/ --level=6 --memory-limit=512M` → `[OK] No errors` (was 1 error before this change), full `vendor/bin/phpunit` suite green (1300 tests).

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change — no behavior changed, existing tests cover `UnitLogoService`; no new test needed for a docblock accuracy fix
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse core/ --level=6`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Mo61SR4PG4rButKcDHbeTF)_