### PR TITLE
feat(maintenance): render release/commit notes as formatted HTML

### DIFF
--- a/core/Http/Controller/MaintenanceController.php
+++ b/core/Http/Controller/MaintenanceController.php
@@ -28,6 +28,7 @@ use Core\Security\AuthSession;
 use Core\Security\CsrfGuard;
 use Core\Security\EncryptionService;
 use Core\Security\SecretManager;
+use Core\View\MarkdownRenderer;
 use Twig\Environment;
 
 /**
@@ -263,6 +264,8 @@ class MaintenanceController extends AbstractController
                     return $this->json(['success' => false, 'error' => "Branche « {$branch} » introuvable sur le dépôt GitHub."], 404);
                 }
 
+                $commitMessage = trim($commit->message);
+
                 return $this->json([
                     'success' => true,
                     'channel' => 'dev',
@@ -272,7 +275,8 @@ class MaintenanceController extends AbstractController
                     // commits carry their real rationale in the body (see
                     // any recent `git log`), which is exactly what an admin
                     // deciding whether to install needs to read.
-                    'notes' => trim($commit->message),
+                    'notes' => $commitMessage,
+                    'notes_html' => MarkdownRenderer::toHtml($commitMessage),
                     'url' => $commit->htmlUrl,
                 ]);
             }
@@ -297,6 +301,7 @@ class MaintenanceController extends AbstractController
                 'update_available' => VersionFile::isNewerThan($release->version(), $installedVersion),
                 'version' => $release->version(),
                 'notes' => $release->body,
+                'notes_html' => MarkdownRenderer::toHtml($release->body),
                 'url' => $release->htmlUrl,
             ]);
         } catch (UpdateException $e) {

--- a/core/View/MarkdownRenderer.php
+++ b/core/View/MarkdownRenderer.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\View;
+
+/**
+ * Renders the narrow Markdown subset actually produced by the two sources
+ * shown on Configuration > Maintenance: GitHub's own `--generate-notes`
+ * output and the "Résumé/Nouveautés/Corrections de bugs/Compatibilité
+ * ascendante/…/Vérifications effectuées" structure `scripts/release.sh`
+ * always appends (AGENTS.md "Releases") — headings, bold, inline code,
+ * bullet lists, horizontal rules, paragraphs, and `[text](url)` links —
+ * plus, for the development channel, a plain commit message (which this
+ * renders as ordinary paragraphs, since it carries no Markdown at all).
+ * Not a general-purpose CommonMark implementation (ARCHITECTURE.md §1:
+ * "only a small, explicitly justified set of external dependencies is
+ * allowed" — a full parser isn't worth a new Composer dependency for
+ * this one, well-defined need).
+ *
+ * Every line is HTML-escaped before any Markdown markup is reintroduced,
+ * so the output is safe to print unescaped regardless of what the source
+ * (a GitHub release body, ultimately admin/maintainer-authored, or a
+ * commit message from anyone with push access) contains.
+ */
+final class MarkdownRenderer
+{
+    public static function toHtml(string $markdown): string
+    {
+        $lines = preg_split('/\r\n|\r|\n/', trim($markdown)) ?: [];
+        $html = '';
+        $listOpen = false;
+        /** @var string[] $paragraph */
+        $paragraph = [];
+
+        $flushParagraph = static function () use (&$paragraph, &$html): void {
+            if ($paragraph === []) {
+                return;
+            }
+            $html .= '<p>' . self::inline(implode(' ', $paragraph)) . '</p>';
+            $paragraph = [];
+        };
+        $closeList = static function () use (&$listOpen, &$html): void {
+            if ($listOpen) {
+                $html .= '</ul>';
+                $listOpen = false;
+            }
+        };
+
+        foreach ($lines as $line) {
+            $trimmed = trim($line);
+
+            if ($trimmed === '') {
+                $flushParagraph();
+                continue;
+            }
+
+            if (preg_match('/^-{3,}$/', $trimmed) === 1) {
+                $flushParagraph();
+                $closeList();
+                $html .= '<hr>';
+                continue;
+            }
+
+            if (preg_match('/^#{1,6}\s+(.+)$/', $trimmed, $m) === 1) {
+                $flushParagraph();
+                $closeList();
+                $html .= '<h6 class="fw-semibold mt-2 mb-1">' . self::inline($m[1]) . '</h6>';
+                continue;
+            }
+
+            if (preg_match('/^[-*]\s+(.+)$/', $trimmed, $m) === 1) {
+                $flushParagraph();
+                if (!$listOpen) {
+                    $html .= '<ul class="ps-3 mb-2">';
+                    $listOpen = true;
+                }
+                $html .= '<li>' . self::inline($m[1]) . '</li>';
+                continue;
+            }
+
+            $closeList();
+            $paragraph[] = $trimmed;
+        }
+
+        $flushParagraph();
+        $closeList();
+
+        return $html;
+    }
+
+    /**
+     * Bold/italic/inline-code/links within a single block of text already
+     * split from structural Markdown (headings, list markers, horizontal
+     * rules) — escaped first, so the regexes below only ever reintroduce
+     * markup this method itself controls.
+     */
+    private static function inline(string $text): string
+    {
+        $escaped = htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+
+        // [text](https://…) — http(s) only, so a stray "javascript:" or
+        // similar in a commit message can never become a clickable link.
+        $escaped = (string) preg_replace_callback(
+            '/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/i',
+            static fn (array $m): string => '<a href="' . $m[2] . '" target="_blank" rel="noopener">' . $m[1] . '</a>',
+            $escaped
+        );
+
+        $escaped = (string) preg_replace('/\*\*(.+?)\*\*/', '<strong>$1</strong>', $escaped);
+        $escaped = (string) preg_replace('/(?<!\*)\*([^*\s][^*]*?)\*(?!\*)/', '<em>$1</em>', $escaped);
+        $escaped = (string) preg_replace('/`([^`]+)`/', '<code>$1</code>', $escaped);
+
+        return $escaped;
+    }
+}

