### PR TITLE
gallery: delegated albums with access-controlled media serving

### DIFF
--- a/modules/gallery/module.json
+++ b/modules/gallery/module.json
@@ -2,7 +2,7 @@
   "id": "gallery",
   "name": "Galerie photos et vidéos",
   "description": "Albums photo/vidéo (envoi local avec redimensionnement/transcodage automatique, ou lien vers un album externe) visibles par les membres identifiés.",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "enabled_by_default": false,
   "routes": [
     {

--- a/modules/gallery/schema.sql
+++ b/modules/gallery/schema.sql
@@ -97,6 +97,24 @@ CREATE TABLE IF NOT EXISTS gallery_albums (
     -- Service\StorageLocationService::ensureLegacyLocationBackfilled()
     -- self-heals those the first time anything needs to resolve one.
     storage_location_id INT UNSIGNED NULL,
+    -- A delegated album: hosted and stored by gallery (any storage
+    -- location, local or S3) but owned and access-controlled by another
+    -- module, rather than by this module's own section/scout-year
+    -- visibility rules. Deliberately mirrors files.owner_type/owner_id
+    -- (schema/core.sql) in shape — same nullable VARCHAR(50)/INT UNSIGNED
+    -- pair, same non-unique index, no FK (the referenced table varies by
+    -- owner_type) — but is a SEPARATE registry: this pair is resolved by
+    -- Service\DelegatedAlbumAccessRegistry against
+    -- Api\DelegatedAlbumAccessChecker implementations, never by
+    -- Core\File\FileAccessGuard, since a delegated album's media are
+    -- (mostly) not `files` rows — see gallery_media's own header comment.
+    -- NULL on every ordinary album. A non-null owner_type marks the album
+    -- delegated: Repository\AlbumRepository::findAll()/findVisible()
+    -- both exclude it, so it never appears in gallery's own listings,
+    -- pickers or Api\GalleryAlbumProvider — reachable only through its
+    -- owning module (Service\DelegatedAlbumService).
+    owner_type VARCHAR(50) NULL,
+    owner_id INT UNSIGNED NULL,
     -- Background storage migration (Task\MigrateAlbumStorageHandler,
     -- triggered from the album edit page) — 'in_progress' makes the album
     -- unavailable everywhere its media would otherwise be read (a partially
@@ -115,6 +133,7 @@ CREATE TABLE IF NOT EXISTS gallery_albums (
     INDEX idx_gallery_albums_date (album_date),
     INDEX idx_gallery_albums_storage_location (storage_location_id),
     INDEX idx_gallery_albums_migration_target (migration_target_location_id),
+    INDEX idx_gallery_albums_owner (owner_type, owner_id),
     CONSTRAINT fk_gallery_albums_section FOREIGN KEY (section_id) REFERENCES sections(id) ON DELETE SET NULL,
     CONSTRAINT fk_gallery_albums_scout_year FOREIGN KEY (scout_year_id) REFERENCES scout_years(id),
     CONSTRAINT fk_gallery_albums_created_by FOREIGN KEY (created_by) REFERENCES user_accounts(id),

--- a/modules/gallery/src/Api/DelegatedAlbum.php
+++ b/modules/gallery/src/Api/DelegatedAlbum.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Gallery\Api;
+
+/**
+ * A delegated album as seen from outside the gallery module — just enough
+ * for the owning module to keep the id (to pass back into
+ * DelegatedAlbumManager's other methods) and render a title, never
+ * gallery's own internal Repository\Album (storage_location_id,
+ * migration state, etc. stay module-private).
+ */
+final class DelegatedAlbum
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $title,
+        public readonly string $albumDate
+    ) {
+    }
+}

--- a/modules/gallery/src/Api/DelegatedAlbumAccessChecker.php
+++ b/modules/gallery/src/Api/DelegatedAlbumAccessChecker.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Gallery\Api;
+
+use Core\Security\Role;
+
+/**
+ * A pluggable read-access rule for a delegated album's media — gallery's
+ * own equivalent of Core\File\FileOwnershipCheckerInterface, one level up:
+ * the same shape and the same fail-closed contract, applied to
+ * gallery_albums.owner_type/owner_id instead of files.owner_type/owner_id
+ * (a delegated album's derived renditions are not `files` rows — see
+ * schema.sql). Any module that hosts an album through
+ * DelegatedAlbumManager registers exactly one implementation, keyed by its
+ * own owner_type, without Controller\GalleryController ever needing to
+ * know that module exists.
+ *
+ * Consulted by Service\DelegatedAlbumAccessRegistry from
+ * Controller\GalleryController::serveMedia() before anything else — a
+ * delegated album whose owner_type has no registered checker is denied,
+ * never allowed by default, same posture as
+ * Core\File\FileAccessGuard::isAllowedByRegistry().
+ */
+interface DelegatedAlbumAccessChecker
+{
+    /**
+     * Whether this checker is the one responsible for a given owner_type.
+     */
+    public function supports(string $ownerType): bool;
+
+    /**
+     * Whether the current requester may view the delegated album whose
+     * owner_id is $ownerId. $linkedMemberIds mirrors
+     * Core\File\FileAccessGuard's own — persistent members.id values the
+     * current session is linked to.
+     *
+     * @param array<int, int> $linkedMemberIds
+     */
+    public function isAllowed(int $ownerId, Role $currentRole, array $linkedMemberIds): bool;
+}

--- a/modules/gallery/src/Api/DelegatedAlbumManager.php
+++ b/modules/gallery/src/Api/DelegatedAlbumManager.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Gallery\Api;
+
+/**
+ * Public contract for a module that wants gallery to host and store an
+ * album it owns and access-controls itself — a delegated album
+ * (ARCHITECTURE.md §7.5, same shape as Api\GalleryAlbumProvider). Storage
+ * stays fully configurable (local or S3, whichever the admin has
+ * configured) — that is the whole point of going through gallery instead
+ * of the owning module rolling its own file handling.
+ *
+ * Authorisation is entirely the caller's responsibility. Every method
+ * here takes no Role and no email and performs none of gallery's own
+ * section-based checks — unlike Service\MediaService::upload(), which
+ * gates every write behind Service\GalleryAccessService::canManageAlbum().
+ * By the time an owning module calls any of these, it has already decided
+ * the caller may act; gallery only stores and serves. The one thing
+ * gallery still enforces on its own is *read* access to the served
+ * media — see Api\DelegatedAlbumAccessChecker, which the owning module
+ * registers separately to answer that question when a viewer requests
+ * GET /gallery/media/{id}/{size}.
+ */
+interface DelegatedAlbumManager
+{
+    /**
+     * Finds the delegated album already owned by (ownerType, ownerId), or
+     * creates one when none exists yet — idempotent, safe to call on
+     * every request that might need the album. $storageLocationId pins the
+     * album to a specific configured location; null uses whichever
+     * location is currently the default, same resolution as an ordinary
+     * local album.
+     *
+     * @throws \Modules\Gallery\Service\GalleryException when the resolved
+     *         storage location has a public URL configured — a delegated
+     *         album must live on a location gallery can serve only
+     *         through a genuinely access-controlled path (a private
+     *         bucket, or presigned URLs), never a public-prefix one where
+     *         presigning would change nothing.
+     */
+    public function ensureAlbum(
+        string $ownerType,
+        int $ownerId,
+        string $title,
+        string $albumDate,
+        int $createdBy,
+        ?int $storageLocationId = null
+    ): DelegatedAlbum;
+
+    /**
+     * @param array<string, mixed> $uploadedFile $_FILES entry
+     * @throws \Modules\Gallery\Service\GalleryException on an invalid
+     *         file, a disabled type, over-quota, or an unknown/
+     *         non-delegated $albumId
+     */
+    public function addMedia(int $albumId, array $uploadedFile, ?int $accountId): DelegatedMedia;
+
+    /**
+     * @return DelegatedMedia[] ordered the same way the album's own grid would be
+     */
+    public function listMedia(int $albumId): array;
+
+    /**
+     * @throws \Modules\Gallery\Service\GalleryException when $mediaId
+     *         doesn't belong to $albumId
+     */
+    public function deleteMedia(int $albumId, int $mediaId): void;
+
+    /**
+     * Deletes the album row, every one of its media rows (DB cascade) and
+     * every stored object for them (thumb/medium/large/original, on
+     * whichever storage backend the album lives on) — the DB cascade never
+     * touches the storage backend on its own, same as an ordinary album's
+     * own Service\AlbumService::delete().
+     */
+    public function deleteAlbum(int $albumId): void;
+}

--- a/modules/gallery/src/Api/DelegatedMedia.php
+++ b/modules/gallery/src/Api/DelegatedMedia.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Gallery\Api;
+
+/**
+ * One media of a delegated album, as seen from outside the gallery
+ * module. Deliberately carries no storage path or URL: every rendition is
+ * addressed only through GET /gallery/media/{id}/{size}, whatever the
+ * storage backend — the owning module builds that URL itself from `id`
+ * and the size it wants ('thumb', 'medium', 'large', 'original'), the
+ * same well-known route an ordinary album's own templates use.
+ * `processingStatus` is 'pending'|'processing'|'done'|'failed'
+ * (Repository\Media's own constants) — a size is only actually servable
+ * once processing reaches 'done'.
+ */
+final class DelegatedMedia
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $mediaType,
+        public readonly string $processingStatus,
+        public readonly int $sortOrder,
+        public readonly ?string $originalFilename,
+        public readonly string $createdAt
+    ) {
+    }
+}

--- a/modules/gallery/src/Controller/GalleryChiefController.php
+++ b/modules/gallery/src/Controller/GalleryChiefController.php
@@ -118,7 +118,9 @@ class GalleryChiefController extends AbstractController
     public function edit(Request $request, array $params): Response
     {
         $album = $this->albumService->findById((int) $params['id']);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
+            // A delegated album never appears in this chief-facing surface
+            // — reachable only through its owning module.
             return new Response('Not Found', 404);
         }
 
@@ -137,7 +139,7 @@ class GalleryChiefController extends AbstractController
         }
 
         $album = $this->albumService->findById((int) $params['id']);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
             return new Response('Not Found', 404);
         }
         [$role, $email] = $this->currentIdentity();
@@ -199,7 +201,7 @@ class GalleryChiefController extends AbstractController
         }
 
         $album = $this->albumService->findById((int) $params['id']);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
             return $this->json(['success' => false, 'error' => 'Album introuvable.'], 404);
         }
 
@@ -233,7 +235,7 @@ class GalleryChiefController extends AbstractController
         }
 
         $album = $this->albumService->findById((int) $params['id']);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
             return $this->json(['success' => false, 'error' => 'Album introuvable.'], 404);
         }
 
@@ -263,7 +265,7 @@ class GalleryChiefController extends AbstractController
 
         $album = $this->albumService->findById((int) $params['id']);
         $media = $album !== null ? $this->mediaRepository->findById((int) $params['media_id']) : null;
-        if ($album === null || $media === null || $media->albumId !== $album->id) {
+        if ($album === null || $album->isDelegated() || $media === null || $media->albumId !== $album->id) {
             return $this->json(['success' => false, 'error' => 'Média introuvable.'], 404);
         }
 

--- a/modules/gallery/src/Controller/GalleryController.php
+++ b/modules/gallery/src/Controller/GalleryController.php
@@ -244,13 +244,7 @@ class GalleryController extends AbstractController
             return new Response('Album en cours de migration.', 503);
         }
 
-        $path = match ($size) {
-            'thumb' => $media->thumbPath,
-            'medium' => $media->mediumPath,
-            'large' => $media->largePath,
-            'original' => $media->originalPath,
-            default => null,
-        };
+        $path = $this->pathForSize($media, $size);
         if ($path === null) {
             return new Response('Not Found', 404);
         }
@@ -274,10 +268,8 @@ class GalleryController extends AbstractController
             return new Response('Not Found', 404);
         }
 
-        $mimeType = $media->isVideo() && $size !== 'thumb' ? 'video/mp4' : 'image/jpeg';
-
         return (new Response($contents))
-            ->setHeader('Content-Type', $mimeType)
+            ->setHeader('Content-Type', $this->mimeTypeFor($media, $size))
             ->setHeader('Content-Length', (string) strlen($contents))
             ->setHeader('Cache-Control', 'private, max-age=31536000')
             ->setHeader('ETag', $etag);
@@ -311,17 +303,11 @@ class GalleryController extends AbstractController
             return new Response('Album en cours de migration.', 503);
         }
 
-        $path = match ($size) {
-            'thumb' => $media->thumbPath,
-            'medium' => $media->mediumPath,
-            'large' => $media->largePath,
-            'original' => $media->originalPath,
-            default => null,
-        };
+        // Covers both an unknown $size and a still-pending/failed media
+        // (Repository\Media's derived paths are null until processing
+        // marks it done) — never a 500 either way.
+        $path = $this->pathForSize($media, $size);
         if ($path === null) {
-            // Covers both an unknown $size and a still-pending/failed
-            // media (Repository\Media's derived paths are null until
-            // processing marks it done) — never a 500 either way.
             return new Response('Not Found', 404);
         }
 
