### PR TITLE
Add copyright notice, contributor attribution, and AGPL name clause

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,17 @@ Thank you for considering contributing to this project.
 4. Ensure static analysis passes: `vendor/bin/phpstan analyse` (covers `core/`, `modules/`, and `public/index.php`/`public/cron.php` — the composition roots where controllers are wired up are in scope specifically because a wiring bug there only ever surfaces at runtime, never in an IDE or a unit test)
 5. Open a PR against `main` and fill in the PR template checklist.
 
+## License and attribution
+
+This project is licensed under AGPL-3.0-or-later (see [LICENSE](LICENSE)). By submitting a
+contribution, you agree that it is licensed under the same terms.
+
+Contributors are added to [NOTICE](NOTICE) as their contributions are merged. LICENSE also
+carries an additional permission under AGPL §7: a modified version of this project may not be
+distributed, or offered as a service, under the name "ScoutMagic" (or a confusingly similar
+name) without the copyright holder's prior written permission. This does not restrict
+contributing to or running this project — only publishing a modified fork under its name.
+
 ## Security issues
 
 Report security vulnerabilities privately — not via public issues. Contact the maintainer directly.

--- a/LICENSE
+++ b/LICENSE
@@ -1,674 +1,264 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
+ScoutMagic
+Copyright (C) 2026 Xavier Dubois and contributors
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version, subject to the additional terms below.
+
+Additional permission under GNU AGPL version 3 section 7:
+
+If you modify this Program, or any covered work, you may not distribute
+the modified version, nor offer it as a service, under the name
+"ScoutMagic" or any name confusingly similar to it, without prior written
+permission from the copyright holder. This restriction does not apply to
+unmodified copies of this Program.
+
+--------------------------------------------------------------------------
+
+GNU AFFERO GENERAL PUBLIC LICENSE
+Version 3, 19 November 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
 
                             Preamble
 
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+The GNU Affero General Public License is a free, copyleft license for software and other kinds of works, specifically designed to ensure cooperation with the community in the case of network server software.
 
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
+The licenses for most software and other practical works are designed to take away your freedom to share and change the works.  By contrast, our General Public Licenses are intended to guarantee your freedom to share and change all versions of a program--to make sure it remains free software for all its users.
 
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
+When we speak of free software, we are referring to freedom, not price.  Our General Public Licenses are designed to make sure that you have the freedom to distribute copies of free software (and charge for them if you wish), that you receive source code or can get it if you want it, that you can change the software or use pieces of it in new free programs, and that you know you can do these things.
 
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
+Developers that use our General Public Licenses protect your rights with two steps: (1) assert copyright on the software, and (2) offer you this License which gives you legal permission to copy, distribute and/or modify the software.
 
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
+A secondary benefit of defending all users' freedom is that improvements made in alternate versions of the program, if they receive widespread use, become available for other developers to incorporate.  Many developers of free software are heartened and encouraged by the resulting cooperation.  However, in the case of software used on network servers, this result may fail to come about. The GNU General Public License permits making a modified version and letting the public access it on a server without ever releasing its source code to the public.
 
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
+The GNU Affero General Public License is designed specifically to ensure that, in such cases, the modified source code becomes available to the community.  It requires the operator of a network server to provide the source code of the modified version running there to the users of that server.  Therefore, public use of a modified version, on a publicly accessible server, gives the public access to the source code of the modified version.
 
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
+An older license, called the Affero General Public License and published by Affero, was designed to accomplish similar goals.  This is a different license, not a version of the Affero GPL, but Affero has released a new version of the Affero GPL which permits relicensing under this license.
 
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
+The precise terms and conditions for copying, distribution and modification follow.
 
                        TERMS AND CONDITIONS
 
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Use with the GNU Affero General Public License.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
+0. Definitions.
+
+"This License" refers to version 3 of the GNU Affero General Public License.
+
+"Copyright" also means copyright-like laws that apply to other kinds of works, such as semiconductor masks.
+
+"The Program" refers to any copyrightable work licensed under this License.  Each licensee is addressed as "you".  "Licensees" and "recipients" may be individuals or organizations.
+
+To "modify" a work means to copy from or adapt all or part of the work in a fashion requiring copyright permission, other than the making of an exact copy.  The resulting work is called a "modified version" of the earlier work or a work "based on" the earlier work.
+
+A "covered work" means either the unmodified Program or a work based on the Program.
+
+To "propagate" a work means to do anything with it that, without permission, would make you directly or secondarily liable for infringement under applicable copyright law, except executing it on a computer or modifying a private copy.  Propagation includes copying, distribution (with or without modification), making available to the public, and in some countries other activities as well.
+
+To "convey" a work means any kind of propagation that enables other parties to make or receive copies.  Mere interaction with a user through a computer network, with no transfer of a copy, is not conveying.
+
+An interactive user interface displays "Appropriate Legal Notices" to the extent that it includes a convenient and prominently visible feature that (1) displays an appropriate copyright notice, and (2) tells the user that there is no warranty for the work (except to the extent that warranties are provided), that licensees may convey the work under this License, and how to view a copy of this License.  If the interface presents a list of user commands or options, such as a menu, a prominent item in the list meets this criterion.
+
+1. Source Code.
+
+The "source code" for a work means the preferred form of the work for making modifications to it.  "Object code" means any non-source form of a work.
+
+A "Standard Interface" means an interface that either is an official standard defined by a recognized standards body, or, in the case of interfaces specified for a particular programming language, one that is widely used among developers working in that language.
+
+The "System Libraries" of an executable work include anything, other than the work as a whole, that (a) is included in the normal form of packaging a Major Component, but which is not part of that Major Component, and (b) serves only to enable use of the work with that Major Component, or to implement a Standard Interface for which an implementation is available to the public in source code form.  A "Major Component", in this context, means a major essential component (kernel, window system, and so on) of the specific operating system (if any) on which the executable work runs, or a compiler used to produce the work, or an object code interpreter used to run it.
+
+The "Corresponding Source" for a work in object code form means all the source code needed to generate, install, and (for an executable work) run the object code and to modify the work, including scripts to control those activities.  However, it does not include the work's System Libraries, or general-purpose tools or generally available free programs which are used unmodified in performing those activities but which are not part of the work.  For example, Corresponding Source includes interface definition files associated with source files for the work, and the source code for shared libraries and dynamically linked subprograms that the work is specifically designed to require, such as by intimate data communication or control flow between those subprograms and other parts of the work.
+
+The Corresponding Source need not include anything that users can regenerate automatically from other parts of the Corresponding Source.
+
+The Corresponding Source for a work in source code form is that same work.
+
+2. Basic Permissions.
+
+All rights granted under this License are granted for the term of copyright on the Program, and are irrevocable provided the stated conditions are met.  This License explicitly affirms your unlimited permission to run the unmodified Program.  The output from running a covered work is covered by this License only if the output, given its content, constitutes a covered work.  This License acknowledges your rights of fair use or other equivalent, as provided by copyright law.
+
+You may make, run and propagate covered works that you do not convey, without conditions so long as your license otherwise remains in force.  You may convey covered works to others for the sole purpose of having them make modifications exclusively for you, or provide you with facilities for running those works, provided that you comply with the terms of this License in conveying all material for which you do not control copyright.  Those thus making or running the covered works for you must do so exclusively on your behalf, under your direction and control, on terms that prohibit them from making any copies of your copyrighted material outside their relationship with you.
+
+Conveying under any other circumstances is permitted solely under the conditions stated below.  Sublicensing is not allowed; section 10 makes it unnecessary.
+
+3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+No covered work shall be deemed part of an effective technological measure under any applicable law fulfilling obligations under article 11 of the WIPO copyright treaty adopted on 20 December 1996, or similar laws prohibiting or restricting circumvention of such measures.
+
+When you convey a covered work, you waive any legal power to forbid circumvention of technological measures to the extent such circumvention is effected by exercising rights under this License with respect to the covered work, and you disclaim any intention to limit operation or modification of the work as a means of enforcing, against the work's users, your or third parties' legal rights to forbid circumvention of technological measures.
+
+4. Conveying Verbatim Copies.
+
+You may convey verbatim copies of the Program's source code as you receive it, in any medium, provided that you conspicuously and appropriately publish on each copy an appropriate copyright notice; keep intact all notices stating that this License and any non-permissive terms added in accord with section 7 apply to the code; keep intact all notices of the absence of any warranty; and give all recipients a copy of this License along with the Program.
+
+You may charge any price or no price for each copy that you convey, and you may offer support or warranty protection for a fee.
+
+5. Conveying Modified Source Versions.
+
+You may convey a work based on the Program, or the modifications to produce it from the Program, in the form of source code under the terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is released under this License and any conditions added under section 7.  This requirement modifies the requirement in section 4 to "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this License to anyone who comes into possession of a copy.  This License will therefore apply, along with any applicable section 7 additional terms, to the whole of the work, and all its parts, regardless of how they are packaged.  This License gives no permission to license the work in any other way, but it does not invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display Appropriate Legal Notices; however, if the Program has interactive interfaces that do not display Appropriate Legal Notices, your work need not make them do so.
+
+A compilation of a covered work with other separate and independent works, which are not by their nature extensions of the covered work, and which are not combined with it such as to form a larger program, in or on a volume of a storage or distribution medium, is called an "aggregate" if the compilation and its resulting copyright are not used to limit the access or legal rights of the compilation's users beyond what the individual works permit.  Inclusion of a covered work in an aggregate does not cause this License to apply to the other parts of the aggregate.
+
+6. Conveying Non-Source Forms.
+
+You may convey a covered work in object code form under the terms of sections 4 and 5, provided that you also convey the machine-readable Corresponding Source under the terms of this License, in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by the Corresponding Source fixed on a durable physical medium customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product (including a physical distribution medium), accompanied by a written offer, valid for at least three years and valid for as long as you offer spare parts or customer support for that product model, to give anyone who possesses the object code either (1) a copy of the Corresponding Source for all the software in the product that is covered by this License, on a durable physical medium customarily used for software interchange, for a price no more than your reasonable cost of physically performing this conveying of source, or (2) access to copy the Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the written offer to provide the Corresponding Source.  This alternative is allowed only occasionally and noncommercially, and only if you received the object code with such an offer, in accord with subsection 6b.
+
+    d) Convey the object code by offering access from a designated place (gratis or for a charge), and offer equivalent access to the Corresponding Source in the same way through the same place at no further charge.  You need not require recipients to copy the Corresponding Source along with the object code.  If the place to copy the object code is a network server, the Corresponding Source may be on a different server (operated by you or a third party) that supports equivalent copying facilities, provided you maintain clear directions next to the object code saying where to find the Corresponding Source.  Regardless of what server hosts the Corresponding Source, you remain obligated to ensure that it is available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided you inform other peers where the object code and Corresponding Source of the work are being offered to the general public at no charge under subsection 6d.
+
+A separable portion of the object code, whose source code is excluded from the Corresponding Source as a System Library, need not be included in conveying the object code work.
+
+A "User Product" is either (1) a "consumer product", which means any tangible personal property which is normally used for personal, family, or household purposes, or (2) anything designed or sold for incorporation into a dwelling.  In determining whether a product is a consumer product, doubtful cases shall be resolved in favor of coverage.  For a particular product received by a particular user, "normally used" refers to a typical or common use of that class of product, regardless of the status of the particular user or of the way in which the particular user actually uses, or expects or is expected to use, the product.  A product is a consumer product regardless of whether the product has substantial commercial, industrial or non-consumer uses, unless such uses represent the only significant mode of use of the product.
+
+"Installation Information" for a User Product means any methods, procedures, authorization keys, or other information required to install and execute modified versions of a covered work in that User Product from a modified version of its Corresponding Source.  The information must suffice to ensure that the continued functioning of the modified object code is in no case prevented or interfered with solely because modification has been made.
+
+If you convey an object code work under this section in, or with, or specifically for use in, a User Product, and the conveying occurs as part of a transaction in which the right of possession and use of the User Product is transferred to the recipient in perpetuity or for a fixed term (regardless of how the transaction is characterized), the Corresponding Source conveyed under this section must be accompanied by the Installation Information.  But this requirement does not apply if neither you nor any third party retains the ability to install modified object code on the User Product (for example, the work has been installed in ROM).
+
+The requirement to provide Installation Information does not include a requirement to continue to provide support service, warranty, or updates for a work that has been modified or installed by the recipient, or for the User Product in which it has been modified or installed.  Access to a network may be denied when the modification itself materially and adversely affects the operation of the network or violates the rules and protocols for communication across the network.
+
+Corresponding Source conveyed, and Installation Information provided, in accord with this section must be in a format that is publicly documented (and with an implementation available to the public in source code form), and must require no special password or key for unpacking, reading or copying.
+
+7. Additional Terms.
+
+"Additional permissions" are terms that supplement the terms of this License by making exceptions from one or more of its conditions. Additional permissions that are applicable to the entire Program shall be treated as though they were included in this License, to the extent that they are valid under applicable law.  If additional permissions apply only to part of the Program, that part may be used separately under those permissions, but the entire Program remains governed by this License without regard to the additional permissions.
+
+When you convey a copy of a covered work, you may at your option remove any additional permissions from that copy, or from any part of it.  (Additional permissions may be written to require their own removal in certain cases when you modify the work.)  You may place additional permissions on material, added by you to a covered work, for which you have or can give appropriate copyright permission.
+
+Notwithstanding any other provision of this License, for material you add to a covered work, you may (if authorized by the copyright holders of that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or author attributions in that material or in the Appropriate Legal Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or requiring that modified versions of such material be marked in reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that material by anyone who conveys the material (or modified versions of it) with contractual assumptions of liability to the recipient, for any liability that these contractual assumptions directly impose on those licensors and authors.
+
+All other non-permissive additional terms are considered "further restrictions" within the meaning of section 10.  If the Program as you received it, or any part of it, contains a notice stating that it is governed by this License along with a term that is a further restriction, you may remove that term.  If a license document contains a further restriction but permits relicensing or conveying under this License, you may add to a covered work material governed by the terms of that license document, provided that the further restriction does not survive such relicensing or conveying.
+
+If you add terms to a covered work in accord with this section, you must place, in the relevant source files, a statement of the additional terms that apply to those files, or a notice indicating where to find the applicable terms.
+
+Additional terms, permissive or non-permissive, may be stated in the form of a separately written license, or stated as exceptions; the above requirements apply either way.
+
+8. Termination.
+
+You may not propagate or modify a covered work except as expressly provided under this License.  Any attempt otherwise to propagate or modify it is void, and will automatically terminate your rights under this License (including any patent licenses granted under the third paragraph of section 11).
+
+However, if you cease all violation of this License, then your license from a particular copyright holder is reinstated (a) provisionally, unless and until the copyright holder explicitly and finally terminates your license, and (b) permanently, if the copyright holder fails to notify you of the violation by some reasonable means prior to 60 days after the cessation.
+
+Moreover, your license from a particular copyright holder is reinstated permanently if the copyright holder notifies you of the violation by some reasonable means, this is the first time you have received notice of violation of this License (for any work) from that copyright holder, and you cure the violation prior to 30 days after your receipt of the notice.
+
+Termination of your rights under this section does not terminate the licenses of parties who have received copies or rights from you under this License.  If your rights have been terminated and not permanently reinstated, you do not qualify to receive new licenses for the same material under section 10.
+
+9. Acceptance Not Required for Having Copies.
+
+You are not required to accept this License in order to receive or run a copy of the Program.  Ancillary propagation of a covered work occurring solely as a consequence of using peer-to-peer transmission to receive a copy likewise does not require acceptance.  However, nothing other than this License grants you permission to propagate or modify any covered work.  These actions infringe copyright if you do not accept this License.  Therefore, by modifying or propagating a covered work, you indicate your acceptance of this License to do so.
+
+10. Automatic Licensing of Downstream Recipients.
+
+Each time you convey a covered work, the recipient automatically receives a license from the original licensors, to run, modify and propagate that work, subject to this License.  You are not responsible for enforcing compliance by third parties with this License.
+
+An "entity transaction" is a transaction transferring control of an organization, or substantially all assets of one, or subdividing an organization, or merging organizations.  If propagation of a covered work results from an entity transaction, each party to that transaction who receives a copy of the work also receives whatever licenses to the work the party's predecessor in interest had or could give under the previous paragraph, plus a right to possession of the Corresponding Source of the work from the predecessor in interest, if the predecessor has it or can get it with reasonable efforts.
+
+You may not impose any further restrictions on the exercise of the rights granted or affirmed under this License.  For example, you may not impose a license fee, royalty, or other charge for exercise of rights granted under this License, and you may not initiate litigation (including a cross-claim or counterclaim in a lawsuit) alleging that any patent claim is infringed by making, using, selling, offering for sale, or importing the Program or any portion of it.
+
+11. Patents.
+
+A "contributor" is a copyright holder who authorizes use under this License of the Program or a work on which the Program is based.  The work thus licensed is called the contributor's "contributor version".
+
+A contributor's "essential patent claims" are all patent claims owned or controlled by the contributor, whether already acquired or hereafter acquired, that would be infringed by some manner, permitted by this License, of making, using, or selling its contributor version, but do not include claims that would be infringed only as a consequence of further modification of the contributor version.  For purposes of this definition, "control" includes the right to grant patent sublicenses in a manner consistent with the requirements of this License.
+
+Each contributor grants you a non-exclusive, worldwide, royalty-free patent license under the contributor's essential patent claims, to make, use, sell, offer for sale, import and otherwise run, modify and propagate the contents of its contributor version.
+
+In the following three paragraphs, a "patent license" is any express agreement or commitment, however denominated, not to enforce a patent (such as an express permission to practice a patent or covenant not to sue for patent infringement).  To "grant" such a patent license to a party means to make such an agreement or commitment not to enforce a patent against the party.
+
+If you convey a covered work, knowingly relying on a patent license, and the Corresponding Source of the work is not available for anyone to copy, free of charge and under the terms of this License, through a publicly available network server or other readily accessible means, then you must either (1) cause the Corresponding Source to be so available, or (2) arrange to deprive yourself of the benefit of the patent license for this particular work, or (3) arrange, in a manner consistent with the requirements of this License, to extend the patent license to downstream recipients.  "Knowingly relying" means you have actual knowledge that, but for the patent license, your conveying the covered work in a country, or your recipient's use of the covered work in a country, would infringe one or more identifiable patents in that country that you have reason to believe are valid.
+
+If, pursuant to or in connection with a single transaction or arrangement, you convey, or propagate by procuring conveyance of, a covered work, and grant a patent license to some of the parties receiving the covered work authorizing them to use, propagate, modify or convey a specific copy of the covered work, then the patent license you grant is automatically extended to all recipients of the covered work and works based on it.
+
+A patent license is "discriminatory" if it does not include within the scope of its coverage, prohibits the exercise of, or is conditioned on the non-exercise of one or more of the rights that are specifically granted under this License.  You may not convey a covered work if you are a party to an arrangement with a third party that is in the business of distributing software, under which you make payment to the third party based on the extent of your activity of conveying the work, and under which the third party grants, to any of the parties who would receive the covered work from you, a discriminatory patent license (a) in connection with copies of the covered work conveyed by you (or copies made from those copies), or (b) primarily for and in connection with specific products or compilations that contain the covered work, unless you entered into that arrangement, or that patent license was granted, prior to 28 March 2007.
+
+Nothing in this License shall be construed as excluding or limiting any implied license or other defenses to infringement that may otherwise be available to you under applicable patent law.
+
+12. No Surrender of Others' Freedom.
+
+If conditions are imposed on you (whether by court order, agreement or otherwise) that contradict the conditions of this License, they do not excuse you from the conditions of this License.  If you cannot convey a covered work so as to satisfy simultaneously your obligations under this License and any other pertinent obligations, then as a consequence you may not convey it at all.  For example, if you agree to terms that obligate you to collect a royalty for further conveying from those to whom you convey the Program, the only way you could satisfy both those terms and this License would be to refrain entirely from conveying the Program.
+
+13. Remote Network Interaction; Use with the GNU General Public License.
+
+Notwithstanding any other provision of this License, if you modify the Program, your modified version must prominently offer all users interacting with it remotely through a computer network (if your version supports such interaction) an opportunity to receive the Corresponding Source of your version by providing access to the Corresponding Source from a network server at no charge, through some standard or customary means of facilitating copying of software.  This Corresponding Source shall include the Corresponding Source for any work covered by version 3 of the GNU General Public License that is incorporated pursuant to the following paragraph.
+
+Notwithstanding any other provision of this License, you have permission to link or combine any covered work with a work licensed under version 3 of the GNU General Public License into a single combined work, and to convey the resulting work.  The terms of this License will continue to apply to the part which is the covered work, but the work with which it is combined will remain governed by version 3 of the GNU General Public License.
+
+14. Revised Versions of this License.
+
+The Free Software Foundation may publish revised and/or new versions of the GNU Affero General Public License from time to time.  Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program specifies that a certain numbered version of the GNU Affero General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that numbered version or of any later version published by the Free Software Foundation.  If the Program does not specify a version number of the GNU Affero General Public License, you may choose any version ever published by the Free Software Foundation.
+
+If the Program specifies that a proxy can decide which future versions of the GNU Affero General Public License can be used, that proxy's public statement of acceptance of a version permanently authorizes you to choose that version for the Program.
+
+Later license versions may give you additional or different permissions.  However, no additional obligations are imposed on any author or copyright holder as a result of your choosing to follow a later version.
+
+15. Disclaimer of Warranty.
+
+THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+16. Limitation of Liability.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+17. Interpretation of Sections 15 and 16.
+
+If the disclaimer of warranty and limitation of liability provided above cannot be given local legal effect according to their terms, reviewing courts shall apply local law that most closely approximates an absolute waiver of all civil liability in connection with the Program, unless a warranty or assumption of liability accompanies a copy of the Program in return for a fee.
 
                      END OF TERMS AND CONDITIONS
 
             How to Apply These Terms to Your New Programs
 
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
+If you develop a new program, and you want it to be of the greatest possible use to the public, the best way to achieve this is to make it free software which everyone can redistribute and change under these terms.
 
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
+To do so, attach the following notices to the program.  It is safest to attach them to the start of each source file to most effectively state the exclusion of warranty; and each file should have at least the "copyright" line and a pointer to where the full notice is found.
 
     <one line to give the program's name and a brief idea of what it does.>
     Copyright (C) <year>  <name of author>
 
     This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
+    it under the terms of the GNU Affero General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+    GNU Affero General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
+If your software can interact with users remotely through a computer network, you should also make sure that it provides a way for users to get its source.  For example, if your program is a web application, its interface could display a "Source" link that leads users to an archive of the code.  There are many ways you could offer source, and different solutions will be better for different programs; see section 13 for the specific requirements.
 
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+You should also get your employer (if you work as a programmer) or school, if any, to sign a "copyright disclaimer" for the program, if necessary. For more information on this, and how to apply and follow the GNU AGPL, see <http://www.gnu.org/licenses/>.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,17 @@
+ScoutMagic
+Copyright (C) 2026 Xavier Dubois
+
+Original author and maintainer: Xavier Dubois
+
+This product includes software developed as part of the ScoutMagic project
+(https://github.com/xdubois-57/scoutmagic).
+
+Contributors:
+  - Xavier Dubois <xdubois@gmail.com>
+  - Claude <noreply@anthropic.com>
+
+See LICENSE for the full license text, including additional terms under
+AGPL-3.0 section 7 regarding use of the "ScoutMagic" name.
+
+See README.md for a disclaimer regarding warranty, security and RGPD/GDPR
+responsibility for deployments of this software by third parties.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,32 @@
 
 Open-source website for Belgian scout units in the "Les Scouts" federation.
 
+## Auteur
+
+ScoutMagic est développé et maintenu par Xavier Dubois.
+
+Voir [NOTICE](NOTICE) pour la liste des contributeurs et
+[LICENSE](LICENSE) pour les conditions de licence, y compris les conditions
+additionnelles relatives à l'usage du nom « ScoutMagic ».
+
+## Avertissement
+
+ScoutMagic est un logiciel libre fourni sans garantie d'aucune sorte,
+conformément à la licence AGPL-3.0 (voir LICENSE, sections 15-16).
+
+Toute unité qui déploie ScoutMagic agit en tant que responsable de
+traitement au sens du RGPD pour les données qu'elle y héberge : c'est à
+elle qu'incombent l'évaluation de la conformité RGPD, la sécurisation de
+son hébergement, la tenue du registre de traitement et la notification en
+cas de violation de données. L'auteur et les contributeurs du projet ne
+sont ni responsables de traitement ni sous-traitants pour les instances
+déployées par des tiers, et n'ont aucun accès aux données qui y sont
+hébergées.
+
+Une faille de sécurité découverte dans le code doit être signalée via
+[SECURITY.md](SECURITY.md). Les corrections sont apportées sur une base
+volontaire, sans garantie de délai.
+
 ## Features
 
 - Member management from Desk CSV import
@@ -12,7 +38,7 @@ Open-source website for Belgian scout units in the "Les Scouts" federation.
 - Modular architecture for extensibility
 - Encrypted personal data at rest
 - DKIM-signed transactional emails
-- Cookie consent management (ePrivacy compliant)
+- Cookie consent management (banner and preferences aligned with ePrivacy requirements)
 - Automated schema migration
 - Task scheduler (cron + poor man's cron)
 - Audit journal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,22 @@
 
 This document defines the non-negotiable security requirements for the project. Every contribution must comply. The RBAC guard, encryption, and file access guard are the three pillars — none may be bypassed.
 
+## Reporting a vulnerability
+
+Report security vulnerabilities privately — not via public GitHub issues — by contacting the
+maintainer directly. Include enough detail to reproduce the issue. There is no guaranteed
+response time; this project is maintained on a volunteer basis, and fixes are made as time
+allows.
+
+## Avertissement
+
+Les exigences de ce document décrivent les pratiques de sécurité visées
+par le projet. Leur respect n'emporte aucune garantie de sécurité absolue,
+conformément à l'exclusion de garantie de la licence AGPL-3.0 (voir
+LICENSE). La sécurité effective d'un déploiement dépend aussi de facteurs
+hors du contrôle du projet : configuration de l'hébergement, mises à jour
+appliquées, mots de passe et clés gérés par l'unité déployante.
+
 ## 1. Database access
 
 - Prepared statements everywhere (PDO). **No SQL concatenation, ever.**

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,13 @@
     "name": "les-scouts/unit-website",
     "description": "Open-source website for Belgian scout units (Les Scouts federation)",
     "type": "project",
-    "license": "AGPL-3.0-only",
+    "license": "AGPL-3.0-or-later",
+    "authors": [
+        {
+            "name": "Xavier Dubois",
+            "role": "Author & Maintainer"
+        }
+    ],
     "require": {
         "php": "^8.4",
         "twig/twig": "^3.0",

--- a/core/Badge/Badge.php
+++ b/core/Badge/Badge.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Badge/BadgeException.php
+++ b/core/Badge/BadgeException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Badge/BadgeRepository.php
+++ b/core/Badge/BadgeRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Badge/BadgeService.php
+++ b/core/Badge/BadgeService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Badge/MemberBadgeRepository.php
+++ b/core/Badge/MemberBadgeRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Config/AppConfig.php
+++ b/core/Config/AppConfig.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Config/ScoutYearService.php
+++ b/core/Config/ScoutYearService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Config/SettingException.php
+++ b/core/Config/SettingException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Config/SettingRepository.php
+++ b/core/Config/SettingRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Config/SettingService.php
+++ b/core/Config/SettingService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Cookie/CookieConsentException.php
+++ b/core/Cookie/CookieConsentException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Cookie/CookieConsentService.php
+++ b/core/Cookie/CookieConsentService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Cookie/CookieHelper.php
+++ b/core/Cookie/CookieHelper.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Cookie/CookieRegistry.php
+++ b/core/Cookie/CookieRegistry.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/ColumnDefinition.php
+++ b/core/Database/ColumnDefinition.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/Connection.php
+++ b/core/Database/Connection.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/DatabaseDumper.php
+++ b/core/Database/DatabaseDumper.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/ForeignKeyDefinition.php
+++ b/core/Database/ForeignKeyDefinition.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/IndexDefinition.php
+++ b/core/Database/IndexDefinition.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/MigrationProgress.php
+++ b/core/Database/MigrationProgress.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/MigrationResult.php
+++ b/core/Database/MigrationResult.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/MigrationRunner.php
+++ b/core/Database/MigrationRunner.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/SchemaComparator.php
+++ b/core/Database/SchemaComparator.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/SchemaIntrospector.php
+++ b/core/Database/SchemaIntrospector.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/SqlParser.php
+++ b/core/Database/SqlParser.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Database/TableDefinition.php
+++ b/core/Database/TableDefinition.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Debug/RequestTimeline.php
+++ b/core/Debug/RequestTimeline.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/EncryptedFileStorageService.php
+++ b/core/File/EncryptedFileStorageService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/FileAccessGuard.php
+++ b/core/File/FileAccessGuard.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/FileOwnershipCheckerInterface.php
+++ b/core/File/FileOwnershipCheckerInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/FileRecord.php
+++ b/core/File/FileRecord.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/FileRepository.php
+++ b/core/File/FileRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/PdfRasterizer.php
+++ b/core/File/PdfRasterizer.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/PdfTextExtractor.php
+++ b/core/File/PdfTextExtractor.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/UploadException.php
+++ b/core/File/UploadException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/File/UploadHandler.php
+++ b/core/File/UploadHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/AbstractController.php
+++ b/core/Http/Controller/AbstractController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/AccountController.php
+++ b/core/Http/Controller/AccountController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/AuthController.php
+++ b/core/Http/Controller/AuthController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ConfigBadgesController.php
+++ b/core/Http/Controller/ConfigBadgesController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ConfigGeneralController.php
+++ b/core/Http/Controller/ConfigGeneralController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ConfigModeController.php
+++ b/core/Http/Controller/ConfigModeController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ConfigModulesController.php
+++ b/core/Http/Controller/ConfigModulesController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/CookieController.php
+++ b/core/Http/Controller/CookieController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/EditableContentController.php
+++ b/core/Http/Controller/EditableContentController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/FileController.php
+++ b/core/Http/Controller/FileController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/FunctionsController.php
+++ b/core/Http/Controller/FunctionsController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ImportController.php
+++ b/core/Http/Controller/ImportController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/JournalController.php
+++ b/core/Http/Controller/JournalController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/MaintenanceController.php
+++ b/core/Http/Controller/MaintenanceController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/MemberController.php
+++ b/core/Http/Controller/MemberController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/MemberEmailAddressController.php
+++ b/core/Http/Controller/MemberEmailAddressController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/NotificationConfigController.php
+++ b/core/Http/Controller/NotificationConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/NotificationController.php
+++ b/core/Http/Controller/NotificationController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/NotificationPreferenceController.php
+++ b/core/Http/Controller/NotificationPreferenceController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/OfflineController.php
+++ b/core/Http/Controller/OfflineController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/PageController.php
+++ b/core/Http/Controller/PageController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/PasswordResetController.php
+++ b/core/Http/Controller/PasswordResetController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/PlaceholderController.php
+++ b/core/Http/Controller/PlaceholderController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/PushSubscriptionController.php
+++ b/core/Http/Controller/PushSubscriptionController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/PwaController.php
+++ b/core/Http/Controller/PwaController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/RgpdConfigController.php
+++ b/core/Http/Controller/RgpdConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ScheduledActionsController.php
+++ b/core/Http/Controller/ScheduledActionsController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ScoutYearController.php
+++ b/core/Http/Controller/ScoutYearController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/SectionDocumentController.php
+++ b/core/Http/Controller/SectionDocumentController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/SettingsController.php
+++ b/core/Http/Controller/SettingsController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/SetupController.php
+++ b/core/Http/Controller/SetupController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/ShortUrlController.php
+++ b/core/Http/Controller/ShortUrlController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/StaffsController.php
+++ b/core/Http/Controller/StaffsController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/UploadController.php
+++ b/core/Http/Controller/UploadController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Controller/WebhookController.php
+++ b/core/Http/Controller/WebhookController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/FlashMessage.php
+++ b/core/Http/FlashMessage.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/FrontController.php
+++ b/core/Http/FrontController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Request.php
+++ b/core/Http/Request.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/ResolvedRoute.php
+++ b/core/Http/ResolvedRoute.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Response.php
+++ b/core/Http/Response.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Http/Router.php
+++ b/core/Http/Router.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/AgeBranchRepository.php
+++ b/core/Import/AgeBranchRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/DeskCsvParser.php
+++ b/core/Import/DeskCsvParser.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/DeskImportService.php
+++ b/core/Import/DeskImportService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/FeeCategoryRepository.php
+++ b/core/Import/FeeCategoryRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/FunctionRepository.php
+++ b/core/Import/FunctionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ImportException.php
+++ b/core/Import/ImportException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ImportJournalRepository.php
+++ b/core/Import/ImportJournalRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ImportResult.php
+++ b/core/Import/ImportResult.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ImportSectionRepository.php
+++ b/core/Import/ImportSectionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/MappingResolver.php
+++ b/core/Import/MappingResolver.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/MemberRepository.php
+++ b/core/Import/MemberRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/MemberYearRepository.php
+++ b/core/Import/MemberYearRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ParsedAddress.php
+++ b/core/Import/ParsedAddress.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ParsedFunction.php
+++ b/core/Import/ParsedFunction.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ParsedImport.php
+++ b/core/Import/ParsedImport.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Import/ParsedMember.php
+++ b/core/Import/ParsedMember.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Journal/JournalRepository.php
+++ b/core/Journal/JournalRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Journal/JournalService.php
+++ b/core/Journal/JournalService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Mail/DkimManager.php
+++ b/core/Mail/DkimManager.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Mail/DnsVerifier.php
+++ b/core/Mail/DnsVerifier.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Mail/MailException.php
+++ b/core/Mail/MailException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Mail/MailService.php
+++ b/core/Mail/MailService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Mail/MailServiceFactory.php
+++ b/core/Mail/MailServiceFactory.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Backup.php
+++ b/core/Maintenance/Backup.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/BackupException.php
+++ b/core/Maintenance/BackupException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/BackupRepository.php
+++ b/core/Maintenance/BackupRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/BackupService.php
+++ b/core/Maintenance/BackupService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/BackupServiceInterface.php
+++ b/core/Maintenance/BackupServiceInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/CommitInfo.php
+++ b/core/Maintenance/CommitInfo.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/GitHubReleaseClient.php
+++ b/core/Maintenance/GitHubReleaseClient.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/GitHubReleaseClientInterface.php
+++ b/core/Maintenance/GitHubReleaseClientInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/GitHubWebhookService.php
+++ b/core/Maintenance/GitHubWebhookService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/ReleaseInfo.php
+++ b/core/Maintenance/ReleaseInfo.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Task/AutoBackupHandler.php
+++ b/core/Maintenance/Task/AutoBackupHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Task/CheckStableUpdateHandler.php
+++ b/core/Maintenance/Task/CheckStableUpdateHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Task/CreateBackupHandler.php
+++ b/core/Maintenance/Task/CreateBackupHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Task/FullResetHandler.php
+++ b/core/Maintenance/Task/FullResetHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Task/InstallUpdateHandler.php
+++ b/core/Maintenance/Task/InstallUpdateHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Task/ResetSettingsHandler.php
+++ b/core/Maintenance/Task/ResetSettingsHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/Task/RestoreBackupHandler.php
+++ b/core/Maintenance/Task/RestoreBackupHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/UpdateException.php
+++ b/core/Maintenance/UpdateException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/UpdateHistory.php
+++ b/core/Maintenance/UpdateHistory.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/UpdateHistoryRepository.php
+++ b/core/Maintenance/UpdateHistoryRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Maintenance/VersionFile.php
+++ b/core/Maintenance/VersionFile.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/AddressNormalizer.php
+++ b/core/Member/AddressNormalizer.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/Controller/MemberSearchController.php
+++ b/core/Member/Controller/MemberSearchController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/DepartureRepository.php
+++ b/core/Member/DepartureRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/DepartureService.php
+++ b/core/Member/DepartureService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/DepartureStatus.php
+++ b/core/Member/DepartureStatus.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/EffectiveAge.php
+++ b/core/Member/EffectiveAge.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/EmailDomainValidator.php
+++ b/core/Member/EmailDomainValidator.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/FeeEstimate.php
+++ b/core/Member/FeeEstimate.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/FeeEstimationRepository.php
+++ b/core/Member/FeeEstimationRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/FeeEstimationService.php
+++ b/core/Member/FeeEstimationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/HouseholdFeeCategory.php
+++ b/core/Member/HouseholdFeeCategory.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberAddress.php
+++ b/core/Member/MemberAddress.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberDocument.php
+++ b/core/Member/MemberDocument.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberDocumentRepository.php
+++ b/core/Member/MemberDocumentRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberDocumentService.php
+++ b/core/Member/MemberDocumentService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberEmail.php
+++ b/core/Member/MemberEmail.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberEmailException.php
+++ b/core/Member/MemberEmailException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberEmailRepository.php
+++ b/core/Member/MemberEmailRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberEmailService.php
+++ b/core/Member/MemberEmailService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberFunctionInfo.php
+++ b/core/Member/MemberFunctionInfo.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberNotFoundException.php
+++ b/core/Member/MemberNotFoundException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberPageService.php
+++ b/core/Member/MemberPageService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberProfile.php
+++ b/core/Member/MemberProfile.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberSectionPeriod.php
+++ b/core/Member/MemberSectionPeriod.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberService.php
+++ b/core/Member/MemberService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/MemberYearService.php
+++ b/core/Member/MemberYearService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/Repository/MemberSearchRepository.php
+++ b/core/Member/Repository/MemberSearchRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionDocument.php
+++ b/core/Member/SectionDocument.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionDocumentException.php
+++ b/core/Member/SectionDocumentException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionDocumentOwnershipChecker.php
+++ b/core/Member/SectionDocumentOwnershipChecker.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionDocumentRepository.php
+++ b/core/Member/SectionDocumentRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionDocumentService.php
+++ b/core/Member/SectionDocumentService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionMembershipRepository.php
+++ b/core/Member/SectionMembershipRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionMembershipService.php
+++ b/core/Member/SectionMembershipService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionService.php
+++ b/core/Member/SectionService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/SectionStaffAuthorizationService.php
+++ b/core/Member/SectionStaffAuthorizationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/Service/MemberSearchResult.php
+++ b/core/Member/Service/MemberSearchResult.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/Service/MemberSearchService.php
+++ b/core/Member/Service/MemberSearchService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/Task/CompressSectionDocumentHandler.php
+++ b/core/Member/Task/CompressSectionDocumentHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Member/UnitStaffSectionService.php
+++ b/core/Member/UnitStaffSectionService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/EspaceAnimesEntryProvider.php
+++ b/core/Module/EspaceAnimesEntryProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/FunctionFlagsProvider.php
+++ b/core/Module/FunctionFlagsProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/HomeBannerProvider.php
+++ b/core/Module/HomeBannerProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/HomeNewsProvider.php
+++ b/core/Module/HomeNewsProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/ModuleException.php
+++ b/core/Module/ModuleException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/ModuleInfo.php
+++ b/core/Module/ModuleInfo.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/ModuleManager.php
+++ b/core/Module/ModuleManager.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/ModuleManifest.php
+++ b/core/Module/ModuleManifest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/ModuleRegistryRepository.php
+++ b/core/Module/ModuleRegistryRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/SectionResponsableProvider.php
+++ b/core/Module/SectionResponsableProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Module/StaffDirectoryProvider.php
+++ b/core/Module/StaffDirectoryProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/NotificationPreference.php
+++ b/core/Notification/NotificationPreference.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/NotificationPreferenceRepository.php
+++ b/core/Notification/NotificationPreferenceRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/NotificationRecord.php
+++ b/core/Notification/NotificationRecord.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/NotificationRegistry.php
+++ b/core/Notification/NotificationRegistry.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/NotificationRepository.php
+++ b/core/Notification/NotificationRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/NotificationService.php
+++ b/core/Notification/NotificationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/NotificationType.php
+++ b/core/Notification/NotificationType.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/PushSubscription.php
+++ b/core/Notification/PushSubscription.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/PushSubscriptionRepository.php
+++ b/core/Notification/PushSubscriptionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/Task/PurgeNotificationsHandler.php
+++ b/core/Notification/Task/PurgeNotificationsHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/Task/SendNotificationsHandler.php
+++ b/core/Notification/Task/SendNotificationsHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Notification/VapidKeyPairFactory.php
+++ b/core/Notification/VapidKeyPairFactory.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Offline/OfflineWhitelist.php
+++ b/core/Offline/OfflineWhitelist.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Pdf/PdfCompressor.php
+++ b/core/Pdf/PdfCompressor.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Pdf/PosterPdfService.php
+++ b/core/Pdf/PosterPdfService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/LandscapeImageProcessor.php
+++ b/core/Photo/LandscapeImageProcessor.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/MemberPhotoRepository.php
+++ b/core/Photo/MemberPhotoRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/MemberPhotoService.php
+++ b/core/Photo/MemberPhotoService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/SectionPhotoProcessor.php
+++ b/core/Photo/SectionPhotoProcessor.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/SectionPhotoRepository.php
+++ b/core/Photo/SectionPhotoRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/SectionPhotoService.php
+++ b/core/Photo/SectionPhotoService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/StaffThumbnailProcessor.php
+++ b/core/Photo/StaffThumbnailProcessor.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/UnitLogoProcessor.php
+++ b/core/Photo/UnitLogoProcessor.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Photo/UnitLogoService.php
+++ b/core/Photo/UnitLogoService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Scheduler/SchedulerRepository.php
+++ b/core/Scheduler/SchedulerRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Scheduler/SchedulerRunner.php
+++ b/core/Scheduler/SchedulerRunner.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Scheduler/SchedulerService.php
+++ b/core/Scheduler/SchedulerService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Scheduler/TaskContext.php
+++ b/core/Scheduler/TaskContext.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Scheduler/TaskHandlerInterface.php
+++ b/core/Scheduler/TaskHandlerInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/ScoutYear/EffectiveScoutYear.php
+++ b/core/ScoutYear/EffectiveScoutYear.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/ScoutYear/ScoutYearAdminService.php
+++ b/core/ScoutYear/ScoutYearAdminService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/ScoutYear/ScoutYearResolver.php
+++ b/core/ScoutYear/ScoutYearResolver.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/ScoutYear/ScoutYearSession.php
+++ b/core/ScoutYear/ScoutYearSession.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/ScoutYear/ScoutYearTransitionVetoedException.php
+++ b/core/ScoutYear/ScoutYearTransitionVetoedException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/AuthService.php
+++ b/core/Security/AuthService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/AuthSession.php
+++ b/core/Security/AuthSession.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/CsrfGuard.php
+++ b/core/Security/CsrfGuard.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/DecryptionException.php
+++ b/core/Security/DecryptionException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/EncryptionService.php
+++ b/core/Security/EncryptionService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/HtmlSanitizer.php
+++ b/core/Security/HtmlSanitizer.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/HumanCheck/HumanCheckChallenge.php
+++ b/core/Security/HumanCheck/HumanCheckChallenge.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/HumanCheck/HumanCheckRateLimitRepository.php
+++ b/core/Security/HumanCheck/HumanCheckRateLimitRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/HumanCheck/HumanCheckResult.php
+++ b/core/Security/HumanCheck/HumanCheckResult.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/HumanCheck/HumanCheckService.php
+++ b/core/Security/HumanCheck/HumanCheckService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/HumanCheck/Task/PurgeHumanCheckRateLimitsHandler.php
+++ b/core/Security/HumanCheck/Task/PurgeHumanCheckRateLimitsHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/LastLoginMethodCookie.php
+++ b/core/Security/LastLoginMethodCookie.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/LoginThrottler.php
+++ b/core/Security/LoginThrottler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/MagicLinkRecord.php
+++ b/core/Security/MagicLinkRecord.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/MagicLinkRepository.php
+++ b/core/Security/MagicLinkRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/MagicLinkResult.php
+++ b/core/Security/MagicLinkResult.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/PasswordAuthMethod.php
+++ b/core/Security/PasswordAuthMethod.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/PasswordPolicy.php
+++ b/core/Security/PasswordPolicy.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/PasswordResetRepository.php
+++ b/core/Security/PasswordResetRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/PasswordResetService.php
+++ b/core/Security/PasswordResetService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/PasswordResetToken.php
+++ b/core/Security/PasswordResetToken.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/RbacGuard.php
+++ b/core/Security/RbacGuard.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/Role.php
+++ b/core/Security/Role.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/RoleResolver.php
+++ b/core/Security/RoleResolver.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/SecretManager.php
+++ b/core/Security/SecretManager.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/SessionManager.php
+++ b/core/Security/SessionManager.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/SessionStore.php
+++ b/core/Security/SessionStore.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/UserAccount.php
+++ b/core/Security/UserAccount.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/UserAccountRepository.php
+++ b/core/Security/UserAccountRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/VerifiedMagicLink.php
+++ b/core/Security/VerifiedMagicLink.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/WebAuthnCredentialRepository.php
+++ b/core/Security/WebAuthnCredentialRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Security/WebAuthnService.php
+++ b/core/Security/WebAuthnService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Service/TextNormalizerService.php
+++ b/core/Service/TextNormalizerService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/System/ComposerAutoloadSync.php
+++ b/core/System/ComposerAutoloadSync.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/System/ExecutableLocator.php
+++ b/core/System/ExecutableLocator.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/System/ShellExecutor.php
+++ b/core/System/ShellExecutor.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Url/ShortUrl.php
+++ b/core/Url/ShortUrl.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Url/ShortUrlRepository.php
+++ b/core/Url/ShortUrlRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/Url/ShortUrlService.php
+++ b/core/Url/ShortUrlService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/ConfigurationMode.php
+++ b/core/View/ConfigurationMode.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/EditableContentRepository.php
+++ b/core/View/EditableContentRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/EditableContentService.php
+++ b/core/View/EditableContentService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/MenuBuilder.php
+++ b/core/View/MenuBuilder.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/MonthGrid/GridEvent.php
+++ b/core/View/MonthGrid/GridEvent.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/MonthGrid/MonthGridBuilder.php
+++ b/core/View/MonthGrid/MonthGridBuilder.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/RgpdContentService.php
+++ b/core/View/RgpdContentService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 
@@ -132,13 +136,45 @@ class RgpdContentService
         }
 
         try {
-            return $this->sanitizeHtmlOutput($content);
+            $sanitized = $this->sanitizeHtmlOutput($content);
         } catch (\RuntimeException $e) {
             // Log the raw LLM response to help diagnose the issue
             error_log('RGPD AI Generation Error: ' . $e->getMessage());
             error_log('Raw LLM Response (first 1000 chars): ' . substr($content, 0, 1000));
             throw $e;
         }
+
+        $unitName = $this->settingService->get('site_name') ?: 'Unité scoute';
+        if (!$this->hasClearControllerDesignation($sanitized, $unitName)) {
+            // The system prompt requires the deploying unit to be named as
+            // data controller (never ScoutMagic or its author) — see rule
+            // 6bis in buildSystemPrompt(). If that didn't happen, the text
+            // must not be silently auto-saved and published (see save flow
+            // in RgpdConfigController::generate()); surfacing this as an
+            // exception routes it through that controller's existing
+            // catch-all error handling instead.
+            throw new \RuntimeException(
+                "Le contenu généré ne désigne pas clairement « {$unitName} » comme responsable du traitement — il n'a pas été enregistré. Réessayez, ou complétez les instructions personnalisées pour préciser le nom de l'unité."
+            );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Simple post-generation sanity check: does the generated text actually
+     * name the deploying unit as data controller? Not a full legal review —
+     * just a guard against the model silently omitting or genericizing the
+     * one thing rule 6bis of buildSystemPrompt() requires.
+     */
+    private function hasClearControllerDesignation(string $content, string $unitName): bool
+    {
+        $plainText = strip_tags($content);
+        if ($unitName === '' || stripos($plainText, $unitName) === false) {
+            return false;
+        }
+
+        return stripos($plainText, 'responsable du traitement') !== false;
     }
 
     /**
@@ -260,6 +296,7 @@ RÈGLES CRITIQUES (ne JAMAIS déroger) :
 4bis. **Espace animés (page membre)** : Section 2.2 doit conserver explicitement : (a) que l'espace personnel d'un membre peut afficher des documents qui lui sont propres (documents privés, ex. future attestation fiscale), chiffrés au repos et accessibles uniquement aux comptes explicitement liés à ce membre — jamais à un chef ou administrateur non lié, même avec un rôle plus élevé ; (b) que le nom complet et l'adresse postale du chef désigné responsable d'une section sont affichés, sur la page de chaque membre de cette section, aux comptes qui lui sont liés (le membre, ses parents) — jamais publiquement ; (c) que le site conserve un historique des sections auxquelles chaque membre a appartenu au fil des années (utilisé uniquement pour déterminer l'accès aux documents de section ci-dessous) ; (d) que les responsables d'une section peuvent y déposer des documents (carnets de camp, feuilles d'activité, etc.), chiffrés au repos, consultables par tout membre ayant appartenu à cette section — y compris les années passées, même si la section a depuis été masquée — et que les PDF peuvent être compressés automatiquement en arrière-plan, entièrement sur le serveur, sans aucun envoi à un service externe ; (e) qu'un chef ou animateur peut marquer qu'un animé ne reviendra probablement pas l'année suivante, avec un motif optionnel chiffré au repos, jamais visible dans le journal d'audit, et propre à l'année scoute en cours (il ne se reporte jamais d'une année à l'autre) ; (f) qu'un index aveugle est calculé sur une forme normalisée non lisible de l'adresse postale, utilisé uniquement pour suggérer une catégorie de cotisation selon le nombre de personnes au même foyer — jamais pour afficher ou reconstituer l'adresse elle-même
 5. **Modules actifs uniquement** : Retirer les sections des modules INACTIFS (comparer avec liste modules actifs)
 6. **Personnalisation obligatoire** : Remplacer {$unitName} et {$contactEmail} partout. Ne JAMAIS laisser de placeholder générique
+6bis. **Responsable du traitement — jamais ScoutMagic** : Le responsable du traitement décrit en section 1.1 est TOUJOURS {$unitName} (l'unité qui déploie ce site), jamais « ScoutMagic », son auteur ou ses contributeurs. Le contenu de référence l'illustre déjà (« le chef d'unité de notre unité scoute ») : personnalise cette désignation avec {$unitName} sans jamais la remplacer par le nom du logiciel ou de son éditeur. Le logiciel ScoutMagic n'est mentionné, le cas échéant, qu'à titre d'outil technique utilisé par l'unité (section 1.5), jamais comme partie responsable d'un traitement de données. Cette règle n'admet aucune exception, y compris si les instructions de l'administrateur ne précisent rien à ce sujet.
 7. **Délai raisonnable bénévoles** : Section 1.1 doit mentionner "délai raisonnable" car organisation bénévole, visant 1 mois art. 12.3
 8. **Hébergeur générique** : NE PAS demander à l'admin de remplir. Écrire "La localisation dépend de l'hébergeur sélectionné. Pour toute question, contacter le responsable."
 9. **IA provider** : Utiliser les infos exactes du fournisseur actif ({$providerInfo}, {$modelsInfo}) avec localisation et privacy policy

--- a/core/View/SectionPickerHelper.php
+++ b/core/View/SectionPickerHelper.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/SectionRepository.php
+++ b/core/View/SectionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/TextNormalizerExtension.php
+++ b/core/View/TextNormalizerExtension.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/TwigFactory.php
+++ b/core/View/TwigFactory.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/core/View/templates/base.html.twig
+++ b/core/View/templates/base.html.twig
@@ -1,3 +1,7 @@
+{#
+ ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+#}
 <!DOCTYPE html>
 <html lang="fr">
 <head>

--- a/core/View/templates/email/base.html.twig
+++ b/core/View/templates/email/base.html.twig
@@ -1,3 +1,7 @@
+{#
+ ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+#}
 <!DOCTYPE html>
 <html lang="fr">
 <head>

--- a/core/View/templates/partials/breadcrumb_bar.html.twig
+++ b/core/View/templates/partials/breadcrumb_bar.html.twig
@@ -1,3 +1,7 @@
+{#
+ ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+#}
 {# Fil d'Ariane — always visible on mobile viewports (below the site's lg
    breakpoint, 992px), and on desktop only when the site runs as an
    installed PWA (display-mode: standalone). Visibility is 100% CSS (see

--- a/core/View/templates/partials/cookie_banner.html.twig
+++ b/core/View/templates/partials/cookie_banner.html.twig
@@ -1,3 +1,7 @@
+{#
+ ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+#}
 <div id="cookie-banner" class="fixed-bottom border-top bg-body shadow-lg" style="z-index:1050;">
     <div class="container py-3">
         <div class="row align-items-center g-3">

--- a/core/View/templates/partials/nav.html.twig
+++ b/core/View/templates/partials/nav.html.twig
@@ -1,3 +1,7 @@
+{#
+ ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+#}
 {# Mobile header bar — visible below lg #}
 <header class="d-lg-none d-flex align-items-center px-3 border-bottom bg-white" style="height:56px;">
     <button class="btn btn-link text-dark p-2 me-auto d-inline-flex align-items-center justify-content-center" type="button" data-bs-toggle="offcanvas" data-bs-target="#navOffcanvas" aria-label="Menu" style="min-width:44px;min-height:44px;">

--- a/modules/banner/src/Controller/BannerConfigController.php
+++ b/modules/banner/src/Controller/BannerConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/banner/src/Repository/Banner.php
+++ b/modules/banner/src/Repository/Banner.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/banner/src/Repository/BannerRepository.php
+++ b/modules/banner/src/Repository/BannerRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/banner/src/Service/BannerException.php
+++ b/modules/banner/src/Service/BannerException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/banner/src/Service/BannerService.php
+++ b/modules/banner/src/Service/BannerService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Api/CalendarEventLookupInterface.php
+++ b/modules/calendar/src/Api/CalendarEventLookupInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Api/EventSummary.php
+++ b/modules/calendar/src/Api/EventSummary.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Controller/CalendarChiefController.php
+++ b/modules/calendar/src/Controller/CalendarChiefController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Controller/CalendarConfigController.php
+++ b/modules/calendar/src/Controller/CalendarConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Controller/CalendarPublicController.php
+++ b/modules/calendar/src/Controller/CalendarPublicController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Repository/Calendar.php
+++ b/modules/calendar/src/Repository/Calendar.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Repository/CalendarEvent.php
+++ b/modules/calendar/src/Repository/CalendarEvent.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Repository/CalendarEventRepository.php
+++ b/modules/calendar/src/Repository/CalendarEventRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Repository/CalendarPersonalTokenRepository.php
+++ b/modules/calendar/src/Repository/CalendarPersonalTokenRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Repository/CalendarRepository.php
+++ b/modules/calendar/src/Repository/CalendarRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Repository/CalendarUnitFeedTokenRepository.php
+++ b/modules/calendar/src/Repository/CalendarUnitFeedTokenRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/CalendarEventService.php
+++ b/modules/calendar/src/Service/CalendarEventService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/CalendarException.php
+++ b/modules/calendar/src/Service/CalendarException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/CalendarNotificationService.php
+++ b/modules/calendar/src/Service/CalendarNotificationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/CalendarPickerService.php
+++ b/modules/calendar/src/Service/CalendarPickerService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/CalendarRetroAutoCreateService.php
+++ b/modules/calendar/src/Service/CalendarRetroAutoCreateService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/CalendarService.php
+++ b/modules/calendar/src/Service/CalendarService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/IcsBuilder.php
+++ b/modules/calendar/src/Service/IcsBuilder.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Service/PersonalFeedService.php
+++ b/modules/calendar/src/Service/PersonalFeedService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Task/AutoCreateRetroHandler.php
+++ b/modules/calendar/src/Task/AutoCreateRetroHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Task/EventReminderHandler.php
+++ b/modules/calendar/src/Task/EventReminderHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/calendar/src/Task/MultidayEventReminderHandler.php
+++ b/modules/calendar/src/Task/MultidayEventReminderHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Api/ExpectedReceivableInterface.php
+++ b/modules/finance/src/Api/ExpectedReceivableInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Api/FinanceAccountInterface.php
+++ b/modules/finance/src/Api/FinanceAccountInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Api/SepaQrCodeInterface.php
+++ b/modules/finance/src/Api/SepaQrCodeInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Api/StructuredCommunicationInterface.php
+++ b/modules/finance/src/Api/StructuredCommunicationInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ConfigAccountController.php
+++ b/modules/finance/src/Controller/ConfigAccountController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ConfigCategoryController.php
+++ b/modules/finance/src/Controller/ConfigCategoryController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ConfigController.php
+++ b/modules/finance/src/Controller/ConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ConfigDangerController.php
+++ b/modules/finance/src/Controller/ConfigDangerController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ConfigRuleController.php
+++ b/modules/finance/src/Controller/ConfigRuleController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/DashboardController.php
+++ b/modules/finance/src/Controller/DashboardController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ImportController.php
+++ b/modules/finance/src/Controller/ImportController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/MovementController.php
+++ b/modules/finance/src/Controller/MovementController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ReceiptController.php
+++ b/modules/finance/src/Controller/ReceiptController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Controller/ReceivablesController.php
+++ b/modules/finance/src/Controller/ReceivablesController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Parser/BankStatementParserFactory.php
+++ b/modules/finance/src/Parser/BankStatementParserFactory.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Parser/BankStatementParserInterface.php
+++ b/modules/finance/src/Parser/BankStatementParserInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Parser/BnpParser.php
+++ b/modules/finance/src/Parser/BnpParser.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Parser/StatementLine.php
+++ b/modules/finance/src/Parser/StatementLine.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/Account.php
+++ b/modules/finance/src/Repository/Account.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/AccountRepository.php
+++ b/modules/finance/src/Repository/AccountRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/AiCategorySuggestionRepository.php
+++ b/modules/finance/src/Repository/AiCategorySuggestionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/Attachment.php
+++ b/modules/finance/src/Repository/Attachment.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/AttachmentRepository.php
+++ b/modules/finance/src/Repository/AttachmentRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/BalanceCheckpoint.php
+++ b/modules/finance/src/Repository/BalanceCheckpoint.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/BalanceCheckpointRepository.php
+++ b/modules/finance/src/Repository/BalanceCheckpointRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/Category.php
+++ b/modules/finance/src/Repository/Category.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/CategoryRepository.php
+++ b/modules/finance/src/Repository/CategoryRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/CategoryRule.php
+++ b/modules/finance/src/Repository/CategoryRule.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/CategoryRuleRepository.php
+++ b/modules/finance/src/Repository/CategoryRuleRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/ExpectedReceivable.php
+++ b/modules/finance/src/Repository/ExpectedReceivable.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/ExpectedReceivableRepository.php
+++ b/modules/finance/src/Repository/ExpectedReceivableRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/FiscalYear.php
+++ b/modules/finance/src/Repository/FiscalYear.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/FiscalYearRepository.php
+++ b/modules/finance/src/Repository/FiscalYearRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/StatementImport.php
+++ b/modules/finance/src/Repository/StatementImport.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/StatementImportRepository.php
+++ b/modules/finance/src/Repository/StatementImportRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/Transaction.php
+++ b/modules/finance/src/Repository/Transaction.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/TransactionAttachmentRepository.php
+++ b/modules/finance/src/Repository/TransactionAttachmentRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Repository/TransactionRepository.php
+++ b/modules/finance/src/Repository/TransactionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/AccountTransferCategoryService.php
+++ b/modules/finance/src/Service/AccountTransferCategoryService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/AiCategorizationService.php
+++ b/modules/finance/src/Service/AiCategorizationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/BalanceService.php
+++ b/modules/finance/src/Service/BalanceService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/BulkCategorizationResult.php
+++ b/modules/finance/src/Service/BulkCategorizationResult.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/BulkCategorizationService.php
+++ b/modules/finance/src/Service/BulkCategorizationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/CategoryRuleEngine.php
+++ b/modules/finance/src/Service/CategoryRuleEngine.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/ExpectedReceivableService.php
+++ b/modules/finance/src/Service/ExpectedReceivableService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/FinanceAccountService.php
+++ b/modules/finance/src/Service/FinanceAccountService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/FinanceException.php
+++ b/modules/finance/src/Service/FinanceException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/FinanceService.php
+++ b/modules/finance/src/Service/FinanceService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/FirstReceiptResolver.php
+++ b/modules/finance/src/Service/FirstReceiptResolver.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/IbanNormalizer.php
+++ b/modules/finance/src/Service/IbanNormalizer.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/ImportResult.php
+++ b/modules/finance/src/Service/ImportResult.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/ImportService.php
+++ b/modules/finance/src/Service/ImportService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/MovementPresenter.php
+++ b/modules/finance/src/Service/MovementPresenter.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/ReceiptExtractionService.php
+++ b/modules/finance/src/Service/ReceiptExtractionService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/ReceiptMatchingService.php
+++ b/modules/finance/src/Service/ReceiptMatchingService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/ReceiptService.php
+++ b/modules/finance/src/Service/ReceiptService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/ReceivablesOverviewService.php
+++ b/modules/finance/src/Service/ReceivablesOverviewService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/SepaQrCodeService.php
+++ b/modules/finance/src/Service/SepaQrCodeService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Service/StructuredCommunicationService.php
+++ b/modules/finance/src/Service/StructuredCommunicationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Task/ExtractReceiptDataHandler.php
+++ b/modules/finance/src/Task/ExtractReceiptDataHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Task/PurgeOldMovementsHandler.php
+++ b/modules/finance/src/Task/PurgeOldMovementsHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/finance/src/Task/RunCategorizationRulesHandler.php
+++ b/modules/finance/src/Task/RunCategorizationRulesHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Api/GalleryAlbumProvider.php
+++ b/modules/gallery/src/Api/GalleryAlbumProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Controller/GalleryChiefController.php
+++ b/modules/gallery/src/Controller/GalleryChiefController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Controller/GalleryConfigController.php
+++ b/modules/gallery/src/Controller/GalleryConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Controller/GalleryController.php
+++ b/modules/gallery/src/Controller/GalleryController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Controller/GalleryStorageLocationController.php
+++ b/modules/gallery/src/Controller/GalleryStorageLocationController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Repository/Album.php
+++ b/modules/gallery/src/Repository/Album.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Repository/AlbumRepository.php
+++ b/modules/gallery/src/Repository/AlbumRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Repository/Media.php
+++ b/modules/gallery/src/Repository/Media.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Repository/MediaRepository.php
+++ b/modules/gallery/src/Repository/MediaRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Repository/S3SecretRepository.php
+++ b/modules/gallery/src/Repository/S3SecretRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Repository/StorageLocation.php
+++ b/modules/gallery/src/Repository/StorageLocation.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Repository/StorageLocationRepository.php
+++ b/modules/gallery/src/Repository/StorageLocationRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/AlbumService.php
+++ b/modules/gallery/src/Service/AlbumService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/FfmpegAvailability.php
+++ b/modules/gallery/src/Service/FfmpegAvailability.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/GalleryAccessService.php
+++ b/modules/gallery/src/Service/GalleryAccessService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/GalleryException.php
+++ b/modules/gallery/src/Service/GalleryException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/GalleryMemberQueryService.php
+++ b/modules/gallery/src/Service/GalleryMemberQueryService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/ImageProcessingService.php
+++ b/modules/gallery/src/Service/ImageProcessingService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/MediaService.php
+++ b/modules/gallery/src/Service/MediaService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/OgScraperService.php
+++ b/modules/gallery/src/Service/OgScraperService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/S3ErrorExplainerService.php
+++ b/modules/gallery/src/Service/S3ErrorExplainerService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/Storage/LocalStorageBackend.php
+++ b/modules/gallery/src/Service/Storage/LocalStorageBackend.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/Storage/S3StorageBackend.php
+++ b/modules/gallery/src/Service/Storage/S3StorageBackend.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/Storage/StorageBackendFactory.php
+++ b/modules/gallery/src/Service/Storage/StorageBackendFactory.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/Storage/StorageBackendInterface.php
+++ b/modules/gallery/src/Service/Storage/StorageBackendInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/StorageLocationService.php
+++ b/modules/gallery/src/Service/StorageLocationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Service/VideoProcessingService.php
+++ b/modules/gallery/src/Service/VideoProcessingService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Task/MigrateAlbumStorageHandler.php
+++ b/modules/gallery/src/Task/MigrateAlbumStorageHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Task/ProcessPhotoHandler.php
+++ b/modules/gallery/src/Task/ProcessPhotoHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/gallery/src/Task/ProcessVideoHandler.php
+++ b/modules/gallery/src/Task/ProcessVideoHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Api/LlmConnectorInterface.php
+++ b/modules/llm_connector/src/Api/LlmConnectorInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Api/LlmException.php
+++ b/modules/llm_connector/src/Api/LlmException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Api/LlmRequest.php
+++ b/modules/llm_connector/src/Api/LlmRequest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Api/LlmResponse.php
+++ b/modules/llm_connector/src/Api/LlmResponse.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Api/LlmTier.php
+++ b/modules/llm_connector/src/Api/LlmTier.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Controller/ConfigController.php
+++ b/modules/llm_connector/src/Controller/ConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Provider/AnthropicProvider.php
+++ b/modules/llm_connector/src/Provider/AnthropicProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Provider/LlmProviderInterface.php
+++ b/modules/llm_connector/src/Provider/LlmProviderInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Provider/MistralProvider.php
+++ b/modules/llm_connector/src/Provider/MistralProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Provider/ProviderResponse.php
+++ b/modules/llm_connector/src/Provider/ProviderResponse.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Provider/ScalewayProvider.php
+++ b/modules/llm_connector/src/Provider/ScalewayProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Repository/ProviderModelRepository.php
+++ b/modules/llm_connector/src/Repository/ProviderModelRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Repository/ProviderRepository.php
+++ b/modules/llm_connector/src/Repository/ProviderRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Service/LlmConnectorService.php
+++ b/modules/llm_connector/src/Service/LlmConnectorService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Service/OcrModelSelector.php
+++ b/modules/llm_connector/src/Service/OcrModelSelector.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/llm_connector/src/Task/RefreshModelsHandler.php
+++ b/modules/llm_connector/src/Task/RefreshModelsHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Api/MassMailQueryInterface.php
+++ b/modules/mass_mail/src/Api/MassMailQueryInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Controller/ConfigController.php
+++ b/modules/mass_mail/src/Controller/ConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Controller/MassMailController.php
+++ b/modules/mass_mail/src/Controller/MassMailController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Controller/MemberEmailController.php
+++ b/modules/mass_mail/src/Controller/MemberEmailController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Controller/UnsubscribeController.php
+++ b/modules/mass_mail/src/Controller/UnsubscribeController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/Email.php
+++ b/modules/mass_mail/src/Repository/Email.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/EmailAttachment.php
+++ b/modules/mass_mail/src/Repository/EmailAttachment.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/EmailAttachmentRepository.php
+++ b/modules/mass_mail/src/Repository/EmailAttachmentRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/EmailRepository.php
+++ b/modules/mass_mail/src/Repository/EmailRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/MailingList.php
+++ b/modules/mass_mail/src/Repository/MailingList.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/MailingListRepository.php
+++ b/modules/mass_mail/src/Repository/MailingListRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/MemberResolutionRepository.php
+++ b/modules/mass_mail/src/Repository/MemberResolutionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/Recipient.php
+++ b/modules/mass_mail/src/Repository/Recipient.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Repository/RecipientRepository.php
+++ b/modules/mass_mail/src/Repository/RecipientRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Service/MailingListException.php
+++ b/modules/mass_mail/src/Service/MailingListException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Service/MailingListService.php
+++ b/modules/mass_mail/src/Service/MailingListService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Service/MassMailAccessService.php
+++ b/modules/mass_mail/src/Service/MassMailAccessService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Service/MassMailException.php
+++ b/modules/mass_mail/src/Service/MassMailException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Service/MassMailQueryService.php
+++ b/modules/mass_mail/src/Service/MassMailQueryService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Service/MassMailService.php
+++ b/modules/mass_mail/src/Service/MassMailService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Service/SenderAuthorization.php
+++ b/modules/mass_mail/src/Service/SenderAuthorization.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/mass_mail/src/Task/SendBatchHandler.php
+++ b/modules/mass_mail/src/Task/SendBatchHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/member_stats/src/Controller/MemberStatsController.php
+++ b/modules/member_stats/src/Controller/MemberStatsController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/member_stats/src/Repository/MemberStatsRepository.php
+++ b/modules/member_stats/src/Repository/MemberStatsRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/member_stats/src/Service/MemberStatsService.php
+++ b/modules/member_stats/src/Service/MemberStatsService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Controller/FormController.php
+++ b/modules/news/src/Controller/FormController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Controller/NewsController.php
+++ b/modules/news/src/Controller/NewsController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/Article.php
+++ b/modules/news/src/Repository/Article.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/ArticleRepository.php
+++ b/modules/news/src/Repository/ArticleRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/FormField.php
+++ b/modules/news/src/Repository/FormField.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/FormFieldRepository.php
+++ b/modules/news/src/Repository/FormFieldRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/FormRepository.php
+++ b/modules/news/src/Repository/FormRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/FormResponse.php
+++ b/modules/news/src/Repository/FormResponse.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/FormResponseRepository.php
+++ b/modules/news/src/Repository/FormResponseRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Repository/NewsForm.php
+++ b/modules/news/src/Repository/NewsForm.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Service/ArticleService.php
+++ b/modules/news/src/Service/ArticleService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Service/DigestService.php
+++ b/modules/news/src/Service/DigestService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Service/FormService.php
+++ b/modules/news/src/Service/FormService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Service/NewsException.php
+++ b/modules/news/src/Service/NewsException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Service/ResponseService.php
+++ b/modules/news/src/Service/ResponseService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Service/SeoKeywordService.php
+++ b/modules/news/src/Service/SeoKeywordService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/news/src/Task/SendResponseDigestHandler.php
+++ b/modules/news/src/Task/SendResponseDigestHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Api/ExternalMailingListProvider.php
+++ b/modules/registration/src/Api/ExternalMailingListProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Api/HouseholdRegistrationCountProvider.php
+++ b/modules/registration/src/Api/HouseholdRegistrationCountProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Api/ReconciliationTrigger.php
+++ b/modules/registration/src/Api/ReconciliationTrigger.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Api/ScoutYearTransitionVetoProvider.php
+++ b/modules/registration/src/Api/ScoutYearTransitionVetoProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Controller/DeparturesController.php
+++ b/modules/registration/src/Controller/DeparturesController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Controller/ForecastController.php
+++ b/modules/registration/src/Controller/ForecastController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Controller/PassageController.php
+++ b/modules/registration/src/Controller/PassageController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Controller/PublicRegistrationController.php
+++ b/modules/registration/src/Controller/PublicRegistrationController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Controller/RegistrationConfigController.php
+++ b/modules/registration/src/Controller/RegistrationConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Controller/RegistrationRequestController.php
+++ b/modules/registration/src/Controller/RegistrationRequestController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Controller/TrackingController.php
+++ b/modules/registration/src/Controller/TrackingController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/AgeBracket.php
+++ b/modules/registration/src/Repository/AgeBracket.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/AgeBracketRepository.php
+++ b/modules/registration/src/Repository/AgeBracketRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/RegistrationRequest.php
+++ b/modules/registration/src/Repository/RegistrationRequest.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/RegistrationRequestRepository.php
+++ b/modules/registration/src/Repository/RegistrationRequestRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/RegistrationSecondaryEmail.php
+++ b/modules/registration/src/Repository/RegistrationSecondaryEmail.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/RegistrationSecondaryEmailRepository.php
+++ b/modules/registration/src/Repository/RegistrationSecondaryEmailRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/RegistrationYearCode.php
+++ b/modules/registration/src/Repository/RegistrationYearCode.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/RegistrationYearCodeRepository.php
+++ b/modules/registration/src/Repository/RegistrationYearCodeRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/SectionTransferRepository.php
+++ b/modules/registration/src/Repository/SectionTransferRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Repository/SlotCapacityRepository.php
+++ b/modules/registration/src/Repository/SlotCapacityRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/ExternalMailingListService.php
+++ b/modules/registration/src/Service/ExternalMailingListService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/ForecastService.php
+++ b/modules/registration/src/Service/ForecastService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/HouseholdRegistrationCountService.php
+++ b/modules/registration/src/Service/HouseholdRegistrationCountService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/MigrationService.php
+++ b/modules/registration/src/Service/MigrationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/PassageService.php
+++ b/modules/registration/src/Service/PassageService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/ReconciliationService.php
+++ b/modules/registration/src/Service/ReconciliationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/RegistrationException.php
+++ b/modules/registration/src/Service/RegistrationException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/RegistrationMenuHookService.php
+++ b/modules/registration/src/Service/RegistrationMenuHookService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/RegistrationService.php
+++ b/modules/registration/src/Service/RegistrationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/RequestEmailService.php
+++ b/modules/registration/src/Service/RequestEmailService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/RequestStatusService.php
+++ b/modules/registration/src/Service/RequestStatusService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/ScoutYearTransitionVetoService.php
+++ b/modules/registration/src/Service/ScoutYearTransitionVetoService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/SecondaryEmailService.php
+++ b/modules/registration/src/Service/SecondaryEmailService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/SlotMath.php
+++ b/modules/registration/src/Service/SlotMath.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/SlotService.php
+++ b/modules/registration/src/Service/SlotService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Service/TrackingService.php
+++ b/modules/registration/src/Service/TrackingService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Task/CloseRegistrationHandler.php
+++ b/modules/registration/src/Task/CloseRegistrationHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Task/OpenRegistrationHandler.php
+++ b/modules/registration/src/Task/OpenRegistrationHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/registration/src/Task/PurgeRegistrationRequestsHandler.php
+++ b/modules/registration/src/Task/PurgeRegistrationRequestsHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Api/RetroEventLinkLookupInterface.php
+++ b/modules/retro/src/Api/RetroEventLinkLookupInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Api/RetroLinkSummary.php
+++ b/modules/retro/src/Api/RetroLinkSummary.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Controller/RetroBoardController.php
+++ b/modules/retro/src/Controller/RetroBoardController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Controller/RetroChiefController.php
+++ b/modules/retro/src/Controller/RetroChiefController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Controller/RetroConfigController.php
+++ b/modules/retro/src/Controller/RetroConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Repository/Board.php
+++ b/modules/retro/src/Repository/Board.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Repository/BoardRepository.php
+++ b/modules/retro/src/Repository/BoardRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Repository/Comment.php
+++ b/modules/retro/src/Repository/Comment.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Repository/CommentRepository.php
+++ b/modules/retro/src/Repository/CommentRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Repository/RateLimitRepository.php
+++ b/modules/retro/src/Repository/RateLimitRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Repository/Vote.php
+++ b/modules/retro/src/Repository/Vote.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Repository/VoteRepository.php
+++ b/modules/retro/src/Repository/VoteRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Service/BoardService.php
+++ b/modules/retro/src/Service/BoardService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Service/CommentService.php
+++ b/modules/retro/src/Service/CommentService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Service/ModerationService.php
+++ b/modules/retro/src/Service/ModerationService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Service/RateLimitService.php
+++ b/modules/retro/src/Service/RateLimitService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Service/RetroException.php
+++ b/modules/retro/src/Service/RetroException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Service/SummaryService.php
+++ b/modules/retro/src/Service/SummaryService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Service/VoteService.php
+++ b/modules/retro/src/Service/VoteService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Task/AutoCloseHandler.php
+++ b/modules/retro/src/Task/AutoCloseHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/retro/src/Task/PurgeRateLimitHandler.php
+++ b/modules/retro/src/Task/PurgeRateLimitHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Controller/SosAdminController.php
+++ b/modules/sos_staff/src/Controller/SosAdminController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Controller/SosConfigController.php
+++ b/modules/sos_staff/src/Controller/SosConfigController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Provider/ForwardingState.php
+++ b/modules/sos_staff/src/Provider/ForwardingState.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Provider/Ovh/OvhApiClient.php
+++ b/modules/sos_staff/src/Provider/Ovh/OvhApiClient.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Provider/Ovh/OvhApiException.php
+++ b/modules/sos_staff/src/Provider/Ovh/OvhApiException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Provider/Ovh/OvhTelephonyProvider.php
+++ b/modules/sos_staff/src/Provider/Ovh/OvhTelephonyProvider.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Provider/PhoneLine.php
+++ b/modules/sos_staff/src/Provider/PhoneLine.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Provider/PhoneProviderInterface.php
+++ b/modules/sos_staff/src/Provider/PhoneProviderInterface.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Provider/ProviderException.php
+++ b/modules/sos_staff/src/Provider/ProviderException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/CalendarSyncEntry.php
+++ b/modules/sos_staff/src/Repository/CalendarSyncEntry.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/CalendarSyncRepository.php
+++ b/modules/sos_staff/src/Repository/CalendarSyncRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/ExcludedSectionRepository.php
+++ b/modules/sos_staff/src/Repository/ExcludedSectionRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/OnCallAssignment.php
+++ b/modules/sos_staff/src/Repository/OnCallAssignment.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/OnCallRepository.php
+++ b/modules/sos_staff/src/Repository/OnCallRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/ProviderCredential.php
+++ b/modules/sos_staff/src/Repository/ProviderCredential.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/ProviderCredentialRepository.php
+++ b/modules/sos_staff/src/Repository/ProviderCredentialRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Repository/SosSettingsRepository.php
+++ b/modules/sos_staff/src/Repository/SosSettingsRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Service/CalendarSyncService.php
+++ b/modules/sos_staff/src/Service/CalendarSyncService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Service/OnCallService.php
+++ b/modules/sos_staff/src/Service/OnCallService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Service/ProviderConfigService.php
+++ b/modules/sos_staff/src/Service/ProviderConfigService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Service/RedirectService.php
+++ b/modules/sos_staff/src/Service/RedirectService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Service/SosException.php
+++ b/modules/sos_staff/src/Service/SosException.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Service/SosSettingsService.php
+++ b/modules/sos_staff/src/Service/SosSettingsService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/sos_staff/src/Task/ApplyRedirectHandler.php
+++ b/modules/sos_staff/src/Task/ApplyRedirectHandler.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/trombinoscope/src/Controller/TrombinoscopeController.php
+++ b/modules/trombinoscope/src/Controller/TrombinoscopeController.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/trombinoscope/src/Repository/FunctionFlagsRepository.php
+++ b/modules/trombinoscope/src/Repository/FunctionFlagsRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/trombinoscope/src/Repository/TrombinoscopeRepository.php
+++ b/modules/trombinoscope/src/Repository/TrombinoscopeRepository.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/trombinoscope/src/Service/FunctionFlagsService.php
+++ b/modules/trombinoscope/src/Service/FunctionFlagsService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/modules/trombinoscope/src/Service/TrombinoscopeService.php
+++ b/modules/trombinoscope/src/Service/TrombinoscopeService.php
@@ -1,4 +1,8 @@
 <?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
 
 declare(strict_types=1);
 

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 :root {
     --page-max-width: 1200px;
     --page-narrow-width: 560px;

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 /* Core member_photo() component (see Core\Photo, TwigFactory::create()).
    3:4 portrait format, same size wherever it's used (e.g. every photo on the
    trombinoscope, including the highlighted "responsable" card). */

--- a/public/assets/css/editable.css
+++ b/public/assets/css/editable.css
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 .editable-content,
 .editable-image {
     position: relative;

--- a/public/assets/js/auth.js
+++ b/public/assets/js/auth.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 (function() {
     // --- Tab switching ---
     var tabs = document.querySelectorAll('[data-tab]');

--- a/public/assets/js/breadcrumb.js
+++ b/public/assets/js/breadcrumb.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // partials/breadcrumb_bar.html.twig — a breadcrumb parent (e.g. "Espace
 // animés") never links to a specific page anymore: clicking it OPENS that
 // menu's section so the visitor picks the sub-page themselves, rather than

--- a/public/assets/js/chip-picker.js
+++ b/public/assets/js/chip-picker.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Generic chip picker — see core/View/templates/partials/chip_picker.html.twig.
 // Knows nothing about what an item "is"; owns two things only:
 //

--- a/public/assets/js/cookie-consent.js
+++ b/public/assets/js/cookie-consent.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 document.addEventListener('DOMContentLoaded', function () {
     var banner = document.getElementById('cookie-banner');
     if (!banner) return;

--- a/public/assets/js/editable.js
+++ b/public/assets/js/editable.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 (function () {
     // Image upload — navigate to upload page. data-context lets other core
     // components (e.g. member_photo()) reuse this same overlay/click wiring

--- a/public/assets/js/gallery-storage-location.js
+++ b/public/assets/js/gallery-storage-location.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Gallery module superadmin storage-location pages: the locations table on
 // config.html.twig (test/delete buttons), the album storage-migration table
 // on the same page, and the add/edit location form (location_form.html.twig:

--- a/public/assets/js/gallery.js
+++ b/public/assets/js/gallery.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Gallery module front-end: lightbox/player (album.html.twig), drag-and-drop
 // batch upload + media reorder/delete/cover (album_form.html.twig). Pure JS,
 // no external library — same IIFE/var/fetch style as list-editor.js.

--- a/public/assets/js/list-editor.js
+++ b/public/assets/js/list-editor.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Generic reusable list editor — see
 // core/View/templates/partials/list_editor.html.twig. Knows nothing about
 // what an item "is"; only handles the list chrome: native HTML5

--- a/public/assets/js/maintenance.js
+++ b/public/assets/js/maintenance.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Configuration > Maintenance — "Sauvegarde automatique" frequency select:
 // auto-saves on change (same pattern as the banner module's per-item
 // visibility select's JS).

--- a/public/assets/js/nav.js
+++ b/public/assets/js/nav.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 (function () {
     var buttons = document.querySelectorAll('.desktop-menu-btn');
     var submenus = document.querySelectorAll('.desktop-submenu');

--- a/public/assets/js/news-form-builder.js
+++ b/public/assets/js/news-form-builder.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // News module: article editor rich-text toolbar, visibility/SEO toggles,
 // the interactive form builder (field list add/edit/reorder/delete), and
 // the live payment total on the public submission form. One file since

--- a/public/assets/js/notification-badge.js
+++ b/public/assets/js/notification-badge.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Avatar notification badge (Core\Notification, Lot 2) — the count is
 // server-rendered on page load (nav.html.twig), refreshed every 60s (same
 // setInterval pattern as the backup-status/magic-link polls) and, when a

--- a/public/assets/js/notification-preferences.js
+++ b/public/assets/js/notification-preferences.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Notification preferences page (Core\Notification, Lot 2) — auto-saves
 // every toggle individually on change (no "Enregistrer" button). The Push
 // column is gated on Notification.permission rather than requesting it

--- a/public/assets/js/offline-cache.js
+++ b/public/assets/js/offline-cache.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Offline content caching (Lot 3) — hands the server-declared whitelist
 // (Core\Offline\OfflineWhitelist), the staleness setting, and the current
 // functional-consent/account-scope state to the service worker on every

--- a/public/assets/js/offline-nav.js
+++ b/public/assets/js/offline-nav.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Offline navigation (Lot 3) — while offline, a link to a page outside
 // the offline whitelist is greyed out and inert rather than leading to a
 // dead end. The generic offline page (Lot 1) remains the safety net for

--- a/public/assets/js/offline-photos.js
+++ b/public/assets/js/offline-photos.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Offline trombinoscope photo pre-download (Lot 3) — every section's
 // staff faces, not just the viewer's own, so the trombinoscope shows
 // faces and not initials while offline. Fires once, on the first launch

--- a/public/assets/js/password-complexity.js
+++ b/public/assets/js/password-complexity.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Shared live password complexity checklist — mirrors Core\Security\
 // PasswordPolicy exactly (5 rules, ≥12 chars). Reused by the password-reset
 // page and the account page's change-password box.

--- a/public/assets/js/push-notifications.js
+++ b/public/assets/js/push-notifications.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // "Mon compte" push notification toggle (Core\Notification, Iteration 1).
 // The toggle always reflects THIS device's actual subscription state
 // (checked via PushManager.getSubscription() on load), never a stored

--- a/public/assets/js/retro-board.js
+++ b/public/assets/js/retro-board.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Retro module public board (retro/board.html.twig): polling, comment
 // submission with AI-shorten, vote controls, hide/unhide, QR toggle, copy
 // link. Pure JS, no external library — same IIFE/var/fetch style as

--- a/public/assets/js/retro-config.js
+++ b/public/assets/js/retro-config.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Retro module chief-facing create/edit form (retro/config.html.twig):
 // vote-mode toggle, event-picker date sync, max-length slider live value.
 // Pure JS, no external library — same IIFE/var style as gallery-config.js.

--- a/public/assets/js/rich-text-field.js
+++ b/public/assets/js/rich-text-field.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 // Generic reusable "rich text field" wiring — see
 // core/View/templates/partials/rich_text_field.html.twig and
 // partials/rich_text_edit_button.html.twig. Reuses the same shared

--- a/public/assets/js/settings.js
+++ b/public/assets/js/settings.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 document.addEventListener('DOMContentLoaded', function() {
     var modal = new bootstrap.Modal(document.getElementById('settingEditModal'));
     var currentModuleId = null;

--- a/public/assets/js/setup.js
+++ b/public/assets/js/setup.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 (function() {
     var form = document.getElementById('setup-form');
     var mailMode = document.getElementById('mail_mode');

--- a/public/assets/js/unit-logo-notify-ios.js
+++ b/public/assets/js/unit-logo-notify-ios.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 document.addEventListener('DOMContentLoaded', function() {
     var notifyBtn = document.getElementById('unit-logo-notify-ios-btn');
     if (!notifyBtn) {

--- a/public/assets/js/unit-logo.js
+++ b/public/assets/js/unit-logo.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 document.addEventListener('DOMContentLoaded', function() {
     var deleteBtn = document.getElementById('unit-logo-delete-btn');
     if (!deleteBtn) {

--- a/public/assets/js/upload.js
+++ b/public/assets/js/upload.js
@@ -1,3 +1,8 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
 (function () {
     var dropZone = document.getElementById('drop-zone');
     var fileInput = document.getElementById('file-input');

--- a/tests/Core/View/RgpdContentServiceTest.php
+++ b/tests/Core/View/RgpdContentServiceTest.php
@@ -32,7 +32,7 @@ class RgpdContentServiceTest extends TestCase
         $llmConnector->method('isAvailable')->willReturn(true);
         $llmConnector->expects($this->once())->method('complete')
             ->with($this->callback(fn(LlmRequest $request) => $request->maxTokens === 8192))
-            ->willReturn(new LlmResponse(content: '<h2>Titre</h2><p>Contenu</p>', parsed: null, inputTokens: 10, outputTokens: 20, truncated: false));
+            ->willReturn(new LlmResponse(content: '<h2>Titre</h2><p>Contenu. Unité scoute est responsable du traitement.</p>', parsed: null, inputTokens: 10, outputTokens: 20, truncated: false));
 
         $service = new RgpdContentService($this->moduleManager, $this->settingService, $llmConnector);
 
@@ -48,7 +48,7 @@ class RgpdContentServiceTest extends TestCase
         $llmConnector->expects($this->exactly(2))->method('complete')
             ->willReturnOnConsecutiveCalls(
                 new LlmResponse(content: '<h2>Titre</h2><p>Début du contenu', parsed: null, inputTokens: 10, outputTokens: 8192, truncated: true),
-                new LlmResponse(content: ' et fin du contenu.</p>', parsed: null, inputTokens: 10, outputTokens: 50, truncated: false)
+                new LlmResponse(content: ' et fin du contenu. Unité scoute est responsable du traitement.</p>', parsed: null, inputTokens: 10, outputTokens: 50, truncated: false)
             );
 
         $service = new RgpdContentService($this->moduleManager, $this->settingService, $llmConnector);
@@ -70,7 +70,7 @@ class RgpdContentServiceTest extends TestCase
                     return new LlmResponse(content: '<h2>Titre</h2><p>Début du contenu', parsed: null, inputTokens: 10, outputTokens: 8192, truncated: true);
                 }
                 $capturedContinuationRequest = $request;
-                return new LlmResponse(content: ' et fin.</p>', parsed: null, inputTokens: 10, outputTokens: 50, truncated: false);
+                return new LlmResponse(content: ' et fin. Unité scoute est responsable du traitement.</p>', parsed: null, inputTokens: 10, outputTokens: 50, truncated: false);
             });
 
         $service = new RgpdContentService($this->moduleManager, $this->settingService, $llmConnector);
@@ -102,6 +102,26 @@ class RgpdContentServiceTest extends TestCase
         $service = new RgpdContentService($this->moduleManager, $this->settingService, null);
 
         $this->expectException(\RuntimeException::class);
+        $service->generateWithAi('Instructions');
+    }
+
+    public function testGenerateWithAiThrowsAndDoesNotReturnContentWhenNoControllerIsDesignated(): void
+    {
+        $settingService = $this->createMock(SettingService::class);
+        $settingService->method('get')->willReturnCallback(
+            fn(string $key) => $key === 'site_name' ? 'Unité Test' : ''
+        );
+
+        $llmConnector = $this->createMock(LlmConnectorInterface::class);
+        $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('complete')->willReturn(
+            new LlmResponse(content: '<h2>Titre</h2><p>Le site traite vos données.</p>', parsed: null, inputTokens: 10, outputTokens: 20, truncated: false)
+        );
+
+        $service = new RgpdContentService($this->moduleManager, $settingService, $llmConnector);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessageMatches('/responsable du traitement/');
         $service->generateWithAi('Instructions');
     }
 }


### PR DESCRIPTION
## Description

Documentary/legal lot — no application behavior changes beyond one new guard described below.

- Replace `LICENSE` with the actual AGPL-3.0-or-later text (it previously contained plain GPL-3.0 — section 13 was the GPL's "Use with the GNU Affero General Public License" clause, not the AGPL's own section 13). Verified word-for-word against the official text; prefixed with a copyright notice (Copyright (C) 2026 Xavier Dubois and contributors — year and holder confirmed with Xavier) and an additional permission under AGPL §7(c) restricting use of the "ScoutMagic" name on modified/redistributed versions.
- Add `NOTICE` at the repo root with author/contributor attribution (contributors generated from `git shortlog -sne`) and a pointer to the README disclaimer.
- Add a short copyright header to every application PHP/JS/CSS file under `core/`, `modules/`, and `public/assets/` (excluding `vendor/`), plus the structural Twig templates (`base.html.twig`, `email/base.html.twig`, `partials/nav.html.twig`, `partials/breadcrumb_bar.html.twig`, `partials/cookie_banner.html.twig`) — not the ~140 smaller per-feature partials, to keep signal over noise.
- `composer.json`: add `authors`, align `license` to `AGPL-3.0-or-later`.
- `README.md`: add "Auteur" and "Avertissement" sections near the top (RGPD responsibility sits with the deploying unit, not the project); reword the "ePrivacy compliant" claim to describe the cookie banner/preferences feature rather than implying whole-product compliance.
- `CONTRIBUTING.md`: note that contributions are under AGPL-3.0-or-later, added to `NOTICE`, and subject to the name clause.
- `SECURITY.md`: add a short vulnerability-reporting procedure and a warranty disclaimer.
- `RgpdContentService`: `buildSystemPrompt()` now has an explicit rule (6bis) requiring the AI-generated RGPD text to name the deploying unit as data controller and never ScoutMagic/its author. `generateWithAi()` adds a simple post-generation check (unit name + "responsable du traitement") that throws — blocking the auto-save in `RgpdConfigController::generate()` — instead of silently publishing text missing that designation. Existing tests' mocked LLM responses updated accordingly, plus a new test for the check.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change (RgpdContentServiceTest)
- [ ] Tests pass locally (`vendor/bin/phpunit`) — **could not run**: this sandbox's `composer install` cannot fetch phpunit/phpstan (GitHub API/auth restrictions in this network, unrelated to the change). Every touched PHP file was checked with `php -l` (all pass) and the RGPD-service logic was reviewed manually. Please run the real suite before merging.
- [ ] PHPStan passes (`vendor/bin/phpstan analyse`) — same reason as above, not run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sgs2Tz9BA5iE3K45YKW4FA)_