--- a/core/View/TwigFactory.php
+++ b/core/View/TwigFactory.php
@@ -294,6 +294,13 @@ class TwigFactory
             return (int) $dateTime->format('j') . ' ' . $months[(int) $dateTime->format('n')] . ' ' . $dateTime->format('Y');
         }));
 
+        // Register markdown filter — renders release/commit notes (see
+        // Core\View\MarkdownRenderer) as safe HTML instead of raw Markdown
+        // syntax.
+        $environment->addFilter(new TwigFilter('markdown', function (?string $text): string {
+            return MarkdownRenderer::toHtml((string) $text);
+        }, ['is_safe' => ['html']]));
+
         return $environment;
     }
 

--- a/core/View/templates/config/maintenance.html.twig
+++ b/core/View/templates/config/maintenance.html.twig
@@ -27,7 +27,7 @@
                 {% endif %}
             </p>
             {% if installed_version_notes %}
-                <p class="small text-body-secondary mb-1" style="white-space: pre-line;">{{ installed_version_notes|slice(0, 500) }}{% if installed_version_notes|length > 500 %}…{% endif %}</p>
+                <div class="small text-body-secondary mb-1">{{ installed_version_notes|markdown }}</div>
             {% endif %}
             <p class="small text-body-secondary">
                 Dernière vérification :
@@ -49,7 +49,7 @@
                endpoint and is polled the same way (see maintenance.js). #}
             <div class="alert alert-primary d-none" id="update-check-now-dialog">
                 <p class="mb-2" id="update-check-now-message"></p>
-                <p class="small mb-3" style="white-space: pre-line;" id="update-check-now-notes"></p>
+                <div class="small mb-3" id="update-check-now-notes"></div>
                 <form id="update-check-now-install-form">
                     {{ csrf_field()|raw }}
                     <button type="submit" class="btn btn-primary btn-sm" id="update-check-now-install-submit">
@@ -72,7 +72,7 @@
                         {% endif %}
                     </p>
                     {% if update_release_notes %}
-                        <p class="small mb-2" style="white-space: pre-line;">{{ update_release_notes|slice(0, 500) }}{% if update_release_notes|length > 500 %}…{% endif %}</p>
+                        <div class="small mb-2">{{ update_release_notes|markdown }}</div>
                     {% endif %}
                     {% if update_dependencies_changed %}
                         <div class="alert alert-warning small mb-2">

--- a/public/assets/js/maintenance.js
+++ b/public/assets/js/maintenance.js
@@ -252,7 +252,10 @@
                 }
 
                 messageEl.textContent = 'Nouvelle version disponible : ' + data.version;