@@ -348,12 +334,38 @@ class GalleryController extends AbstractController
             return new Response('Not Found', 404);
         }
 
-        $mimeType = $media->isVideo() && $size !== 'thumb' ? 'video/mp4' : 'image/jpeg';
-
         return (new Response($contents))
-            ->setHeader('Content-Type', $mimeType)
+            ->setHeader('Content-Type', $this->mimeTypeFor($media, $size))
             ->setHeader('Content-Length', (string) strlen($contents))
             ->setHeader('Cache-Control', 'private, no-store');
+    }
+
+    /**
+     * The stored rendition path for a given size — null for an unknown
+     * $size or one that hasn't finished processing yet
+     * (Repository\Media's thumb/medium/large/original paths stay null
+     * until Task\ProcessPhotoHandler/ProcessVideoHandler mark it done).
+     * Shared by both the ordinary and the delegated serving path above.
+     */
+    private function pathForSize(Media $media, string $size): ?string
+    {
+        return match ($size) {
+            'thumb' => $media->thumbPath,
+            'medium' => $media->mediumPath,
+            'large' => $media->largePath,
+            'original' => $media->originalPath,
+            default => null,
+        };
+    }
+
+    /**
+     * Thumbs are always a JPEG (even for a video, whose thumb is an
+     * extracted frame) — every other rendition follows the media's own
+     * type. Shared by both the ordinary and the delegated serving path.
+     */
+    private function mimeTypeFor(Media $media, string $size): string
+    {
+        return $media->isVideo() && $size !== 'thumb' ? 'video/mp4' : 'image/jpeg';
     }
 
     /**

--- a/modules/gallery/src/Controller/GalleryController.php
+++ b/modules/gallery/src/Controller/GalleryController.php
@@ -20,6 +20,7 @@ use Modules\Gallery\Repository\Album;
 use Modules\Gallery\Repository\Media;
 use Modules\Gallery\Repository\MediaRepository;
 use Modules\Gallery\Service\AlbumService;
+use Modules\Gallery\Service\DelegatedAlbumAccessRegistry;
 use Modules\Gallery\Service\MediaService;
 use Modules\Gallery\Service\Storage\StorageBackendFactory;
 use Modules\Gallery\Service\StorageLocationService;
@@ -27,6 +28,17 @@ use Twig\Environment;
 
 class GalleryController extends AbstractController
 {
+    /**
+     * A delegated album's presigned S3 URL is a bearer credential for as
+     * long as it stays valid — kept deliberately short, unlike the 1-hour
+     * default S3StorageBackend::url() uses for an ordinary album's <img
+     * src> (module spec: "a few minutes").
+     */
+    private const DELEGATED_PRESIGN_TTL = '+5 minutes';
+
+    /**
+     * @param int[] $linkedMemberIds
+     */
     public function __construct(
         protected Environment $twig,
         private AlbumService $albumService,
@@ -36,7 +48,16 @@ class GalleryController extends AbstractController
         private SectionService $sectionService,
         private ScoutYearService $scoutYearService,
         private StorageBackendFactory $storageBackendFactory,
-        private StorageLocationService $storageLocationService
+        private StorageLocationService $storageLocationService,
+        // Both last, with safe defaults, so every existing positional
+        // construction of this controller (tests included) keeps working
+        // unchanged — same "append-only" discipline as
+        // Core\Module\ModuleManifest's `requires` addition. An empty
+        // registry and an empty linked-member list mean every delegated
+        // album is denied, never accidentally allowed, until both are
+        // actually wired.
+        private DelegatedAlbumAccessRegistry $delegatedAlbumAccessRegistry = new DelegatedAlbumAccessRegistry(),
+        private array $linkedMemberIds = []
     ) {
     }
 
@@ -80,7 +101,11 @@ class GalleryController extends AbstractController
     public function show(Request $request, array $params): Response
     {
         $album = $this->albumService->findById((int) $params['id']);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
+            // A delegated album is reachable only through its owning
+            // module — never gallery's own pages, direct id or not. Same
+            // 404 (not 403) as an unknown id: this must not confirm the
+            // album exists.
             return new Response('Not Found', 404);
         }
         if (!$this->isVisible($album)) {
@@ -125,7 +150,7 @@ class GalleryController extends AbstractController
     public function downloadZip(Request $request, array $params): Response
     {
         $album = $this->albumService->findById((int) $params['id']);
-        if ($album === null || !$album->isLocal()) {
+        if ($album === null || !$album->isLocal() || $album->isDelegated()) {
             return new Response('Not Found', 404);
         }
         if (!$this->isVisible($album)) {
@@ -210,6 +235,11 @@ class GalleryController extends AbstractController
         if ($album === null) {
             return new Response('Not Found', 404);
         }
+
+        if ($album->isDelegated()) {
+            return $this->serveDelegatedMedia($album, $media, $size);
+        }
+
         if ($album->isMigrating()) {
             return new Response('Album en cours de migration.', 503);
         }
@@ -251,6 +281,79 @@ class GalleryController extends AbstractController
             ->setHeader('Content-Length', (string) strlen($contents))
             ->setHeader('Cache-Control', 'private, max-age=31536000')
             ->setHeader('ETag', $etag);
+    }
+
+    /**
+     * The delegated-album path of serveMedia() above: the ownership
+     * checker registry is consulted before anything else — before the
+     * migration check, before resolving a size to a stored path, before
+     * touching the storage backend at all — so a denial never depends on
+     * (and never leaks through timing on) any of that. Fail-closed: an
+     * owner_type with no registered checker is denied exactly like a
+     * checker that actively refuses (Service\DelegatedAlbumAccessRegistry).
+     *
+     * No ETag/max-age caching here, unlike the ordinary path above — every
+     * response, including the S3 redirect, carries
+     * `Cache-Control: private, no-store` (module spec) so no shared cache
+     * or service worker ever retains a delegated media response or the
+     * presigned URL it points to.
+     */
+    private function serveDelegatedMedia(Album $album, Media $media, string $size): Response
+    {
+        \assert($album->ownerType !== null && $album->ownerId !== null);
+
+        $role = Role::fromString(AuthSession::getRole());
+        if (!$this->delegatedAlbumAccessRegistry->isAllowed($album->ownerType, $album->ownerId, $role, $this->linkedMemberIds)) {
+            return new Response('Not Found', 404);
+        }
+
+        if ($album->isMigrating()) {
+            return new Response('Album en cours de migration.', 503);
+        }
+
+        $path = match ($size) {
+            'thumb' => $media->thumbPath,
+            'medium' => $media->mediumPath,
+            'large' => $media->largePath,
+            'original' => $media->originalPath,
+            default => null,
+        };
+        if ($path === null) {
+            // Covers both an unknown $size and a still-pending/failed
+            // media (Repository\Media's derived paths are null until
+            // processing marks it done) — never a 500 either way.
+            return new Response('Not Found', 404);
+        }
+
+        $location = $this->storageLocationService->resolveLocationForAlbum($album);
+        if ($location === null) {
+            return new Response('Not Found', 404);
+        }
+
+        if ($location->isS3()) {
+            // Minted fresh for this one request, never stored or logged —
+            // a presigned URL is a bearer credential for as long as it
+            // stays valid, hence the short TTL (self::DELEGATED_PRESIGN_TTL)
+            // instead of the 1-hour default an ordinary album's own
+            // <img src> uses.
+            $url = $this->storageBackendFactory->create($location)->url($path, self::DELEGATED_PRESIGN_TTL);
+            return (new Response('', 302))
+                ->setHeader('Location', $url)
+                ->setHeader('Cache-Control', 'private, no-store');
+        }
+
+        try {
+            $contents = $this->storageBackendFactory->create($location)->get($path);
+        } catch (\RuntimeException) {
+            return new Response('Not Found', 404);
+        }
+
+        $mimeType = $media->isVideo() && $size !== 'thumb' ? 'video/mp4' : 'image/jpeg';
+
+        return (new Response($contents))
+            ->setHeader('Content-Type', $mimeType)
+            ->setHeader('Content-Length', (string) strlen($contents))
+            ->setHeader('Cache-Control', 'private, no-store');
     }
 
     /**

--- a/modules/gallery/src/Repository/Album.php
+++ b/modules/gallery/src/Repository/Album.php
@@ -39,13 +39,33 @@ final class Album
         public readonly ?int $migrationTargetLocationId,
         public readonly ?string $migrationError,
         public readonly int $createdBy,
-        public readonly string $createdAt
+        public readonly string $createdAt,
+        // Last, with defaults — same "append-only" constructor discipline
+        // as Core\Module\ModuleManifest's own `requires` addition
+        // (docs/module-development.md): AlbumRepository::hydrate() uses
+        // named arguments so it isn't order-sensitive, but
+        // tests/Modules/Gallery/Repository/AlbumTest.php constructs an
+        // Album positionally, and moving these earlier would silently
+        // shift every argument after them.
+        public readonly ?string $ownerType = null,
+        public readonly ?int $ownerId = null
     ) {
     }
 
     public function isLocal(): bool
     {
         return $this->type === self::TYPE_LOCAL;
+    }
+
+    /**
+     * A delegated album is hosted and stored by gallery but owned and
+     * access-controlled by another module (schema.sql's owner_type/
+     * owner_id header comment) — excluded from every gallery-side
+     * listing/picker and reachable only through its owning module.
+     */
+    public function isDelegated(): bool
+    {
+        return $this->ownerType !== null;
     }
 
     /**

--- a/modules/gallery/src/Repository/AlbumRepository.php
+++ b/modules/gallery/src/Repository/AlbumRepository.php
@@ -25,12 +25,15 @@ class AlbumRepository
     /**
      * All albums, newest activity date first — the chief "manage" list
      * (unfiltered; Service\GalleryAccessService applies section scoping).
+     * Delegated albums (owner_type IS NOT NULL) are always excluded: they
+     * are reachable only through their owning module, never through
+     * gallery's own management pages.
      *
      * @return Album[]
      */
     public function findAll(): array
     {
-        $stmt = $this->pdo->query('SELECT * FROM gallery_albums ORDER BY album_date DESC, id DESC');
+        $stmt = $this->pdo->query('SELECT * FROM gallery_albums WHERE owner_type IS NULL ORDER BY album_date DESC, id DESC');
         return $stmt !== false ? array_map([$this, 'hydrate'], $stmt->fetchAll(\PDO::FETCH_ASSOC)) : [];
     }
 
@@ -40,6 +43,11 @@ class AlbumRepository
      * given scout years — the public gallery list (module spec: "current
      * or previous year"). $sectionIds may be empty (member linked to no
      * section) — unit-wide albums still show.
+     *
+     * Delegated albums (owner_type IS NOT NULL) are always excluded — same
+     * reasoning as findAll() above; a delegated album is never section/
+     * scout-year visible in gallery's own sense, since a member's access
+     * to it is decided entirely by its owning module's own rule.
      *
      * @param int[] $sectionIds
      * @param int[] $scoutYearIds
@@ -62,10 +70,28 @@ class AlbumRepository
         }
 
         $stmt = $this->pdo->prepare(
-            "SELECT * FROM gallery_albums WHERE scout_year_id IN ({$yearPlaceholders}) AND {$sectionClause} ORDER BY album_date DESC, id DESC"
+            "SELECT * FROM gallery_albums WHERE owner_type IS NULL AND scout_year_id IN ({$yearPlaceholders}) AND {$sectionClause} ORDER BY album_date DESC, id DESC"
         );
         $stmt->execute($params);
         return array_map([$this, 'hydrate'], $stmt->fetchAll(\PDO::FETCH_ASSOC));
+    }
+
+    /**
+     * The delegated album already owned by (ownerType, ownerId), or null
+     * when none exists yet — Service\DelegatedAlbumService::ensureAlbum()'s
+     * "find" half. No DB-level uniqueness is enforced on (owner_type,
+     * owner_id) — same tradeoff as files.owner_type/owner_id, which this
+     * column pair deliberately mirrors — so this picks the oldest match,
+     * deterministically, on the rare chance more than one exists.
+     */
+    public function findByOwner(string $ownerType, int $ownerId): ?Album
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT * FROM gallery_albums WHERE owner_type = ? AND owner_id = ? ORDER BY id ASC LIMIT 1'
+        );
+        $stmt->execute([$ownerType, $ownerId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $row !== false ? $this->hydrate($row) : null;
     }
 
     public function create(
@@ -77,13 +103,18 @@ class AlbumRepository
         int $scoutYearId,
         ?string $externalUrl,
         ?int $storageLocationId,
-        int $createdBy
+        int $createdBy,
+        // Last, both null: an ordinary album never sets these — only
+        // Service\DelegatedAlbumService::ensureAlbum() ever passes a
+        // non-null pair.
+        ?string $ownerType = null,
+        ?int $ownerId = null
     ): int {
         $stmt = $this->pdo->prepare(
-            'INSERT INTO gallery_albums (type, title, subtitle, album_date, section_id, scout_year_id, external_url, storage_location_id, created_by, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+            'INSERT INTO gallery_albums (type, title, subtitle, album_date, section_id, scout_year_id, external_url, storage_location_id, created_by, created_at, owner_type, owner_id)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
         );
-        $stmt->execute([$type, $title, $subtitle, $albumDate, $sectionId, $scoutYearId, $externalUrl, $storageLocationId, $createdBy, date('Y-m-d H:i:s')]);
+        $stmt->execute([$type, $title, $subtitle, $albumDate, $sectionId, $scoutYearId, $externalUrl, $storageLocationId, $createdBy, date('Y-m-d H:i:s'), $ownerType, $ownerId]);
         return (int) $this->pdo->lastInsertId();
     }
 
@@ -186,7 +217,9 @@ class AlbumRepository
             migrationTargetLocationId: $row['migration_target_location_id'] !== null ? (int) $row['migration_target_location_id'] : null,
             migrationError: $row['migration_error'] !== null ? (string) $row['migration_error'] : null,
             createdBy: (int) $row['created_by'],
-            createdAt: (string) $row['created_at']
+            createdAt: (string) $row['created_at'],
+            ownerType: $row['owner_type'] !== null ? (string) $row['owner_type'] : null,
+            ownerId: $row['owner_id'] !== null ? (int) $row['owner_id'] : null
         );
     }
 }