-                notesEl.textContent = (data.notes || '').slice(0, 500);
+                // notes_html is server-rendered from Markdown by
+                // Core\View\MarkdownRenderer (already HTML-escaped there),
+                // never built from data.notes client-side.
+                notesEl.innerHTML = data.notes_html || '';
                 dialog.classList.remove('d-none');
             })
             .catch(function () {

--- a/tests/Core/View/MarkdownRendererTest.php
+++ b/tests/Core/View/MarkdownRendererTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\View;
+
+use Core\View\MarkdownRenderer;
+use PHPUnit\Framework\TestCase;
+
+class MarkdownRendererTest extends TestCase
+{
+    public function testRendersHeadingsBoldInlineCodeAndParagraphs(): void
+    {
+        $html = MarkdownRenderer::toHtml("## Résumé\n\nCorrige `--skip-deployment-check` et **améliore** la détection.");
+
+        $this->assertStringContainsString('<h6 class="fw-semibold mt-2 mb-1">Résumé</h6>', $html);
+        $this->assertStringContainsString('<code>--skip-deployment-check</code>', $html);
+        $this->assertStringContainsString('<strong>améliore</strong>', $html);
+        $this->assertStringContainsString('<p>Corrige', $html);
+    }
+
+    public function testRendersBulletListsAndHorizontalRules(): void
+    {
+        $html = MarkdownRenderer::toHtml("- **Sécurité** : vérifié\n- **Tests** : vérifié\n\n---\n\n## Fin");
+
+        $this->assertStringContainsString('<ul class="ps-3 mb-2"><li><strong>Sécurité</strong> : vérifié</li><li><strong>Tests</strong> : vérifié</li></ul>', $html);
+        $this->assertStringContainsString('<hr>', $html);
+        $this->assertStringContainsString('<h6 class="fw-semibold mt-2 mb-1">Fin</h6>', $html);
+    }
+
+    public function testRendersMarkdownLinksWithHttpsSchemeOnly(): void
+    {
+        $html = MarkdownRenderer::toHtml('Voir [la release](https://github.com/x/y/releases/tag/v1.0.0).');
+
+        $this->assertStringContainsString('<a href="https://github.com/x/y/releases/tag/v1.0.0" target="_blank" rel="noopener">la release</a>', $html);
+    }
+
+    public function testDoesNotLinkifyANonHttpScheme(): void
+    {
+        $html = MarkdownRenderer::toHtml('Voir [ceci](javascript:alert(1)).');
+
+        $this->assertStringNotContainsString('<a href="javascript:', $html);
+    }
+
+    /**
+     * Every line is HTML-escaped before any Markdown markup is
+     * reintroduced (Core\View\MarkdownRenderer's own docblock) — a plain
+     * commit message containing raw HTML-looking text must never end up
+     * unescaped in the output, regardless of who pushed the commit.
+     */
+    public function testEscapesRawHtmlInTheSource(): void
+    {
+        $html = MarkdownRenderer::toHtml('<script>alert(1)</script>');
+
+        $this->assertStringNotContainsString('<script>', $html);
+        $this->assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    public function testRendersAPlainCommitMessageAsOrdinaryParagraphs(): void
+    {
+        $html = MarkdownRenderer::toHtml("Corrige la pagination du Trombinoscope\n\nDétails de la correction.");
+
+        $this->assertSame('<p>Corrige la pagination du Trombinoscope</p><p>Détails de la correction.</p>', $html);
+    }
+
+    public function testReturnsEmptyStringForEmptyInput(): void
+    {
+        $this->assertSame('', MarkdownRenderer::toHtml(''));
+        $this->assertSame('', MarkdownRenderer::toHtml("   \n  "));
+    }
+}


### PR DESCRIPTION
## Summary

- The "Mise à jour" section (installed version notes, cached release banner, and the "Vérifier maintenant" dialog) printed GitHub release bodies and commit messages as raw Markdown text instead of formatting them.
- `Core\View\MarkdownRenderer` renders the narrow Markdown subset actually produced by `scripts/release.sh`'s notes and GitHub's `--generate-notes` (headings, bold, inline code, bullet lists, horizontal rules, paragraphs, safe `http(s)` links) — hand-rolled rather than a new Composer dependency, per `ARCHITECTURE.md`'s "only a small, explicitly justified set of external dependencies is allowed". Every line is HTML-escaped before any markup is reintroduced, so it's safe to print unescaped regardless of source.
- Registered as a `markdown` Twig filter for the two server-rendered spots (installed-version notes, cached "update available" banner), and exposed via a new `notes_html` field on `POST /config/maintenance/update/check-now` for the JS-driven "Vérifier maintenant" dialog (`maintenance.js` now sets `innerHTML` from that pre-rendered, already-escaped field instead of raw `textContent`).
- Dropped the previous 500-character raw-text truncation in favor of showing the full formatted notes.

## Test plan

- [x] `tests/Core/View/MarkdownRendererTest.php` — new unit tests: headings/bold/inline-code/paragraphs, bullet lists + horizontal rules, safe `http(s)` link rendering, rejection of non-`http(s)` schemes (e.g. `javascript:`), HTML-escaping of raw markup in the source, plain commit messages as ordinary paragraphs, empty input.
- [x] Manually verified `MarkdownRenderer::toHtml()` against a real production release body (v1.0.29) — output matches expected `<h6>`/`<p>`/`<code>`/`<ul>`/`<hr>` structure.
- [x] `php -l` on every changed/added file.
- [ ] Full `vendor/bin/phpstan analyse` + `vendor/bin/phpunit` run — blocked in this sandbox: `composer install` cannot download `phpstan/phpstan`'s dist zip (`api.github.com/repos/phpstan/phpstan/zipball/...`, no git `source` alternative in this package) — consistently fails non-interactive GitHub API auth across repeated retries. Reviewed the existing `MaintenanceControllerTest`/`GitHubWebhookServiceTest` fixtures by hand to confirm none of their notes text relies on the removed truncation or contains characters the escaping step would alter.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RXrdxQMZjm7LoDT5QbACsF)_