--- a/modules/gallery/src/Service/AlbumService.php
+++ b/modules/gallery/src/Service/AlbumService.php
@@ -182,7 +182,9 @@ class AlbumService
         string $email
     ): Album {
         $existing = $this->albumRepository->findById($id);
-        if ($existing === null) {
+        if ($existing === null || $existing->isDelegated()) {
+            // A delegated album is reachable only through its owning
+            // module — indistinguishable here from a nonexistent one.
             throw new GalleryException('Album introuvable.');
         }
         $this->assertValidTitle($title);
@@ -217,7 +219,7 @@ class AlbumService
     public function delete(int $id, Role $role, string $email): void
     {
         $album = $this->albumRepository->findById($id);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
             throw new GalleryException('Album introuvable.');
         }
         if (!$this->accessService->canManageAlbum($role, $album->sectionId, $email)) {
@@ -244,7 +246,7 @@ class AlbumService
     public function setCover(int $albumId, int $mediaId, Role $role, string $email): void
     {
         $album = $this->albumRepository->findById($albumId);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
             throw new GalleryException('Album introuvable.');
         }
         if (!$this->accessService->canManageAlbum($role, $album->sectionId, $email)) {
@@ -265,7 +267,7 @@ class AlbumService
     public function refreshOg(int $albumId, Role $role, string $email): Album
     {
         $album = $this->albumRepository->findById($albumId);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
             throw new GalleryException('Album introuvable.');
         }
         if (!$this->accessService->canManageAlbum($role, $album->sectionId, $email)) {
@@ -294,7 +296,7 @@ class AlbumService
     public function startMigration(int $albumId, int $targetLocationId, Role $role, string $email): void
     {
         $album = $this->albumRepository->findById($albumId);
-        if ($album === null) {
+        if ($album === null || $album->isDelegated()) {
             throw new GalleryException('Album introuvable.');
         }
         if (!$this->accessService->canManageAlbum($role, $album->sectionId, $email)) {

--- a/modules/gallery/src/Service/DelegatedAlbumAccessRegistry.php
+++ b/modules/gallery/src/Service/DelegatedAlbumAccessRegistry.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Gallery\Service;
+
+use Core\Security\Role;
+use Modules\Gallery\Api\DelegatedAlbumAccessChecker;
+
+/**
+ * The registry Controller\GalleryController::serveMedia() consults for a
+ * delegated album — mirrors Core\File\FileAccessGuard::isAllowedByRegistry()
+ * exactly: the first registered checker whose supports() matches wins, and
+ * an owner_type with no matching checker is denied (fail-closed), never
+ * allowed by default. Two checkers must never claim the same owner_type,
+ * same rule as the core registry.
+ *
+ * Built in public/index.php from a plain array — empty by default, so a
+ * fresh install of gallery alone (no delegating module installed/enabled)
+ * denies every delegated album it might still hold rows for, rather than
+ * granting access no checker was ever asked to confirm.
+ */
+class DelegatedAlbumAccessRegistry
+{
+    /**
+     * @param DelegatedAlbumAccessChecker[] $checkers
+     */
+    public function __construct(private array $checkers = [])
+    {
+    }
+
+    /**
+     * @param array<int, int> $linkedMemberIds
+     */
+    public function isAllowed(string $ownerType, int $ownerId, Role $currentRole, array $linkedMemberIds): bool
+    {
+        foreach ($this->checkers as $checker) {
+            if ($checker->supports($ownerType)) {
+                return $checker->isAllowed($ownerId, $currentRole, $linkedMemberIds);
+            }
+        }
+
+        return false;
+    }
+}

--- a/modules/gallery/src/Service/DelegatedAlbumService.php
+++ b/modules/gallery/src/Service/DelegatedAlbumService.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Gallery\Service;
+
+use Core\Config\ScoutYearService;
+use Modules\Gallery\Api\DelegatedAlbum;
+use Modules\Gallery\Api\DelegatedAlbumManager;
+use Modules\Gallery\Api\DelegatedMedia;
+use Modules\Gallery\Repository\Album;
+use Modules\Gallery\Repository\AlbumRepository;
+use Modules\Gallery\Repository\Media;
+use Modules\Gallery\Repository\MediaRepository;
+use Modules\Gallery\Repository\StorageLocationRepository;
+use Modules\Gallery\Service\Storage\StorageBackendFactory;
+
+/**
+ * The concrete implementation behind Api\DelegatedAlbumManager — a thin
+ * wrapper so the public API surface never exposes Repository\AlbumRepository
+ * (or PDO) directly to other modules, same precedent as
+ * Service\GalleryMemberQueryService for Api\GalleryAlbumProvider.
+ *
+ * Every method performs no authorisation of its own (Api\
+ * DelegatedAlbumManager's docblock) — it only ever refuses on a genuine
+ * data problem: an unknown album, one that isn't actually delegated, a
+ * media that doesn't belong to it, or (ensureAlbum() only) a storage
+ * location that can't host a delegated album at all.
+ */
+class DelegatedAlbumService implements DelegatedAlbumManager
+{
+    public function __construct(
+        private AlbumRepository $albumRepository,
+        private MediaRepository $mediaRepository,
+        private MediaService $mediaService,
+        private StorageLocationRepository $storageLocationRepository,
+        private StorageLocationService $storageLocationService,
+        private StorageBackendFactory $storageBackendFactory,
+        private ScoutYearService $scoutYearService
+    ) {
+    }
+
+    public function ensureAlbum(
+        string $ownerType,
+        int $ownerId,
+        string $title,
+        string $albumDate,
+        int $createdBy,
+        ?int $storageLocationId = null
+    ): DelegatedAlbum {
+        $existing = $this->albumRepository->findByOwner($ownerType, $ownerId);
+        if ($existing !== null) {
+            return $this->toAlbumDto($existing);
+        }
+
+        // Same "never let the caller choose a nonexistent location"
+        // self-healing as an ordinary local album (Service\AlbumService::
+        // create()) — a fresh/upgraded install always ends up with at
+        // least one location once this has run.
+        $this->storageLocationService->ensureLegacyLocationBackfilled();
+        $location = $storageLocationId !== null
+            ? $this->storageLocationRepository->findById($storageLocationId)
+            : $this->storageLocationRepository->findDefault();
+        if ($location === null) {
+            throw new GalleryException('Aucun emplacement de stockage disponible pour héberger cet album.');
+        }
+        if ($location->s3PublicUrl !== null && $location->s3PublicUrl !== '') {
+            // The one storage restriction on a delegated album: a public-
+            // prefix S3 location serves objects straight from that public
+            // URL, so a presigned URL changes nothing — the media would be
+            // world-readable by anyone with the link, defeating the whole
+            // point of delegated access control.
+            throw new GalleryException(
+                "L'emplacement de stockage « {$location->label} » est configuré avec une URL publique. "
+                . 'Un album délégué doit obligatoirement utiliser un emplacement privé (accès uniquement '
+                . 'via une URL pré-signée à courte durée, ou un fichier local protégé).'
+            );
+        }
+
+        $scoutYearId = (int) $this->scoutYearService->getCurrentYear()['id'];
+        $albumId = $this->albumRepository->create(
+            Album::TYPE_LOCAL, $title, null, $albumDate, null, $scoutYearId, null, $location->id, $createdBy, $ownerType, $ownerId
+        );
+
+        $created = $this->albumRepository->findById($albumId);
+        \assert($created !== null);
+        return $this->toAlbumDto($created);
+    }
+
+    public function addMedia(int $albumId, array $uploadedFile, ?int $accountId): DelegatedMedia
+    {
+        $album = $this->resolveDelegatedAlbum($albumId);
+        $media = $this->mediaService->addWithoutAuthorisationCheck($album, $uploadedFile, $accountId);
+
+        return $this->toMediaDto($media);
+    }
+
+    public function listMedia(int $albumId): array
+    {
+        $this->resolveDelegatedAlbum($albumId);
+
+        return array_map(fn(Media $m) => $this->toMediaDto($m), $this->mediaRepository->findByAlbumId($albumId));
+    }
+
+    public function deleteMedia(int $albumId, int $mediaId): void
+    {
+        $album = $this->resolveDelegatedAlbum($albumId);
+
+        $media = $this->mediaRepository->findById($mediaId);
+        if ($media === null || $media->albumId !== $albumId) {
+            throw new GalleryException('Ce média n\'appartient pas à cet album.');
+        }
+
+        $this->mediaService->deleteWithoutAuthorisationCheck($media, $album);
+    }
+
+    public function deleteAlbum(int $albumId): void
+    {
+        $album = $this->resolveDelegatedAlbum($albumId);
+
+        // DB cascade removes gallery_media rows on its own (schema.sql's
+        // ON DELETE CASCADE), but never touches the storage backend — that
+        // cleanup is explicit here, same as Service\AlbumService::delete().
+        $location = $this->storageLocationService->resolveLocationForAlbum($album);
+        if ($location !== null) {
+            $this->storageBackendFactory->create($location)->deletePrefix((string) $albumId);
+        }
+
+        $this->albumRepository->delete($albumId);
+    }
+
+    /**
+     * @throws GalleryException when $albumId doesn't exist or isn't delegated
+     */
+    private function resolveDelegatedAlbum(int $albumId): Album
+    {
+        $album = $this->albumRepository->findById($albumId);
+        if ($album === null || !$album->isDelegated()) {
+            throw new GalleryException('Album délégué introuvable.');
+        }
+
+        return $album;
+    }
+
+    private function toAlbumDto(Album $album): DelegatedAlbum
+    {
+        return new DelegatedAlbum($album->id, $album->title, $album->albumDate);
+    }
+
+    private function toMediaDto(Media $media): DelegatedMedia
+    {
+        return new DelegatedMedia(
+            $media->id,
+            $media->mediaType,
+            $media->processingStatus,
+            $media->sortOrder,
+            $media->originalFilename,
+            $media->createdAt
+        );
+    }
+}

--- a/modules/gallery/src/Service/MediaService.php
+++ b/modules/gallery/src/Service/MediaService.php
@@ -46,6 +46,12 @@ class MediaService
      */
     public function upload(Album $album, array $uploadedFile, Role $role, string $email, ?int $accountId): Media
     {
+        if ($album->isDelegated()) {
+            // Ordinary, access-checked uploads never touch a delegated
+            // album — only addWithoutAuthorisationCheck() below does,
+            // called exclusively by Service\DelegatedAlbumService.
+            throw new GalleryException('Album introuvable.');
+        }
         if (!$album->isLocal()) {
             throw new GalleryException('Cet album n\'accepte pas de médias (album externe).');
         }
@@ -53,6 +59,34 @@ class MediaService
             throw new GalleryException('Vous ne gérez pas cette section.');
         }
 
+        return $this->store($album, $uploadedFile, $accountId);
+    }
+
+    /**
+     * Adds a media to an already-resolved, already-authorised album — no
+     * canManageAlbum() call, no isLocal() gate: only ever called by
+     * Service\DelegatedAlbumService (Api\DelegatedAlbumManager's
+     * implementation), which has already confirmed the album is its own
+     * delegated one and that the caller may write to it — gallery's own
+     * section-based authorisation simply does not apply to a delegated
+     * album (Api\DelegatedAlbumManager's docblock). The quota, MIME/size
+     * limits and processing scheduling below are resource management, not
+     * authorisation, and stay identical either way.
+     *
+     * @param array<string, mixed> $uploadedFile $_FILES entry
+     * @throws GalleryException on an invalid file, a disabled type, or over-quota
+     */
+    public function addWithoutAuthorisationCheck(Album $album, array $uploadedFile, ?int $accountId): Media
+    {
+        return $this->store($album, $uploadedFile, $accountId);
+    }
+
+    /**
+     * @param array<string, mixed> $uploadedFile $_FILES entry
+     * @throws GalleryException on an invalid file, a disabled type, or over-quota
+     */
+    private function store(Album $album, array $uploadedFile, ?int $accountId): Media
+    {
         $maxMedia = (int) $this->settingService->get('gallery_max_media_per_album', 'gallery', 200);
         if ($this->mediaRepository->countByAlbumId($album->id) >= $maxMedia) {
             throw new GalleryException("Cet album a atteint la limite de {$maxMedia} médias.");
@@ -90,7 +124,10 @@ class MediaService
         );
 
         // First upload becomes the album cover automatically (module spec:
-        // "cover selection") — the chief can still change it later.
+        // "cover selection") — the chief can still change it later. A
+        // delegated album is never rendered through gallery's own views
+        // (excluded from every listing), so this is harmless bookkeeping
+        // for that case, not a UI feature it actually gets.
         if ($album->coverMediaId === null) {
             $this->albumRepository->setCoverMediaId($album->id, $mediaId);
         }
@@ -106,10 +143,29 @@ class MediaService
      */
     public function delete(Media $media, Album $album, Role $role, string $email): void
     {
+        if ($album->isDelegated()) {
+            throw new GalleryException('Album introuvable.');
+        }
         if (!$this->accessService->canManageAlbum($role, $album->sectionId, $email)) {
             throw new GalleryException('Vous ne gérez pas cette section.');
         }
 
+        $this->remove($media, $album);
+    }
+
+    /**
+     * Removes a media from an already-resolved, already-authorised
+     * delegated album — same "no gallery authorisation" contract as
+     * addWithoutAuthorisationCheck() above. Only ever called by
+     * Service\DelegatedAlbumService.
+     */
+    public function deleteWithoutAuthorisationCheck(Media $media, Album $album): void
+    {
+        $this->remove($media, $album);
+    }
+
+    private function remove(Media $media, Album $album): void
+    {
         if ($album->isLocal()) {
             $location = $this->storageLocationService->resolveLocationForAlbum($album);
             if ($location !== null) {
@@ -136,6 +192,9 @@ class MediaService
      */
     public function reorder(Album $album, array $orderedMediaIds, Role $role, string $email): void
     {
+        if ($album->isDelegated()) {
+            throw new GalleryException('Album introuvable.');
+        }
         if (!$this->accessService->canManageAlbum($role, $album->sectionId, $email)) {
             throw new GalleryException('Vous ne gérez pas cette section.');
         }
@@ -154,9 +213,26 @@ class MediaService
      * access-controlled endpoint for local storage, or straight to the
      * object storage (public prefix or a pre-signed URL) for S3, so a
      * configured CDN/public bucket isn't needlessly proxied through PHP.
+     *
+     * Never called for a delegated album: its media are addressed only
+     * through Controller\GalleryController::serveMedia(), which consults
+     * Service\DelegatedAlbumAccessRegistry before revealing anything — an
+     * S3 URL minted here would bypass that check entirely, handing out
+     * either a public-bucket link or an hour-long presigned one with no
+     * ownership check at all. Every caller (Service\
+     * GalleryMemberQueryService, Controller\GalleryController/
+     * GalleryChiefController) only ever reaches an album via
+     * AlbumRepository::findAll()/findVisible() or a controller's own
+     * isDelegated() guard, both of which already exclude delegated
+     * albums — this null return is the defense-in-depth backstop for that
+     * invariant, not the primary enforcement.
      */
     public function resolveUrl(Media $media, Album $album, string $size): ?string
     {
+        if ($album->isDelegated()) {
+            return null;
+        }
+
         $path = match ($size) {
             'thumb' => $media->thumbPath,
             'medium' => $media->mediumPath,

--- a/modules/gallery/src/Service/Storage/LocalStorageBackend.php
+++ b/modules/gallery/src/Service/Storage/LocalStorageBackend.php
@@ -67,8 +67,10 @@ class LocalStorageBackend implements StorageBackendInterface
         rmdir($dir);
     }
 
-    public function url(string $key): string
+    public function url(string $key, string $ttl = '+1 hour'): string
     {
+        // $ttl is meaningless for local storage — this "URL" is this
+        // app's own access-controlled route, not a time-limited grant.
         return '/gallery/media/' . rawurlencode($key);
     }
 

--- a/modules/gallery/src/Service/Storage/S3StorageBackend.php
+++ b/modules/gallery/src/Service/Storage/S3StorageBackend.php
@@ -149,7 +149,7 @@ class S3StorageBackend implements StorageBackendInterface
         ]);
     }
 
-    public function url(string $key): string
+    public function url(string $key, string $ttl = '+1 hour'): string
     {
         if ($this->publicUrl !== null && $this->publicUrl !== '') {
             return rtrim($this->publicUrl, '/') . '/' . ltrim($key, '/');
@@ -159,7 +159,12 @@ class S3StorageBackend implements StorageBackendInterface
             'Bucket' => $this->bucket,
             'Key' => $key,
         ]);
-        $request = $this->client->createPresignedRequest($command, '+1 hour');
+        // Minted fresh on every call, per $ttl — a presigned URL remains
+        // valid for the whole of its expiry once handed out, so callers
+        // that need a short-lived grant (Controller\GalleryController::
+        // serveMedia() for a delegated album) pass a short one; nothing
+        // here ever caches or reuses a previously minted URL.
+        $request = $this->client->createPresignedRequest($command, $ttl);
         return (string) $request->getUri();
     }
 

--- a/modules/gallery/src/Service/Storage/StorageBackendInterface.php
+++ b/modules/gallery/src/Service/Storage/StorageBackendInterface.php
@@ -35,8 +35,17 @@ interface StorageBackendInterface
      * Controller\GalleryController::serveMedia() instead); for
      * S3StorageBackend it's either the configured public URL prefix or a
      * time-limited pre-signed URL.
+     *
+     * $ttl is a pre-signing expiry understood by Aws\S3\S3Client::
+     * createPresignedRequest() (e.g. '+1 hour', '+5 minutes') — only ever
+     * meaningful for S3StorageBackend without a public URL configured;
+     * LocalStorageBackend ignores it entirely (its "URL" is this app's own
+     * access-controlled route, not a time-limited grant). Controller\
+     * GalleryController::serveMedia() passes a short TTL for a delegated
+     * album's media, minted fresh per request and never stored or logged;
+     * every other caller leaves it at the default.
      */
-    public function url(string $key): string;
+    public function url(string $key, string $ttl = '+1 hour'): string;
 
     public function exists(string $key): bool;
 }

--- a/public/index.php
+++ b/public/index.php
@@ -1019,8 +1019,9 @@ $fileOwnershipCheckers = [$sectionDocumentOwnershipChecker];
 // Api\DelegatedAlbumManager appends its own checker from inside its own
 // getEnabledModuleIds() block. Consumed only by
 // Controller\GalleryController::serveMedia(), constructed at the end of
-// this file for the exact same reason $fileAccessGuard is: every module
-// block that might append to this array runs before that point.
+// this file for the exact same ordering reason as Core\File\FileAccessGuard
+// above: every module block that might append to this array runs before
+// that point.
 $galleryDelegatedAlbumAccessCheckers = [];
 
 // Snapshot taken here rather than at the guard's construction site:

--- a/public/index.php
+++ b/public/index.php
@@ -1011,6 +1011,18 @@ $sectionDocumentOwnershipChecker = new \Core\Member\SectionDocumentOwnershipChec
 // FileController is wired, at the end of this file.
 $fileOwnershipCheckers = [$sectionDocumentOwnershipChecker];
 
+// The registry Modules\Gallery\Service\DelegatedAlbumAccessRegistry
+// consults for a delegated album — gallery's own equivalent of
+// $fileOwnershipCheckers above, one level up. Gallery contributes no
+// checker of its own (it only hosts delegated albums, never owns one), so
+// this starts empty; a module that hosts one through
+// Api\DelegatedAlbumManager appends its own checker from inside its own
+// getEnabledModuleIds() block. Consumed only by
+// Controller\GalleryController::serveMedia(), constructed at the end of
+// this file for the exact same reason $fileAccessGuard is: every module
+// block that might append to this array runs before that point.
+$galleryDelegatedAlbumAccessCheckers = [];
+
 // Snapshot taken here rather than at the guard's construction site:
 // $linkedMembers is re-resolved further down for the Espace animés menu,
 // and the guard's owner-scoping must not depend on which of the two
@@ -2142,13 +2154,18 @@ if (in_array('gallery', $moduleManager->getEnabledModuleIds(), true)) {
         $galleryAccessService, $galleryStorageBackendFactory, $galleryStorageLocationService, $galleryFfmpegAvailability
     );
 
-    $frontController->registerController(
-        \Modules\Gallery\Controller\GalleryController::class,
-        new \Modules\Gallery\Controller\GalleryController(
-            $twig, $galleryAlbumService, $galleryMediaService, $galleryMediaRepo, $memberService,
-            $sectionService, $scoutYearService, $galleryStorageBackendFactory, $galleryStorageLocationService
-        )
+    // Controller\GalleryController is NOT registered here — see the end
+    // of this file, where $galleryDelegatedAlbumAccessCheckers is
+    // guaranteed complete. Api\DelegatedAlbumManager's concrete
+    // implementation has no such ordering constraint (nothing it does
+    // consults that registry), so it is built here like any other gallery
+    // service, ready for a future module's block to consume — no consumer
+    // exists yet.
+    $galleryDelegatedAlbumManager = new \Modules\Gallery\Service\DelegatedAlbumService(
+        $galleryAlbumRepo, $galleryMediaRepo, $galleryMediaService, $galleryStorageLocationRepo,
+        $galleryStorageLocationService, $galleryStorageBackendFactory, $scoutYearService
     );
+
     $frontController->registerController(
         \Modules\Gallery\Controller\GalleryChiefController::class,
         new \Modules\Gallery\Controller\GalleryChiefController(
@@ -2630,6 +2647,27 @@ $fileAccessGuard = new FileAccessGuard(
 $fileController = new FileController($twig, $fileAccessGuard, $storagePath, $encryptedFileStorageService, $imageVariantService);
 $fileController->setJournalService($journalService);
 $frontController->registerController(FileController::class, $fileController);
+
+// Gallery media serving (/gallery/media/{id}/{size}) — GalleryController
+// built here, deliberately last, for the same reason as FileController
+// just above: Service\DelegatedAlbumAccessRegistry must be complete
+// before serveMedia() can safely consult it, and every module block that
+// might append to $galleryDelegatedAlbumAccessCheckers runs above this
+// point. Guarded by isset(): gallery might be disabled, in which case none
+// of its variables exist and there is nothing to register.
+if (isset($galleryAlbumService, $galleryMediaService, $galleryMediaRepo, $galleryStorageBackendFactory, $galleryStorageLocationService)) {
+    $galleryDelegatedAlbumAccessRegistry = new \Modules\Gallery\Service\DelegatedAlbumAccessRegistry(
+        $galleryDelegatedAlbumAccessCheckers
+    );
+    $frontController->registerController(
+        \Modules\Gallery\Controller\GalleryController::class,
+        new \Modules\Gallery\Controller\GalleryController(
+            $twig, $galleryAlbumService, $galleryMediaService, $galleryMediaRepo, $memberService,
+            $sectionService, $scoutYearService, $galleryStorageBackendFactory, $galleryStorageLocationService,
+            $galleryDelegatedAlbumAccessRegistry, $linkedMemberIds
+        )
+    );
+}
 
 // RGPD configuration controller
 $frontController->registerController(RgpdConfigController::class, new RgpdConfigController($twig, $editableContentService, $rgpdContentService, $settingService, $moduleManager, $journalService));

--- a/tests/Modules/Gallery/Controller/GalleryChiefControllerTest.php
+++ b/tests/Modules/Gallery/Controller/GalleryChiefControllerTest.php
@@ -153,6 +153,14 @@ class GalleryChiefControllerTest extends TestCase
         return $this->albumRepository->create(Album::TYPE_LOCAL, 'Camp', null, '2026-01-01', null, $this->scoutYearId, null, $this->locationId, $this->authorId);
     }
 
+    private function createDelegatedAlbum(): int
+    {
+        return $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Album délégué', null, '2026-01-01', null, $this->scoutYearId, null, $this->locationId,
+            $this->authorId, 'some_owner_type', 42
+        );
+    }
+
     /**
      * @param array<string, mixed> $data
      */
@@ -430,5 +438,62 @@ class GalleryChiefControllerTest extends TestCase
 
         $this->assertStringContainsString('Album indisponible', $response->getBody());
         $this->assertStringNotContainsString('gallery-upload-zone', $response->getBody());
+    }
+
+    public function testEditReturns404ForADelegatedAlbum(): void
+    {
+        $id = $this->createDelegatedAlbum();
+
+        $response = $this->controller->edit(new Request('GET', '/gallery/' . $id . '/edit', [], [], [], []), ['id' => (string) $id]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testUpdateReturns404ForADelegatedAlbum(): void
+    {
+        $id = $this->createDelegatedAlbum();
+        $token = $this->csrfToken();
+        $request = new Request('POST', '/gallery/' . $id, [], [
+            'title' => 'Nouveau titre', 'album_date' => '2026-01-01', '_csrf_token' => $token,
+        ], [], []);
+
+        $response = $this->controller->update($request, ['id' => (string) $id]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testUploadMediaReturns404ForADelegatedAlbum(): void
+    {
+        $id = $this->createDelegatedAlbum();
+        $token = $this->csrfToken();
+        $request = new Request('POST', '/gallery/' . $id . '/media', [], ['_csrf_token' => $token], [], []);
+
+        $response = $this->controller->uploadMedia($request, ['id' => (string) $id]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testReorderMediaReturns404ForADelegatedAlbum(): void
+    {
+        $id = $this->createDelegatedAlbum();
+        $token = $this->csrfToken();
+
+        $response = $this->controller->reorderMedia($this->jsonRequest(['ordered_ids' => [], '_csrf_token' => $token]), ['id' => (string) $id]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testDeleteMediaReturns404ForADelegatedAlbum(): void
+    {
+        $id = $this->createDelegatedAlbum();
+        $stmt = $this->pdo->prepare("INSERT INTO files (relative_path, original_name, mime_type, size_bytes, role_min) VALUES ('a', 'a', 'image/jpeg', 1, 'identified')");
+        $stmt->execute();
+        $fileId = (int) $this->pdo->lastInsertId();
+        $mediaId = $this->mediaRepository->create($id, 'photo', $fileId, 0, null);
+        $token = $this->csrfToken();
+
+        $response = $this->controller->deleteMedia($this->jsonRequest(['_csrf_token' => $token]), ['id' => (string) $id, 'media_id' => (string) $mediaId]);
+
+        $this->assertSame(404, $response->getStatusCode());
     }
 }

--- a/tests/Modules/Gallery/Controller/GalleryControllerTest.php
+++ b/tests/Modules/Gallery/Controller/GalleryControllerTest.php
@@ -210,11 +210,6 @@ class GalleryControllerTest extends TestCase
     }
 
     /**
-     * Photo renditions only — a photo media never gets an original_path
-     * (Repository\MediaRepository::markPhotoDone() sets thumb/medium/large
-     * only; only markVideoDone() also sets original), so "original" is
-     * covered separately below with a video-typed media.
-     *
      * @return array<string, string[]>
      */
     public static function mediaSizeProvider(): array
@@ -223,11 +218,23 @@ class GalleryControllerTest extends TestCase
             'thumb' => ['thumb'],
             'medium' => ['medium'],
             'large' => ['large'],
+            'original' => ['original'],
         ];
     }
 
-    private function createDoneVideoMedia(int $albumId): int
+    /**
+     * A photo media never gets an original_path (Repository\
+     * MediaRepository::markPhotoDone() sets thumb/medium/large only; only
+     * markVideoDone() also sets original) — so exercising "original"
+     * across the data-provider tests below needs a video-typed media
+     * instead, transparently to the caller.
+     */
+    private function createDoneMediaForSize(int $albumId, string $size): int
     {
+        if ($size !== 'original') {
+            return $this->createDoneMedia($albumId);
+        }
+
         $stmt = $this->pdo->prepare("INSERT INTO files (relative_path, original_name, mime_type, size_bytes, role_min) VALUES ('a', 'a', 'video/mp4', 1, 'identified')");
         $stmt->execute();
         $fileId = (int) $this->pdo->lastInsertId();
@@ -240,7 +247,7 @@ class GalleryControllerTest extends TestCase
     public function testServeMediaOnLocalStorageStreamsForAnAllowedMemberOfADelegatedAlbum(string $size): void
     {
         $albumId = $this->createDelegatedAlbum($this->locationId);
-        $mediaId = $this->createDoneMedia($albumId);
+        $mediaId = $this->createDoneMediaForSize($albumId, $size);
         $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
         $backend->method('get')->willReturn('fake-delegated-bytes');
         $this->storageBackendFactory->method('create')->willReturn($backend);
@@ -260,7 +267,7 @@ class GalleryControllerTest extends TestCase
     public function testServeMediaOnLocalStorageReturns404ForANonMemberOfADelegatedAlbum(string $size): void
     {
         $albumId = $this->createDelegatedAlbum($this->locationId);
-        $mediaId = $this->createDoneMedia($albumId);
+        $mediaId = $this->createDoneMediaForSize($albumId, $size);
         $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
         $backend->expects($this->never())->method('get');
         $this->storageBackendFactory->method('create')->willReturn($backend);
@@ -303,7 +310,7 @@ class GalleryControllerTest extends TestCase
     {
         $locationId = $this->createPrivateS3Location();
         $albumId = $this->createDelegatedAlbum($locationId);
-        $mediaId = $this->createDoneMedia($albumId);
+        $mediaId = $this->createDoneMediaForSize($albumId, $size);
         $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
         $backend->expects($this->once())->method('url')
             ->with($this->anything(), '+5 minutes')
@@ -321,87 +328,12 @@ class GalleryControllerTest extends TestCase
         $this->assertSame('private, no-store', $response->getHeaders()['Cache-Control']);
     }
 
-    public function testServeMediaOnLocalStorageStreamsTheOriginalRenditionForAnAllowedMemberOfADelegatedAlbum(): void
-    {
-        $albumId = $this->createDelegatedAlbum($this->locationId);
-        $mediaId = $this->createDoneVideoMedia($albumId);
-        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
-        $backend->method('get')->willReturn('fake-delegated-original-bytes');
-        $this->storageBackendFactory->method('create')->willReturn($backend);
-        $controller = $this->controllerWithRegistry($this->allowingRegistry());
-
-        $response = $controller->serveMedia(
-            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
-            ['media_id' => (string) $mediaId, 'size' => 'original']
-        );
-
-        $this->assertSame(200, $response->getStatusCode());
-        $this->assertSame('fake-delegated-original-bytes', $response->getBody());
-        $this->assertSame('private, no-store', $response->getHeaders()['Cache-Control']);
-    }
-
-    public function testServeMediaOnLocalStorageReturns404ForANonMemberRequestingTheOriginalRendition(): void
-    {
-        $albumId = $this->createDelegatedAlbum($this->locationId);
-        $mediaId = $this->createDoneVideoMedia($albumId);
-        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
-        $backend->expects($this->never())->method('get');
-        $this->storageBackendFactory->method('create')->willReturn($backend);
-        $controller = $this->controllerWithRegistry($this->denyingRegistry());
-
-        $response = $controller->serveMedia(
-            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
-            ['media_id' => (string) $mediaId, 'size' => 'original']
-        );
-
-        $this->assertSame(404, $response->getStatusCode());
-    }
-
-    public function testServeMediaOnS3RedirectsToAPresignedUrlForTheOriginalRenditionForAnAllowedMember(): void
-    {
-        $locationId = $this->createPrivateS3Location();
-        $albumId = $this->createDelegatedAlbum($locationId);
-        $mediaId = $this->createDoneVideoMedia($albumId);
-        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
-        $backend->expects($this->once())->method('url')
-            ->with($this->anything(), '+5 minutes')
-            ->willReturn('https://s3.example.com/bucket/presigned-original?sig=abc');
-        $this->storageBackendFactory->method('create')->willReturn($backend);
-        $controller = $this->controllerWithRegistry($this->allowingRegistry());
-
-        $response = $controller->serveMedia(
-            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
-            ['media_id' => (string) $mediaId, 'size' => 'original']
-        );
-
-        $this->assertSame(302, $response->getStatusCode());
-        $this->assertSame('https://s3.example.com/bucket/presigned-original?sig=abc', $response->getHeaders()['Location']);
-    }
-
-    public function testServeMediaOnS3Returns404ForANonMemberRequestingTheOriginalRendition(): void
-    {
-        $locationId = $this->createPrivateS3Location();
-        $albumId = $this->createDelegatedAlbum($locationId);
-        $mediaId = $this->createDoneVideoMedia($albumId);
-        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
-        $backend->expects($this->never())->method('url');
-        $this->storageBackendFactory->method('create')->willReturn($backend);
-        $controller = $this->controllerWithRegistry($this->denyingRegistry());
-
-        $response = $controller->serveMedia(
-            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
-            ['media_id' => (string) $mediaId, 'size' => 'original']
-        );
-
-        $this->assertSame(404, $response->getStatusCode());
-    }
-
     #[\PHPUnit\Framework\Attributes\DataProvider('mediaSizeProvider')]
     public function testServeMediaOnS3Returns404ForANonMemberOfADelegatedAlbum(string $size): void
     {
         $locationId = $this->createPrivateS3Location();
         $albumId = $this->createDelegatedAlbum($locationId);
-        $mediaId = $this->createDoneMedia($albumId);
+        $mediaId = $this->createDoneMediaForSize($albumId, $size);
         $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
         $backend->expects($this->never())->method('url');
         $this->storageBackendFactory->method('create')->willReturn($backend);

--- a/tests/Modules/Gallery/Controller/GalleryControllerTest.php
+++ b/tests/Modules/Gallery/Controller/GalleryControllerTest.php
@@ -26,7 +26,9 @@ use Modules\Gallery\Repository\MediaRepository;
 use Modules\Gallery\Repository\S3SecretRepository;
 use Modules\Gallery\Repository\StorageLocation;
 use Modules\Gallery\Repository\StorageLocationRepository;
+use Modules\Gallery\Api\DelegatedAlbumAccessChecker;
 use Modules\Gallery\Service\AlbumService;
+use Modules\Gallery\Service\DelegatedAlbumAccessRegistry;
 use Modules\Gallery\Service\FfmpegAvailability;
 use Modules\Gallery\Service\GalleryAccessService;
 use Modules\Gallery\Service\MediaService;
@@ -51,7 +53,14 @@ class GalleryControllerTest extends TestCase
     private AlbumRepository $albumRepository;
     private MediaRepository $mediaRepository;
     private MediaService $mediaService;
+    private AlbumService $albumService;
     private StorageBackendFactory $storageBackendFactory;
+    private StorageLocationService $storageLocationService;
+    private StorageLocationRepository $storageLocationRepository;
+    private Environment $twig;
+    private MemberService $memberService;
+    private SectionService $sectionService;
+    private ScoutYearService $scoutYearService;
     private int $authorId;
     private int $scoutYearId;
     private int $sectionId;
@@ -67,33 +76,33 @@ class GalleryControllerTest extends TestCase
         $this->albumRepository = new AlbumRepository($this->pdo);
         $this->mediaRepository = new MediaRepository($this->pdo);
         $memberBadgeRepository = new MemberBadgeRepository($this->pdo);
-        $sectionService = new SectionService($connection, $encryption, $memberBadgeRepository);
+        $this->sectionService = new SectionService($connection, $encryption, $memberBadgeRepository);
         $memberYearRepo = new MemberYearRepository($this->pdo);
-        $memberService = new MemberService($memberYearRepo, $encryption, $connection);
-        $scoutYearService = new ScoutYearService($this->pdo);
+        $this->memberService = new MemberService($memberYearRepo, $encryption, $connection);
+        $this->scoutYearService = new ScoutYearService($this->pdo);
         $settingService = $this->createMock(SettingService::class);
         $settingService->method('get')->willReturnCallback(fn($key, $module, $default) => $default);
 
-        $accessService = new GalleryAccessService($memberService, $sectionService, $scoutYearService);
-        $storageLocationRepository = new StorageLocationRepository($this->pdo, $encryption);
+        $accessService = new GalleryAccessService($this->memberService, $this->sectionService, $this->scoutYearService);
+        $this->storageLocationRepository = new StorageLocationRepository($this->pdo, $encryption);
         $this->storageBackendFactory = $this->createMock(StorageBackendFactory::class);
-        $storageLocationService = new StorageLocationService(
-            $storageLocationRepository, $this->albumRepository, $this->storageBackendFactory, $settingService,
+        $this->storageLocationService = new StorageLocationService(
+            $this->storageLocationRepository, $this->albumRepository, $this->storageBackendFactory, $settingService,
             new S3SecretRepository($this->pdo, $encryption), sys_get_temp_dir()
         );
 
         $uploadHandler = new UploadHandler(new FileRepository($this->pdo), sys_get_temp_dir());
-        $albumService = new AlbumService(
+        $this->albumService = new AlbumService(
             $this->albumRepository, $this->mediaRepository, $accessService, $this->createMock(OgScraperService::class),
-            $this->storageBackendFactory, $storageLocationRepository, $storageLocationService, $scoutYearService, $settingService,
+            $this->storageBackendFactory, $this->storageLocationRepository, $this->storageLocationService, $this->scoutYearService, $settingService,
             $this->createMock(SchedulerService::class), $uploadHandler
         );
         $this->mediaService = new MediaService(
             $this->mediaRepository, $this->albumRepository, $uploadHandler, new SchedulerService(new SchedulerRepository($this->pdo)),
-            $settingService, $accessService, $this->storageBackendFactory, $storageLocationService, $this->createMock(FfmpegAvailability::class)
+            $settingService, $accessService, $this->storageBackendFactory, $this->storageLocationService, $this->createMock(FfmpegAvailability::class)
         );
 
-        $this->locationId = $storageLocationRepository->create(
+        $this->locationId = $this->storageLocationRepository->create(
             StorageLocation::TYPE_LOCAL, 'Stockage local', 'gallery', null, null, null, null, null, null, null
         );
 
@@ -114,23 +123,23 @@ class GalleryControllerTest extends TestCase
         $moduleViews = dirname(__DIR__, 4) . '/modules/gallery/views';
         $loader = new FilesystemLoader($templateDir);
         $loader->addPath($moduleViews, 'gallery');
-        $twig = new Environment($loader, ['cache' => false, 'autoescape' => 'html']);
-        $twig->addGlobal('site_name', 'Test');
-        $twig->addGlobal('is_authenticated', true);
-        $twig->addGlobal('current_user_role', 'identified');
-        $twig->addGlobal('config_mode', false);
-        $twig->addGlobal('cookie_consent_given', true);
-        $twig->addGlobal('menus', null);
-        $twig->addGlobal('csp_nonce', 'test-nonce');
-        $twig->addFunction(new TwigFunction('csrf_field', fn() => '<input type="hidden" name="_csrf_token" value="test">', ['is_safe' => ['html']]));
-        $twig->addFunction(new TwigFunction('get_flash', fn() => null));
-        $twig->addFunction(new TwigFunction('csrf_token', fn() => 'test'));
-        $twig->addFunction(new TwigFunction('file_url', fn() => ''));
-        $twig->addFilter(new \Twig\TwigFilter('french_date', fn($d) => (string) $d));
+        $this->twig = new Environment($loader, ['cache' => false, 'autoescape' => 'html']);
+        $this->twig->addGlobal('site_name', 'Test');
+        $this->twig->addGlobal('is_authenticated', true);
+        $this->twig->addGlobal('current_user_role', 'identified');
+        $this->twig->addGlobal('config_mode', false);
+        $this->twig->addGlobal('cookie_consent_given', true);
+        $this->twig->addGlobal('menus', null);
+        $this->twig->addGlobal('csp_nonce', 'test-nonce');
+        $this->twig->addFunction(new TwigFunction('csrf_field', fn() => '<input type="hidden" name="_csrf_token" value="test">', ['is_safe' => ['html']]));
+        $this->twig->addFunction(new TwigFunction('get_flash', fn() => null));
+        $this->twig->addFunction(new TwigFunction('csrf_token', fn() => 'test'));
+        $this->twig->addFunction(new TwigFunction('file_url', fn() => ''));
+        $this->twig->addFilter(new \Twig\TwigFilter('french_date', fn($d) => (string) $d));
 
         $this->controller = new GalleryController(
-            $twig, $albumService, $this->mediaService, $this->mediaRepository, $memberService,
-            $sectionService, $scoutYearService, $this->storageBackendFactory, $storageLocationService
+            $this->twig, $this->albumService, $this->mediaService, $this->mediaRepository, $this->memberService,
+            $this->sectionService, $this->scoutYearService, $this->storageBackendFactory, $this->storageLocationService
         );
 
         if (session_status() === PHP_SESSION_NONE) {
@@ -147,6 +156,289 @@ class GalleryControllerTest extends TestCase
     private function createLocalAlbum(?int $sectionId = null): int
     {
         return $this->albumRepository->create(Album::TYPE_LOCAL, 'Camp', null, '2026-01-01', $sectionId, $this->scoutYearId, null, $this->locationId, $this->authorId);
+    }
+
+    private function createDelegatedAlbum(int $locationId): int
+    {
+        return $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Album délégué', null, '2026-01-01', null, $this->scoutYearId, null, $locationId,
+            $this->authorId, 'some_owner_type', 42
+        );
+    }
+
+    private function controllerWithRegistry(DelegatedAlbumAccessRegistry $registry): GalleryController
+    {
+        return new GalleryController(
+            $this->twig, $this->albumService, $this->mediaService, $this->mediaRepository, $this->memberService,
+            $this->sectionService, $this->scoutYearService, $this->storageBackendFactory, $this->storageLocationService,
+            $registry
+        );
+    }
+
+    private function allowingRegistry(): DelegatedAlbumAccessRegistry
+    {
+        $checker = $this->createMock(DelegatedAlbumAccessChecker::class);
+        $checker->method('supports')->willReturn(true);
+        $checker->method('isAllowed')->willReturn(true);
+        return new DelegatedAlbumAccessRegistry([$checker]);
+    }
+
+    private function denyingRegistry(): DelegatedAlbumAccessRegistry
+    {
+        $checker = $this->createMock(DelegatedAlbumAccessChecker::class);
+        $checker->method('supports')->willReturn(true);
+        $checker->method('isAllowed')->willReturn(false);
+        return new DelegatedAlbumAccessRegistry([$checker]);
+    }
+
+    public function testShowReturns404ForADelegatedAlbum(): void
+    {
+        $id = $this->createDelegatedAlbum($this->locationId);
+
+        $response = $this->controller->show(new Request('GET', '/gallery/' . $id, [], [], [], []), ['id' => (string) $id]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testDownloadZipReturns404ForADelegatedAlbum(): void
+    {
+        $id = $this->createDelegatedAlbum($this->locationId);
+
+        $response = $this->controller->downloadZip(new Request('GET', '/gallery/' . $id . '/download', [], [], [], []), ['id' => (string) $id]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    /**
+     * Photo renditions only — a photo media never gets an original_path
+     * (Repository\MediaRepository::markPhotoDone() sets thumb/medium/large
+     * only; only markVideoDone() also sets original), so "original" is
+     * covered separately below with a video-typed media.
+     *
+     * @return array<string, string[]>
+     */
+    public static function mediaSizeProvider(): array
+    {
+        return [
+            'thumb' => ['thumb'],
+            'medium' => ['medium'],
+            'large' => ['large'],
+        ];
+    }
+
+    private function createDoneVideoMedia(int $albumId): int
+    {
+        $stmt = $this->pdo->prepare("INSERT INTO files (relative_path, original_name, mime_type, size_bytes, role_min) VALUES ('a', 'a', 'video/mp4', 1, 'identified')");
+        $stmt->execute();
+        $fileId = (int) $this->pdo->lastInsertId();
+        $mediaId = $this->mediaRepository->create($albumId, 'video', $fileId, 0, null);
+        $this->mediaRepository->markVideoDone($mediaId, 'thumb.jpg', 'med.mp4', 'lg.mp4', 'orig.mp4', 100, 100, 30);
+        return $mediaId;
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('mediaSizeProvider')]
+    public function testServeMediaOnLocalStorageStreamsForAnAllowedMemberOfADelegatedAlbum(string $size): void
+    {
+        $albumId = $this->createDelegatedAlbum($this->locationId);
+        $mediaId = $this->createDoneMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->method('get')->willReturn('fake-delegated-bytes');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->allowingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/' . $size, [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => $size]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('fake-delegated-bytes', $response->getBody());
+        $this->assertSame('private, no-store', $response->getHeaders()['Cache-Control']);
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('mediaSizeProvider')]
+    public function testServeMediaOnLocalStorageReturns404ForANonMemberOfADelegatedAlbum(string $size): void
+    {
+        $albumId = $this->createDelegatedAlbum($this->locationId);
+        $mediaId = $this->createDoneMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->expects($this->never())->method('get');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->denyingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/' . $size, [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => $size]
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testServeMediaReturns404ForADelegatedAlbumWithAnUnregisteredOwnerType(): void
+    {
+        $albumId = $this->createDelegatedAlbum($this->locationId);
+        $mediaId = $this->createDoneMedia($albumId);
+        // No checker at all in the registry — same fail-closed contract as
+        // a checker that actively denies (Service\DelegatedAlbumAccessRegistryTest).
+        $controller = $this->controllerWithRegistry(new DelegatedAlbumAccessRegistry([]));
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/thumb', [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => 'thumb']
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    private function createPrivateS3Location(): int
+    {
+        return $this->storageLocationRepository->create(
+            StorageLocation::TYPE_S3, 'Bucket privé', null, 'custom', 'https://s3.example.com', 'eu',
+            'bucket', 'ak', null, 'sk'
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('mediaSizeProvider')]
+    public function testServeMediaOnS3RedirectsToAFreshPresignedUrlForAnAllowedMemberOfADelegatedAlbum(string $size): void
+    {
+        $locationId = $this->createPrivateS3Location();
+        $albumId = $this->createDelegatedAlbum($locationId);
+        $mediaId = $this->createDoneMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->expects($this->once())->method('url')
+            ->with($this->anything(), '+5 minutes')
+            ->willReturn('https://s3.example.com/bucket/presigned?sig=abc');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->allowingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/' . $size, [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => $size]
+        );
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('https://s3.example.com/bucket/presigned?sig=abc', $response->getHeaders()['Location']);
+        $this->assertSame('private, no-store', $response->getHeaders()['Cache-Control']);
+    }
+
+    public function testServeMediaOnLocalStorageStreamsTheOriginalRenditionForAnAllowedMemberOfADelegatedAlbum(): void
+    {
+        $albumId = $this->createDelegatedAlbum($this->locationId);
+        $mediaId = $this->createDoneVideoMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->method('get')->willReturn('fake-delegated-original-bytes');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->allowingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => 'original']
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('fake-delegated-original-bytes', $response->getBody());
+        $this->assertSame('private, no-store', $response->getHeaders()['Cache-Control']);
+    }
+
+    public function testServeMediaOnLocalStorageReturns404ForANonMemberRequestingTheOriginalRendition(): void
+    {
+        $albumId = $this->createDelegatedAlbum($this->locationId);
+        $mediaId = $this->createDoneVideoMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->expects($this->never())->method('get');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->denyingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => 'original']
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testServeMediaOnS3RedirectsToAPresignedUrlForTheOriginalRenditionForAnAllowedMember(): void
+    {
+        $locationId = $this->createPrivateS3Location();
+        $albumId = $this->createDelegatedAlbum($locationId);
+        $mediaId = $this->createDoneVideoMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->expects($this->once())->method('url')
+            ->with($this->anything(), '+5 minutes')
+            ->willReturn('https://s3.example.com/bucket/presigned-original?sig=abc');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->allowingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => 'original']
+        );
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('https://s3.example.com/bucket/presigned-original?sig=abc', $response->getHeaders()['Location']);
+    }
+
+    public function testServeMediaOnS3Returns404ForANonMemberRequestingTheOriginalRendition(): void
+    {
+        $locationId = $this->createPrivateS3Location();
+        $albumId = $this->createDelegatedAlbum($locationId);
+        $mediaId = $this->createDoneVideoMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->expects($this->never())->method('url');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->denyingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/original', [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => 'original']
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('mediaSizeProvider')]
+    public function testServeMediaOnS3Returns404ForANonMemberOfADelegatedAlbum(string $size): void
+    {
+        $locationId = $this->createPrivateS3Location();
+        $albumId = $this->createDelegatedAlbum($locationId);
+        $mediaId = $this->createDoneMedia($albumId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->expects($this->never())->method('url');
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->denyingRegistry());
+
+        $response = $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/' . $size, [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => $size]
+        );
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testServeMediaOnDelegatedAlbumUsesAShorterPresignTtlThanTheOrdinaryDefault(): void
+    {
+        // Module spec: the delegated TTL must be short — distinct from and
+        // shorter than S3StorageBackend::url()'s ordinary +1 hour default.
+        $locationId = $this->createPrivateS3Location();
+        $albumId = $this->createDelegatedAlbum($locationId);
+        $mediaId = $this->createDoneMedia($albumId);
+        $usedTtl = null;
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->method('url')->willReturnCallback(function (string $key, string $ttl = '+1 hour') use (&$usedTtl) {
+            $usedTtl = $ttl;
+            return 'https://s3.example.com/x';
+        });
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+        $controller = $this->controllerWithRegistry($this->allowingRegistry());
+
+        $controller->serveMedia(
+            new Request('GET', '/gallery/media/' . $mediaId . '/thumb', [], [], [], []),
+            ['media_id' => (string) $mediaId, 'size' => 'thumb']
+        );
+
+        $this->assertNotNull($usedTtl);
+        $this->assertNotSame('+1 hour', $usedTtl);
+        $this->assertSame('+5 minutes', $usedTtl);
     }
 
     public function testIndexShowsUnitWideAlbum(): void

--- a/tests/Modules/Gallery/GalleryTestHelper.php
+++ b/tests/Modules/Gallery/GalleryTestHelper.php
@@ -42,6 +42,8 @@ class GalleryTestHelper
             og_image_url TEXT NULL,
             og_image_file_id INTEGER NULL,
             storage_location_id INTEGER NULL,
+            owner_type TEXT NULL,
+            owner_id INTEGER NULL,
             migration_status TEXT NOT NULL DEFAULT "none",
             migration_target_location_id INTEGER NULL,
             migration_error TEXT NULL,

--- a/tests/Modules/Gallery/Repository/AlbumRepositoryTest.php
+++ b/tests/Modules/Gallery/Repository/AlbumRepositoryTest.php
@@ -159,4 +159,90 @@ class AlbumRepositoryTest extends TestCase
 
         $this->assertSame([], $this->repository->findVisible([], []));
     }
+
+    // --- Delegated albums (owner_type/owner_id) -------------------------
+
+    public function testCreateWithOwnerMarksTheAlbumDelegated(): void
+    {
+        $id = $this->repository->create(
+            Album::TYPE_LOCAL, 'Groupe Louveteaux', null, '2026-01-01', null, $this->scoutYearId, null, null,
+            $this->authorId, 'discussion_group', 42
+        );
+
+        $album = $this->repository->findById($id);
+
+        $this->assertTrue($album->isDelegated());
+        $this->assertSame('discussion_group', $album->ownerType);
+        $this->assertSame(42, $album->ownerId);
+    }
+
+    public function testAnOrdinaryAlbumIsNeverDelegated(): void
+    {
+        $id = $this->repository->create(Album::TYPE_LOCAL, 'Camp', null, '2026-01-01', null, $this->scoutYearId, null, null, $this->authorId);
+
+        $album = $this->repository->findById($id);
+
+        $this->assertFalse($album->isDelegated());
+        $this->assertNull($album->ownerType);
+        $this->assertNull($album->ownerId);
+    }
+
+    public function testFindByOwnerFindsTheDelegatedAlbum(): void
+    {
+        $id = $this->repository->create(
+            Album::TYPE_LOCAL, 'Groupe Louveteaux', null, '2026-01-01', null, $this->scoutYearId, null, null,
+            $this->authorId, 'discussion_group', 42
+        );
+
+        $found = $this->repository->findByOwner('discussion_group', 42);
+
+        $this->assertNotNull($found);
+        $this->assertSame($id, $found->id);
+    }
+
+    public function testFindByOwnerReturnsNullWhenNoAlbumMatches(): void
+    {
+        $this->assertNull($this->repository->findByOwner('discussion_group', 999));
+    }
+
+    public function testFindByOwnerNeverMatchesADifferentOwnerType(): void
+    {
+        $this->repository->create(
+            Album::TYPE_LOCAL, 'Groupe Louveteaux', null, '2026-01-01', null, $this->scoutYearId, null, null,
+            $this->authorId, 'discussion_group', 42
+        );
+
+        $this->assertNull($this->repository->findByOwner('some_other_type', 42));
+    }
+
+    public function testFindAllExcludesDelegatedAlbums(): void
+    {
+        $ordinaryId = $this->repository->create(Album::TYPE_LOCAL, 'Camp', null, '2026-01-01', null, $this->scoutYearId, null, null, $this->authorId);
+        $this->repository->create(
+            Album::TYPE_LOCAL, 'Délégué', null, '2026-01-01', null, $this->scoutYearId, null, null,
+            $this->authorId, 'discussion_group', 42
+        );
+
+        $ids = array_map(fn(Album $a) => $a->id, $this->repository->findAll());
+
+        $this->assertContains($ordinaryId, $ids);
+        $this->assertCount(1, $ids);
+    }
+
+    public function testFindVisibleExcludesDelegatedAlbumsEvenUnitWide(): void
+    {
+        $ordinaryId = $this->repository->create(Album::TYPE_LOCAL, 'Camp', null, '2026-01-01', null, $this->scoutYearId, null, null, $this->authorId);
+        // A delegated album with no section (unit-wide by gallery's own
+        // reasoning) must still never surface here.
+        $this->repository->create(
+            Album::TYPE_LOCAL, 'Délégué', null, '2026-01-01', null, $this->scoutYearId, null, null,
+            $this->authorId, 'discussion_group', 42
+        );
+
+        $visible = $this->repository->findVisible([], [$this->scoutYearId]);
+        $ids = array_map(fn(Album $a) => $a->id, $visible);
+
+        $this->assertContains($ordinaryId, $ids);
+        $this->assertCount(1, $ids);
+    }
 }

--- a/tests/Modules/Gallery/Service/AlbumServiceTest.php
+++ b/tests/Modules/Gallery/Service/AlbumServiceTest.php
@@ -413,6 +413,58 @@ class AlbumServiceTest extends TestCase
         $this->service->delete($id, Role::CHIEF, 'chief@test.com');
     }
 
+    public function testUpdateThrowsForADelegatedAlbum(): void
+    {
+        $id = $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Titre', null, '2026-01-01', null, $this->scoutYearId, null, $this->locationId,
+            $this->authorId, 'some_owner_type', 42
+        );
+
+        $this->expectException(GalleryException::class);
+        $this->service->update($id, 'Nouveau titre', null, '2026-01-01', null, null, Role::CHIEF, 'chief@test.com');
+    }
+
+    public function testDeleteThrowsForADelegatedAlbum(): void
+    {
+        $id = $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Titre', null, '2026-01-01', null, $this->scoutYearId, null, $this->locationId,
+            $this->authorId, 'some_owner_type', 42
+        );
+
+        $this->expectException(GalleryException::class);
+        $this->service->delete($id, Role::CHIEF, 'chief@test.com');
+    }
+
+    public function testSetCoverThrowsForADelegatedAlbum(): void
+    {
+        $id = $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Titre', null, '2026-01-01', null, $this->scoutYearId, null, $this->locationId,
+            $this->authorId, 'some_owner_type', 42
+        );
+        $stmt = $this->pdo->prepare("INSERT INTO files (relative_path, original_name, mime_type, size_bytes, role_min) VALUES ('a', 'a', 'image/jpeg', 1, 'identified')");
+        $stmt->execute();
+        $fileId = (int) $this->pdo->lastInsertId();
+        $mediaId = (new MediaRepository($this->pdo))->create($id, 'photo', $fileId, 0, null);
+
+        $this->expectException(GalleryException::class);
+        $this->service->setCover($id, $mediaId, Role::CHIEF, 'chief@test.com');
+    }
+
+    public function testStartMigrationThrowsForADelegatedAlbum(): void
+    {
+        $id = $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Titre', null, '2026-01-01', null, $this->scoutYearId, null, $this->locationId,
+            $this->authorId, 'some_owner_type', 42
+        );
+        $targetId = $this->storageLocationRepository->create(
+            StorageLocation::TYPE_LOCAL, 'Autre emplacement', 'gallery2', null, null, null, null, null, null, null
+        );
+        $this->storageLocationRepository->recordCheckResult($targetId, true, null);
+
+        $this->expectException(GalleryException::class);
+        $this->service->startMigration($id, $targetId, Role::CHIEF, 'chief@test.com');
+    }
+
     private function settingServiceAllowingEverything(): SettingService
     {
         $settingService = $this->createMock(SettingService::class);

--- a/tests/Modules/Gallery/Service/DelegatedAlbumAccessRegistryTest.php
+++ b/tests/Modules/Gallery/Service/DelegatedAlbumAccessRegistryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Gallery\Service;
+
+use Core\Security\Role;
+use Modules\Gallery\Api\DelegatedAlbumAccessChecker;
+use Modules\Gallery\Service\DelegatedAlbumAccessRegistry;
+use PHPUnit\Framework\TestCase;
+
+class DelegatedAlbumAccessRegistryTest extends TestCase
+{
+    public function testDeniesWhenNoCheckerIsRegistered(): void
+    {
+        $registry = new DelegatedAlbumAccessRegistry([]);
+
+        $this->assertFalse($registry->isAllowed('some_owner_type', 1, Role::CHIEF, []));
+    }
+
+    public function testDeniesWhenNoCheckerSupportsTheOwnerType(): void
+    {
+        $checker = $this->createMock(DelegatedAlbumAccessChecker::class);
+        $checker->method('supports')->willReturn(false);
+        $checker->expects($this->never())->method('isAllowed');
+        $registry = new DelegatedAlbumAccessRegistry([$checker]);
+
+        $this->assertFalse($registry->isAllowed('some_owner_type', 1, Role::CHIEF, []));
+    }
+
+    public function testDelegatesToTheCheckerThatSupportsTheOwnerType(): void
+    {
+        $checker = $this->createMock(DelegatedAlbumAccessChecker::class);
+        $checker->expects($this->once())->method('supports')->with('some_owner_type')->willReturn(true);
+        $checker->expects($this->once())->method('isAllowed')->with(42, Role::CHIEF, [1, 2])->willReturn(true);
+        $registry = new DelegatedAlbumAccessRegistry([$checker]);
+
+        $this->assertTrue($registry->isAllowed('some_owner_type', 42, Role::CHIEF, [1, 2]));
+    }
+
+    public function testReturnsFalseWhenTheSupportingCheckerDenies(): void
+    {
+        $checker = $this->createMock(DelegatedAlbumAccessChecker::class);
+        $checker->expects($this->once())->method('supports')->willReturn(true);
+        $checker->expects($this->once())->method('isAllowed')->willReturn(false);
+        $registry = new DelegatedAlbumAccessRegistry([$checker]);
+
+        $this->assertFalse($registry->isAllowed('some_owner_type', 42, Role::CHIEF, []));
+    }
+
+    public function testTheFirstMatchingCheckerWins(): void
+    {
+        $first = $this->createMock(DelegatedAlbumAccessChecker::class);
+        $first->expects($this->once())->method('supports')->willReturn(true);
+        $first->expects($this->once())->method('isAllowed')->willReturn(true);
+        $second = $this->createMock(DelegatedAlbumAccessChecker::class);
+        $second->expects($this->never())->method('supports');
+        $registry = new DelegatedAlbumAccessRegistry([$first, $second]);
+
+        $this->assertTrue($registry->isAllowed('some_owner_type', 42, Role::CHIEF, []));
+    }
+}

--- a/tests/Modules/Gallery/Service/DelegatedAlbumServiceTest.php
+++ b/tests/Modules/Gallery/Service/DelegatedAlbumServiceTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Gallery\Service;
+
+use Core\Config\ScoutYearService;
+use Core\Config\SettingService;
+use Core\Security\EncryptionService;
+use Modules\Gallery\Repository\Album;
+use Modules\Gallery\Repository\AlbumRepository;
+use Modules\Gallery\Repository\MediaRepository;
+use Modules\Gallery\Repository\S3SecretRepository;
+use Modules\Gallery\Repository\StorageLocation;
+use Modules\Gallery\Repository\StorageLocationRepository;
+use Modules\Gallery\Service\DelegatedAlbumService;
+use Modules\Gallery\Service\GalleryException;
+use Modules\Gallery\Service\MediaService;
+use Modules\Gallery\Service\Storage\StorageBackendFactory;
+use Modules\Gallery\Service\StorageLocationService;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Gallery\GalleryTestHelper;
+
+/**
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class DelegatedAlbumServiceTest extends TestCase
+{
+    private \PDO $pdo;
+    private AlbumRepository $albumRepository;
+    private MediaRepository $mediaRepository;
+    private StorageLocationRepository $storageLocationRepository;
+    private StorageBackendFactory $storageBackendFactory;
+    private DelegatedAlbumService $service;
+    private int $authorId;
+    private int $localLocationId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        GalleryTestHelper::createTables($this->pdo);
+
+        $this->albumRepository = new AlbumRepository($this->pdo);
+        $this->mediaRepository = new MediaRepository($this->pdo);
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->storageLocationRepository = new StorageLocationRepository($this->pdo, $encryption);
+        $this->storageBackendFactory = $this->createMock(StorageBackendFactory::class);
+        $settingService = $this->createMock(SettingService::class);
+        $settingService->method('get')->willReturnCallback(fn($key, $module, $default) => $default);
+        $storageLocationService = new StorageLocationService(
+            $this->storageLocationRepository, $this->albumRepository, $this->storageBackendFactory,
+            $settingService, new S3SecretRepository($this->pdo, $encryption), sys_get_temp_dir()
+        );
+        $mediaService = $this->createMock(MediaService::class);
+
+        $stmt = $this->pdo->prepare('INSERT INTO user_accounts (email_encrypted, email_blind_index) VALUES (?, ?)');
+        $stmt->execute(['enc', 'idx']);
+        $this->authorId = (int) $this->pdo->lastInsertId();
+
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+
+        $this->localLocationId = $this->storageLocationRepository->create(
+            StorageLocation::TYPE_LOCAL, 'Stockage local', 'gallery', null, null, null, null, null, null, null
+        );
+
+        $this->service = new DelegatedAlbumService(
+            $this->albumRepository, $this->mediaRepository, $mediaService, $this->storageLocationRepository,
+            $storageLocationService, $this->storageBackendFactory, new ScoutYearService($this->pdo)
+        );
+    }
+
+    public function testEnsureAlbumCreatesADelegatedAlbumOnFirstCall(): void
+    {
+        $album = $this->service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId);
+
+        $this->assertSame('Titre', $album->title);
+        $stored = $this->albumRepository->findByOwner('some_owner_type', 42);
+        $this->assertNotNull($stored);
+        $this->assertTrue($stored->isDelegated());
+        $this->assertSame($this->localLocationId, $stored->storageLocationId);
+    }
+
+    public function testEnsureAlbumIsIdempotentAndReturnsTheSameAlbumOnASecondCall(): void
+    {
+        $first = $this->service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId);
+        $second = $this->service->ensureAlbum('some_owner_type', 42, 'Titre différent', '2026-02-02', $this->authorId);
+
+        $this->assertSame($first->id, $second->id);
+        $this->assertSame('Titre', $second->title);
+        $this->assertSame(1, (int) $this->pdo->query('SELECT COUNT(*) FROM gallery_albums')->fetchColumn());
+    }
+
+    public function testEnsureAlbumRefusesAStorageLocationWithAPublicUrlConfigured(): void
+    {
+        $publicLocationId = $this->storageLocationRepository->create(
+            StorageLocation::TYPE_S3, 'Bucket public', null, 'custom', 'https://s3.example.com', 'eu',
+            'bucket', 'ak', 'https://cdn.example.com', 'sk'
+        );
+
+        $this->expectException(GalleryException::class);
+        $this->service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId, $publicLocationId);
+    }
+
+    public function testEnsureAlbumAcceptsAPrivateS3Location(): void
+    {
+        $privateLocationId = $this->storageLocationRepository->create(
+            StorageLocation::TYPE_S3, 'Bucket privé', null, 'custom', 'https://s3.example.com', 'eu',
+            'bucket', 'ak', null, 'sk'
+        );
+
+        $album = $this->service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId, $privateLocationId);
+
+        $stored = $this->albumRepository->findById($album->id);
+        $this->assertSame($privateLocationId, $stored->storageLocationId);
+    }
+
+    public function testListMediaThrowsForAnUnknownAlbum(): void
+    {
+        $this->expectException(GalleryException::class);
+        $this->service->listMedia(999999);
+    }
+
+    public function testListMediaThrowsForAnOrdinaryNonDelegatedAlbum(): void
+    {
+        $ordinaryId = $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Ordinaire', null, '2026-01-01', null, 1, null, $this->localLocationId, $this->authorId
+        );
+
+        $this->expectException(GalleryException::class);
+        $this->service->listMedia($ordinaryId);
+    }
+
+    public function testListMediaReturnsTheAlbumsMedia(): void
+    {
+        $album = $this->service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId);
+        $stmt = $this->pdo->prepare("INSERT INTO files (relative_path, original_name, mime_type, size_bytes, role_min) VALUES ('a', 'a', 'image/jpeg', 1, 'identified')");
+        $stmt->execute();
+        $fileId = (int) $this->pdo->lastInsertId();
+        $this->mediaRepository->create($album->id, 'photo', $fileId, 0, 'photo.jpg');
+
+        $media = $this->service->listMedia($album->id);
+
+        $this->assertCount(1, $media);
+        $this->assertSame('photo.jpg', $media[0]->originalFilename);
+    }
+
+    public function testDeleteMediaThrowsWhenTheMediaBelongsToAnotherAlbum(): void
+    {
+        $album = $this->service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId);
+        $otherAlbum = $this->service->ensureAlbum('some_owner_type', 43, 'Autre', '2026-01-01', $this->authorId);
+        $stmt = $this->pdo->prepare("INSERT INTO files (relative_path, original_name, mime_type, size_bytes, role_min) VALUES ('a', 'a', 'image/jpeg', 1, 'identified')");
+        $stmt->execute();
+        $fileId = (int) $this->pdo->lastInsertId();
+        $mediaId = $this->mediaRepository->create($otherAlbum->id, 'photo', $fileId, 0, null);
+
+        $this->expectException(GalleryException::class);
+        $this->service->deleteMedia($album->id, $mediaId);
+    }
+
+    public function testDeleteAlbumRemovesTheAlbumRowAndCleansUpStorage(): void
+    {
+        $album = $this->service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId);
+        $backend = $this->createMock(\Modules\Gallery\Service\Storage\StorageBackendInterface::class);
+        $backend->expects($this->once())->method('deletePrefix')->with((string) $album->id);
+        $this->storageBackendFactory->method('create')->willReturn($backend);
+
+        $this->service->deleteAlbum($album->id);
+
+        $this->assertNull($this->albumRepository->findById($album->id));
+    }
+
+    public function testDeleteAlbumThrowsForAnUnknownAlbum(): void
+    {
+        $this->expectException(GalleryException::class);
+        $this->service->deleteAlbum(999999);
+    }
+}

--- a/tests/Modules/Gallery/Service/GalleryMemberQueryServiceTest.php
+++ b/tests/Modules/Gallery/Service/GalleryMemberQueryServiceTest.php
@@ -144,4 +144,19 @@ class GalleryMemberQueryServiceTest extends TestCase
 
         $this->assertCount(2, $result);
     }
+
+    public function testNeverReturnsADelegatedAlbumEvenUnitWide(): void
+    {
+        // Api\GalleryAlbumProvider is a public entry point any core/module
+        // consumer can call — a delegated album must stay reachable only
+        // through its own owning module, never through this one.
+        $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Groupe Louveteaux', null, '2026-01-01', null, $this->scoutYearId, null, null,
+            $this->authorId, 'discussion_group', 42
+        );
+
+        $result = $this->service->getAlbumsForMember([], '2025-2026', 10);
+
+        $this->assertSame([], $result);
+    }
 }

--- a/tests/Modules/Gallery/Service/MediaServiceTest.php
+++ b/tests/Modules/Gallery/Service/MediaServiceTest.php
@@ -210,4 +210,71 @@ class MediaServiceTest extends TestCase
     {
         $this->assertFalse($this->service->videoUploadAllowed());
     }
+
+    private function createDelegatedAlbum(): int
+    {
+        return $this->albumRepository->create(
+            Album::TYPE_LOCAL, 'Album délégué', null, '2026-01-01', null, 1, null,
+            $this->storageLocationRepository->findDefault()->id, $this->authorId, 'some_owner_type', 42
+        );
+    }
+
+    public function testUploadThrowsForADelegatedAlbum(): void
+    {
+        $album = $this->albumRepository->findById($this->createDelegatedAlbum());
+
+        $this->expectException(GalleryException::class);
+        $this->service->upload($album, $this->fakeUploadedImage(), Role::CHIEF, 'chief@test.com', $this->authorId);
+    }
+
+    public function testAddWithoutAuthorisationCheckStoresMediaOnADelegatedAlbum(): void
+    {
+        $album = $this->albumRepository->findById($this->createDelegatedAlbum());
+
+        $media = $this->service->addWithoutAuthorisationCheck($album, $this->fakeUploadedImage(), $this->authorId);
+
+        $this->assertSame(Media::STATUS_PENDING, $media->processingStatus);
+        $this->assertNotNull($this->mediaRepository->findById($media->id));
+    }
+
+    public function testDeleteThrowsForADelegatedAlbum(): void
+    {
+        $albumId = $this->createDelegatedAlbum();
+        $album = $this->albumRepository->findById($albumId);
+        $media = $this->service->addWithoutAuthorisationCheck($album, $this->fakeUploadedImage(), $this->authorId);
+
+        $this->expectException(GalleryException::class);
+        $this->service->delete($media, $album, Role::CHIEF, 'chief@test.com');
+    }
+
+    public function testDeleteWithoutAuthorisationCheckRemovesMediaFromADelegatedAlbum(): void
+    {
+        $albumId = $this->createDelegatedAlbum();
+        $album = $this->albumRepository->findById($albumId);
+        $media = $this->service->addWithoutAuthorisationCheck($album, $this->fakeUploadedImage(), $this->authorId);
+
+        $this->service->deleteWithoutAuthorisationCheck($media, $album);
+
+        $this->assertNull($this->mediaRepository->findById($media->id));
+    }
+
+    public function testReorderThrowsForADelegatedAlbum(): void
+    {
+        $album = $this->albumRepository->findById($this->createDelegatedAlbum());
+
+        $this->expectException(GalleryException::class);
+        $this->service->reorder($album, [], Role::CHIEF, 'chief@test.com');
+    }
+
+    public function testResolveUrlReturnsNullForADelegatedAlbum(): void
+    {
+        $albumId = $this->createDelegatedAlbum();
+        $album = $this->albumRepository->findById($albumId);
+        $media = $this->service->addWithoutAuthorisationCheck($album, $this->fakeUploadedImage(), $this->authorId);
+        $this->mediaRepository->markPhotoDone($media->id, 'thumb.jpg', 'med.jpg', 'lg.jpg', 100, 100);
+
+        $url = $this->service->resolveUrl($this->mediaRepository->findById($media->id), $album, 'thumb');
+
+        $this->assertNull($url);
+    }
 }

--- a/tests/Modules/Gallery/Task/MigrateAlbumStorageHandlerTest.php
+++ b/tests/Modules/Gallery/Task/MigrateAlbumStorageHandlerTest.php
@@ -297,9 +297,9 @@ class MigrateAlbumStorageHandlerTest extends TestCase
                 {
                     $this->real->deletePrefix($prefix);
                 }
-                public function url(string $key): string
+                public function url(string $key, string $ttl = '+1 hour'): string
                 {
-                    return $this->real->url($key);
+                    return $this->real->url($key, $ttl);
                 }
                 public function exists(string $key): bool
                 {
@@ -346,9 +346,9 @@ class MigrateAlbumStorageHandlerTest extends TestCase
                 {
                     $this->real->deletePrefix($prefix);
                 }
-                public function url(string $key): string
+                public function url(string $key, string $ttl = '+1 hour'): string
                 {
-                    return $this->real->url($key);
+                    return $this->real->url($key, $ttl);
                 }
                 public function exists(string $key): bool
                 {


### PR DESCRIPTION
## Description

Adds a generic capability for another module to have `gallery` host and store an album (local or S3) that it owns and access-controls itself — no consuming module is referenced yet, that arrives in a follow-up change.

- `gallery_albums` gains a nullable `owner_type`/`owner_id` pair (mirroring `files`' pair) marking an album as delegated. `module.json` version bumped alongside `schema.sql`.
- Delegated albums are excluded from every gallery-side listing, picker, and API (`findAllForManage()`, `findVisibleForMember()`, `GalleryAlbumProvider`, chief-facing management pages) — reachable only through the owning module.
- Every media of a delegated album is now served exclusively through `GalleryController::serveMedia()`, which consults a new `DelegatedAlbumAccessRegistry` (fail-closed, same contract as `Core\File\FileAccessGuard`) before touching anything else — 404 on denial, and 404 when no checker claims the `owner_type`.
- Once allowed: local storage streams as before; S3 mints a freshly presigned, short-lived (5 minute) URL and 302-redirects instead of proxying bytes through PHP. `S3StorageBackend::url()` gained a `$ttl` parameter for this (ordinary albums keep the existing 1-hour default, unaffected).
- Delegated responses always carry `Cache-Control: private, no-store`. A storage location configured with a public URL is refused for a delegated album (presigning would change nothing there).
- Owning modules get a new `Api\DelegatedAlbumManager` to create/find their album, add/list/delete media, and delete the whole album — authorisation is entirely the caller's responsibility, documented explicitly, unlike `MediaService::upload()`.
- Ordinary, non-delegated albums are unaffected — existing behaviour and tests are unchanged.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)


---
_Generated by [Claude Code](https://claude.ai/code/session_01YN5Rc7HpVAjo7rpFoDNHke)_