### PR TITLE
groups: media posts and the group gallery

### DIFF
--- a/core/File/UploadHandler.php
+++ b/core/File/UploadHandler.php
@@ -26,6 +26,12 @@ class UploadHandler
      * @param string $roleMin Access role for the file
      * @param string|null $moduleId Owning module
      * @param int|null $createdBy User account ID
+     * @param string|null $ownerType Generic ownership-registry scoping
+     *        (Core\File\FileOwnershipCheckerInterface, ARCHITECTURE.md
+     *        §8.3) — narrows role_min further, never widens it. Both this
+     *        and $ownerId are trailing/optional so every existing caller
+     *        keeps behaving exactly as before.
+     * @param int|null $ownerId
      * @return int File ID in the files table
      * @throws UploadException On validation failure
      */
@@ -36,7 +42,9 @@ class UploadHandler
         int $maxSizeBytes,
         string $roleMin,
         ?string $moduleId = null,
-        ?int $createdBy = null
+        ?int $createdBy = null,
+        ?string $ownerType = null,
+        ?int $ownerId = null
     ): int {
         // Validate file exists and no upload error
         if (empty($uploadedFile['tmp_name']) || !is_string($uploadedFile['tmp_name'])) {
@@ -97,7 +105,11 @@ class UploadHandler
             $finalSize,
             $roleMin,
             $moduleId,
-            $createdBy
+            $createdBy,
+            false,
+            null,
+            $ownerType,
+            $ownerId
         );
     }
 

--- a/modules/gallery/module.json
+++ b/modules/gallery/module.json
@@ -2,7 +2,7 @@
   "id": "gallery",
   "name": "Galerie photos et vidéos",
   "description": "Albums photo/vidéo (envoi local avec redimensionnement/transcodage automatique, ou lien vers un album externe) visibles par les membres identifiés.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "enabled_by_default": false,
   "routes": [
     {

--- a/modules/gallery/schema.sql
+++ b/modules/gallery/schema.sql
@@ -102,17 +102,30 @@ CREATE TABLE IF NOT EXISTS gallery_albums (
     -- module, rather than by this module's own section/scout-year
     -- visibility rules. Deliberately mirrors files.owner_type/owner_id
     -- (schema/core.sql) in shape — same nullable VARCHAR(50)/INT UNSIGNED
-    -- pair, same non-unique index, no FK (the referenced table varies by
-    -- owner_type) — but is a SEPARATE registry: this pair is resolved by
-    -- Service\DelegatedAlbumAccessRegistry against
-    -- Api\DelegatedAlbumAccessChecker implementations, never by
-    -- Core\File\FileAccessGuard, since a delegated album's media are
-    -- (mostly) not `files` rows — see gallery_media's own header comment.
-    -- NULL on every ordinary album. A non-null owner_type marks the album
-    -- delegated: Repository\AlbumRepository::findAll()/findVisible()
-    -- both exclude it, so it never appears in gallery's own listings,
-    -- pickers or Api\GalleryAlbumProvider — reachable only through its
-    -- owning module (Service\DelegatedAlbumService).
+    -- pair, no FK (the referenced table varies by owner_type) — but is a
+    -- SEPARATE registry: this pair is resolved by Service\
+    -- DelegatedAlbumAccessRegistry against Api\DelegatedAlbumAccessChecker
+    -- implementations, never by Core\File\FileAccessGuard, since a
+    -- delegated album's media are (mostly) not `files` rows — see
+    -- gallery_media's own header comment. NULL on every ordinary album. A
+    -- non-null owner_type marks the album delegated: Repository\
+    -- AlbumRepository::findAll()/findVisible() both exclude it, so it
+    -- never appears in gallery's own listings, pickers or Api\
+    -- GalleryAlbumProvider — reachable only through its owning module
+    -- (Service\DelegatedAlbumService).
+    --
+    -- UNIQUE, unlike files.owner_type/owner_id (which stays non-unique —
+    -- a file's owner may legitimately have several files): an owner may
+    -- have at most one delegated album, and Service\DelegatedAlbumService
+    -- ::ensureAlbum() relies on this constraint, not just its own
+    -- find-then-create check, to stay correct when two requests race to
+    -- create the same owner's album at once — the loser's INSERT fails
+    -- fast on this index instead of silently creating a second album, and
+    -- ensureAlbum() re-fetches the winner's row instead. MySQL and SQLite
+    -- both treat NULL as distinct from every other NULL in a UNIQUE index,
+    -- so every ordinary album (owner_type/owner_id both NULL) is
+    -- unaffected — only a genuine (owner_type, owner_id) collision is
+    -- rejected.
     owner_type VARCHAR(50) NULL,
     owner_id INT UNSIGNED NULL,
     -- Background storage migration (Task\MigrateAlbumStorageHandler,
@@ -133,7 +146,7 @@ CREATE TABLE IF NOT EXISTS gallery_albums (
     INDEX idx_gallery_albums_date (album_date),
     INDEX idx_gallery_albums_storage_location (storage_location_id),
     INDEX idx_gallery_albums_migration_target (migration_target_location_id),
-    INDEX idx_gallery_albums_owner (owner_type, owner_id),
+    UNIQUE INDEX idx_gallery_albums_owner (owner_type, owner_id),
     CONSTRAINT fk_gallery_albums_section FOREIGN KEY (section_id) REFERENCES sections(id) ON DELETE SET NULL,
     CONSTRAINT fk_gallery_albums_scout_year FOREIGN KEY (scout_year_id) REFERENCES scout_years(id),
     CONSTRAINT fk_gallery_albums_created_by FOREIGN KEY (created_by) REFERENCES user_accounts(id),

--- a/modules/gallery/src/Api/DelegatedAlbumManager.php
+++ b/modules/gallery/src/Api/DelegatedAlbumManager.php
@@ -80,4 +80,14 @@ interface DelegatedAlbumManager
      * own Service\AlbumService::delete().
      */
     public function deleteAlbum(int $albumId): void;
+
+    /**
+     * Whether a video may currently be added to a delegated album —
+     * addMedia() already refuses one server-side when this is false
+     * (Service\MediaService::upload()'s own rule: the gallery_allow_video
+     * setting AND ffmpeg/ffprobe both present), so this exists purely so
+     * an owning module's own composer can hide the option proactively
+     * instead of only ever finding out from a rejected upload.
+     */
+    public function videoUploadAllowed(): bool;
 }

--- a/modules/gallery/src/Repository/AlbumRepository.php
+++ b/modules/gallery/src/Repository/AlbumRepository.php
@@ -79,10 +79,11 @@ class AlbumRepository
     /**
      * The delegated album already owned by (ownerType, ownerId), or null
      * when none exists yet — Service\DelegatedAlbumService::ensureAlbum()'s
-     * "find" half. No DB-level uniqueness is enforced on (owner_type,
-     * owner_id) — same tradeoff as files.owner_type/owner_id, which this
-     * column pair deliberately mirrors — so this picks the oldest match,
-     * deterministically, on the rare chance more than one exists.
+     * "find" half, called both before attempting create() (the common
+     * case) and after a UNIQUE constraint violation from it (the losing
+     * side of a race — see gallery_albums.owner_type's schema.sql
+     * comment). LIMIT 1 is defensive, not load-bearing: the index this
+     * queries is UNIQUE, so at most one row can ever match.
      */
     public function findByOwner(string $ownerType, int $ownerId): ?Album
     {

--- a/modules/gallery/src/Service/DelegatedAlbumService.php
+++ b/modules/gallery/src/Service/DelegatedAlbumService.php
@@ -149,6 +149,11 @@ class DelegatedAlbumService implements DelegatedAlbumManager
         $this->albumRepository->delete($albumId);
     }
 
+    public function videoUploadAllowed(): bool
+    {
+        return $this->mediaService->videoUploadAllowed();
+    }
+
     /**
      * @throws GalleryException when $albumId doesn't exist or isn't delegated
      */

--- a/modules/gallery/src/Service/DelegatedAlbumService.php
+++ b/modules/gallery/src/Service/DelegatedAlbumService.php
@@ -82,9 +82,25 @@ class DelegatedAlbumService implements DelegatedAlbumManager
         }
 
         $scoutYearId = (int) $this->scoutYearService->getCurrentYear()['id'];
-        $albumId = $this->albumRepository->create(
-            Album::TYPE_LOCAL, $title, null, $albumDate, null, $scoutYearId, null, $location->id, $createdBy, $ownerType, $ownerId
-        );
+
+        try {
+            $albumId = $this->albumRepository->create(
+                Album::TYPE_LOCAL, $title, null, $albumDate, null, $scoutYearId, null, $location->id, $createdBy, $ownerType, $ownerId
+            );
+        } catch (\PDOException $e) {
+            // Two callers racing to create the first album for the same
+            // owner: the loser's INSERT fails on gallery_albums'
+            // UNIQUE(owner_type, owner_id) index (schema.sql's comment on
+            // that pair) rather than creating a second album. The find()
+            // above already missed the winner's row (it wasn't committed
+            // yet at that point) — it will see it now.
+            if ($e->getCode() !== '23000') {
+                throw $e;
+            }
+            $winner = $this->albumRepository->findByOwner($ownerType, $ownerId);
+            \assert($winner !== null);
+            return $this->toAlbumDto($winner);
+        }
 
         $created = $this->albumRepository->findById($albumId);
         \assert($created !== null);

--- a/modules/gallery/src/Service/MediaService.php
+++ b/modules/gallery/src/Service/MediaService.php
@@ -110,8 +110,14 @@ class MediaService
         $allowedMimes = $isVideo ? self::VIDEO_MIMES : self::PHOTO_MIMES;
 
         try {
+            // A delegated album's original is scoped by the same
+            // owner_type/owner_id as the album itself (null/null for an
+            // ordinary album, unchanged) — so /files/{id} is governed by
+            // the exact same ownership check as /gallery/media/{id}/{size},
+            // instead of stopping at the flat 'identified' floor below.
             $fileId = $this->uploadHandler->handle(
-                $uploadedFile, "gallery/{$album->id}/orig", $allowedMimes, $maxBytes, 'identified', 'gallery', $accountId
+                $uploadedFile, "gallery/{$album->id}/orig", $allowedMimes, $maxBytes, 'identified', 'gallery', $accountId,
+                $album->ownerType, $album->ownerId
             );
         } catch (UploadException $e) {
             throw new GalleryException($e->getMessage());

--- a/modules/groups/module.json
+++ b/modules/groups/module.json
@@ -2,7 +2,7 @@
   "id": "groups",
   "name": "Groupes de discussion",
   "description": "Groupes de discussion privés pour l'unité : un groupe par section et par année scoute, ou des groupes sur invitation. Visibles uniquement par leurs membres.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "enabled_by_default": false,
   "requires": [
     "gallery"
@@ -64,6 +64,21 @@
       "label": "",
       "breadcrumb": {
         "label": "Membres",
+        "parents": [
+          "Espace animés"
+        ]
+      }
+    },
+    {
+      "path": "/groups/{id}/gallery",
+      "method": "GET",
+      "controller": "Modules\\Groups\\Controller\\GroupController",
+      "action": "gallery",
+      "menu": "espace_animes",
+      "role_min": "identified",
+      "label": "",
+      "breadcrumb": {
+        "label": "Galerie du groupe",
         "parents": [
           "Espace animés"
         ]

--- a/modules/groups/schema.sql
+++ b/modules/groups/schema.sql
@@ -39,6 +39,26 @@ CREATE TABLE discussion_groups (
     created_by_member_id INT UNSIGNED NOT NULL,
     created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    -- The group's delegated gallery album (Modules\Gallery\Api\
+    -- DelegatedAlbumManager, owner_type 'discussion_group' — see
+    -- File\GroupFileOwnershipChecker::OWNER_TYPE — owner_id = this
+    -- group's id), created lazily on the group's first media post
+    -- (Service\PostMediaService::ensureAlbumId()), never at group
+    -- creation. NULL until then.
+    --
+    -- No FK: gallery_albums lives in a different module's schema.sql,
+    -- applied independently and in no guaranteed order relative to this
+    -- one (each module's schema is migrated on its own, whenever that
+    -- module happens to load — there is no cross-module migration
+    -- ordering guarantee to declare a FK against). Same reasoning as
+    -- gallery_albums.cover_media_id's own comment one file over, applied
+    -- across a module boundary instead of within one file. This column
+    -- is not the source of truth for uniqueness either — gallery's own
+    -- UNIQUE(owner_type, owner_id) index is (see that column's comment in
+    -- modules/gallery/schema.sql) — it is only a cache of the id
+    -- Service\PostMediaService already resolved, to avoid re-resolving it
+    -- from gallery on every read.
+    gallery_album_id INT UNSIGNED NULL,
     INDEX idx_dg_scout_year (scout_year_id),
     INDEX idx_dg_section (section_id),
     INDEX idx_dg_last_activity (last_activity_at),
@@ -83,10 +103,11 @@ CREATE TABLE discussion_group_members (
     CONSTRAINT fk_dgm_invited_by FOREIGN KEY (invited_by_member_id) REFERENCES members(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Text posts. Replies, reactions, media and link previews arrive later:
--- their tables will hang off this one with ON DELETE CASCADE, which is
--- why post deletion needs no cleanup of its own here and must not grow
--- any later (deleting a post is a real DELETE — this module does not
+-- Text posts, and (see discussion_group_post_media below) up to four
+-- media each. Replies, reactions and link previews arrive later: their
+-- tables will hang off this one with ON DELETE CASCADE, which is why
+-- post deletion needs no cleanup of its own here and must not grow any
+-- later (deleting a post is a real DELETE — this module does not
 -- soft-delete).
 CREATE TABLE discussion_group_posts (
     id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
@@ -124,4 +145,29 @@ CREATE TABLE discussion_group_posts (
     CONSTRAINT fk_dgp_group FOREIGN KEY (group_id) REFERENCES discussion_groups(id) ON DELETE CASCADE,
     CONSTRAINT fk_dgp_author_account FOREIGN KEY (author_user_account_id) REFERENCES user_accounts(id) ON DELETE CASCADE,
     CONSTRAINT fk_dgp_author_member FOREIGN KEY (author_member_id) REFERENCES members(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- One row per media attached to a post, in display order. The media
+-- itself is a Modules\Gallery\Repository\Media row inside the group's
+-- own delegated album (discussion_groups.gallery_album_id) — this table
+-- only records which post it belongs to and where.
+--
+-- No FK to gallery_media: it lives in a different module's schema.sql,
+-- same cross-module reasoning as discussion_groups.gallery_album_id's
+-- own comment. Service\PostMediaService deletes the gallery media itself
+-- (row and stored object, through Api\DelegatedAlbumManager::
+-- deleteMedia()) BEFORE the post row is deleted — the ON DELETE CASCADE
+-- below only ever cleans up this join row afterward, never the media it
+-- pointed at.
+CREATE TABLE discussion_group_post_media (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    post_id INT UNSIGNED NOT NULL,
+    gallery_media_id INT UNSIGNED NOT NULL,
+    -- 0 to 3 (module spec: 1 to 4 media per post) — the composer's own
+    -- attachment order, preserved on display.
+    sort_order TINYINT UNSIGNED NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE INDEX idx_dgpm_post_media (post_id, gallery_media_id),
+    INDEX idx_dgpm_post (post_id, sort_order),
+    CONSTRAINT fk_dgpm_post FOREIGN KEY (post_id) REFERENCES discussion_group_posts(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/modules/groups/src/Controller/GroupController.php
+++ b/modules/groups/src/Controller/GroupController.php
@@ -26,6 +26,7 @@ use Modules\Groups\Service\GroupListService;
 use Modules\Groups\Service\GroupService;
 use Modules\Groups\Service\GroupSessionContext;
 use Modules\Groups\Service\GroupSessionContextFactory;
+use Modules\Groups\Service\PostMediaService;
 use Modules\Groups\Service\PostService;
 use Twig\Environment;
 
@@ -48,7 +49,8 @@ class GroupController extends AbstractController
         private GroupSessionContextFactory $contextFactory,
         private SectionService $sectionService,
         private GroupFeedService $feedService,
-        private MemberService $memberService
+        private MemberService $memberService,
+        private PostMediaService $postMediaService
     ) {
     }
 
@@ -116,6 +118,31 @@ class GroupController extends AbstractController
             // this group — with one, there is nothing to choose.
             'author_options' => $this->authorOptions($group, $context),
             'max_body_length' => PostService::MAX_BODY_LENGTH,
+            'max_media_per_post' => PostMediaService::MAX_MEDIA_PER_POST,
+            'video_upload_allowed' => $this->postMediaService->videoUploadAllowed(),
+        ]);
+    }
+
+    /**
+     * GET /groups/{id}/gallery — "Galerie du groupe": every media of the
+     * group's posts, newest first. Same 404-not-403 membership rule as
+     * every other group page — readableGroup() resolves the album id
+     * from the authorised $group itself, never from anything in the
+     * request, so this can never be pointed at another group's media.
+     *
+     * @param array<string, string> $params
+     */
+    public function gallery(Request $request, array $params): Response
+    {
+        $context = $this->context();
+        $group = $this->readableGroup($params, $context);
+        if ($group === null) {
+            return new Response('Not Found', 404);
+        }
+
+        return $this->render('@groups/gallery.html.twig', [
+            'group' => $group,
+            'media' => $this->postMediaService->groupGalleryMedia($group),
         ]);
     }
 

--- a/modules/groups/src/Controller/PostController.php
+++ b/modules/groups/src/Controller/PostController.php
@@ -9,11 +9,13 @@ declare(strict_types=1);
 namespace Modules\Groups\Controller;
 
 use Core\Http\Controller\AbstractController;
+use Core\Http\FlashMessage;
 use Core\Http\Request;
 use Core\Http\Response;
 use Core\ScoutYear\ScoutYearSession;
 use Core\Security\AuthSession;
 use Core\Security\CsrfGuard;
+use Modules\Gallery\Service\GalleryException;
 use Modules\Groups\Repository\DiscussionGroup;
 use Modules\Groups\Repository\GroupRepository;
 use Modules\Groups\Repository\Post;
@@ -22,6 +24,7 @@ use Modules\Groups\Service\GroupAccessService;
 use Modules\Groups\Service\GroupFeedService;
 use Modules\Groups\Service\GroupSessionContext;
 use Modules\Groups\Service\GroupSessionContextFactory;
+use Modules\Groups\Service\PostMediaService;
 use Modules\Groups\Service\PostService;
 use Twig\Environment;
 
@@ -44,7 +47,8 @@ class PostController extends AbstractController
         private GroupAccessService $accessService,
         private GroupFeedService $feedService,
         private PostService $postService,
-        private GroupSessionContextFactory $contextFactory
+        private GroupSessionContextFactory $contextFactory,
+        private PostMediaService $postMediaService
     ) {
     }
 
@@ -97,7 +101,20 @@ class PostController extends AbstractController
         }
 
         $body = (string) $request->getBody('body', '');
-        if (!$this->postService->isPostable($body)) {
+        $files = $request->getFiles('media');
+
+        // The ceiling is checked before anything is written — a post over
+        // it is rejected whole, never silently truncated to the first
+        // four (module spec).
+        if (count($files) > PostMediaService::MAX_MEDIA_PER_POST) {
+            FlashMessage::set(
+                'error',
+                'Vous ne pouvez joindre que ' . PostMediaService::MAX_MEDIA_PER_POST . ' médias au maximum par message.'
+            );
+            return $this->redirect('/groups/' . $group->id);
+        }
+
+        if (!$this->postService->isPostable($body, count($files))) {
             return $this->redirect('/groups/' . $group->id);
         }
 
@@ -111,7 +128,21 @@ class PostController extends AbstractController
             return new Response('Aucun membre de ce groupe n\'est associé à votre compte.', 403);
         }
 
-        $this->postService->create($group, $context->userAccountId, $authorMemberId, $body);
+        $postId = $this->postService->create($group, $context->userAccountId, $authorMemberId, $body);
+
+        if ($files !== []) {
+            try {
+                $this->postMediaService->addMedia($group, $postId, $files, $context->userAccountId);
+            } catch (GalleryException $e) {
+                // The whole post is rejected, never left half-saved: undo
+                // whatever media did make it in before the failing file,
+                // then the post itself.
+                $this->postMediaService->deleteAllForPost($group, $postId);
+                $this->postRepository->delete($postId);
+                FlashMessage::set('error', $e->getMessage());
+                return $this->redirect('/groups/' . $group->id);
+            }
+        }
 
         return $this->redirect('/groups/' . $group->id);
     }
@@ -157,6 +188,10 @@ class PostController extends AbstractController
                 return new Response('Vous ne pouvez pas supprimer ce message.', 403);
             }
 
+            // Media first: it must be resolved from the still-existing
+            // discussion_group_post_media join rows, which the post's own
+            // deletion below cascades away.
+            $this->postMediaService->deleteAllForPost($group, $post->id);
             $this->postService->delete($post);
 
             return $this->redirect('/groups/' . $group->id);

--- a/modules/groups/src/Gallery/GroupDelegatedAlbumAccessChecker.php
+++ b/modules/groups/src/Gallery/GroupDelegatedAlbumAccessChecker.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Groups\Gallery;
+
+use Core\Security\Role;
+use Modules\Gallery\Api\DelegatedAlbumAccessChecker;
+use Modules\Groups\File\GroupFileOwnershipChecker;
+
+/**
+ * Scopes a group's delegated gallery album (owner_type
+ * GroupFileOwnershipChecker::OWNER_TYPE, owner_id = discussion_groups.id)
+ * to the group's own members — registered into Modules\Gallery\Service\
+ * DelegatedAlbumAccessRegistry, gallery's SEPARATE registry for delegated
+ * albums (gallery prompt 5), never Core\File\FileAccessGuard's own one.
+ *
+ * A thin adapter, not a second implementation of the group-membership
+ * decision: both interfaces share the exact same
+ * supports(string): bool / isAllowed(int, Role, int[]): bool shape (a
+ * deliberate mirror, per Api\DelegatedAlbumAccessChecker's own docblock),
+ * so this simply delegates to File\GroupFileOwnershipChecker — the file
+ * registry's own checker for the identical owner_type — rather than
+ * duplicating Service\GroupAccessService::canRead() a second time. A
+ * member who can read the group's posts can always see the group's media
+ * too, and vice versa, by construction: there is only one decision
+ * function, reached through two registries.
+ */
+class GroupDelegatedAlbumAccessChecker implements DelegatedAlbumAccessChecker
+{
+    public function __construct(private GroupFileOwnershipChecker $fileChecker)
+    {
+    }
+
+    public function supports(string $ownerType): bool
+    {
+        return $this->fileChecker->supports($ownerType);
+    }
+
+    /**
+     * @param array<int, int> $linkedMemberIds
+     */
+    public function isAllowed(int $ownerId, Role $currentRole, array $linkedMemberIds): bool
+    {
+        return $this->fileChecker->isAllowed($ownerId, $currentRole, $linkedMemberIds);
+    }
+}

--- a/modules/groups/src/Repository/DiscussionGroup.php
+++ b/modules/groups/src/Repository/DiscussionGroup.php
@@ -22,7 +22,14 @@ class DiscussionGroup
         public readonly ?string $closedAt,
         public readonly string $lastActivityAt,
         public readonly int $createdByMemberId,
-        public readonly string $createdAt
+        public readonly string $createdAt,
+        // Last, nullable, so every existing positional construction of
+        // this DTO (tests included) keeps working unchanged — same
+        // append-only discipline as Modules\Gallery\Repository\Album's
+        // own trailing owner_type/owner_id pair. Set once, lazily, by
+        // Service\PostMediaService::ensureAlbumId() on the group's first
+        // media post.
+        public readonly ?int $galleryAlbumId = null
     ) {
     }
 

--- a/modules/groups/src/Repository/GroupRepository.php
+++ b/modules/groups/src/Repository/GroupRepository.php
@@ -71,6 +71,19 @@ class GroupRepository
         $stmt->execute([$closedAt, $id]);
     }
 
+    /**
+     * Caches the group's delegated gallery album id, resolved by
+     * Service\PostMediaService::ensureAlbumId(). Idempotent to call twice
+     * with the same value — two concurrent first-media posts both resolve
+     * the same album id from gallery's own concurrency-safe ensureAlbum()
+     * and both land here harmlessly.
+     */
+    public function setGalleryAlbumId(int $id, int $galleryAlbumId): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE discussion_groups SET gallery_album_id = ? WHERE id = ?');
+        $stmt->execute([$galleryAlbumId, $id]);
+    }
+
     public function delete(int $id): void
     {
         $stmt = $this->pdo->prepare('DELETE FROM discussion_groups WHERE id = ?');
@@ -90,7 +103,8 @@ class GroupRepository
             $row['closed_at'] !== null ? (string) $row['closed_at'] : null,
             (string) $row['last_activity_at'],
             (int) $row['created_by_member_id'],
-            (string) $row['created_at']
+            (string) $row['created_at'],
+            $row['gallery_album_id'] !== null ? (int) $row['gallery_album_id'] : null
         );
     }
 }

--- a/modules/groups/src/Repository/PostMediaRepository.php
+++ b/modules/groups/src/Repository/PostMediaRepository.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Groups\Repository;
+
+/**
+ * The discussion_group_post_media join table — which gallery media (by
+ * id, inside the group's own delegated album) belongs to which post, and
+ * in what order. Never touches gallery_media itself: that table belongs
+ * to a different module and is reached only through Modules\Gallery\Api\
+ * DelegatedAlbumManager (Service\PostMediaService).
+ */
+class PostMediaRepository
+{
+    public function __construct(private \PDO $pdo)
+    {
+    }
+
+    public function attach(int $postId, int $galleryMediaId, int $sortOrder): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO discussion_group_post_media (post_id, gallery_media_id, sort_order, created_at)
+             VALUES (?, ?, ?, ?)'
+        );
+        $stmt->execute([$postId, $galleryMediaId, $sortOrder, date('Y-m-d H:i:s')]);
+    }
+
+    /**
+     * @return int[] gallery_media ids, in attachment order
+     */
+    public function findMediaIdsForPost(int $postId): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT gallery_media_id FROM discussion_group_post_media WHERE post_id = ? ORDER BY sort_order ASC, id ASC'
+        );
+        $stmt->execute([$postId]);
+
+        return array_map('intval', $stmt->fetchAll(\PDO::FETCH_COLUMN));
+    }
+
+    /**
+     * Batched form of findMediaIdsForPost() for a whole feed page —
+     * Service\GroupFeedService resolves every post's media in one query
+     * rather than one per post.
+     *
+     * @param int[] $postIds
+     * @return array<int, int[]> postId => gallery_media ids, in attachment order
+     */
+    public function findMediaIdsForPosts(array $postIds): array
+    {
+        if ($postIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($postIds), '?'));
+        $stmt = $this->pdo->prepare(
+            "SELECT post_id, gallery_media_id FROM discussion_group_post_media
+             WHERE post_id IN ({$placeholders})
+             ORDER BY post_id ASC, sort_order ASC, id ASC"
+        );
+        $stmt->execute($postIds);
+
+        $byPost = [];
+        foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+            $byPost[(int) $row['post_id']][] = (int) $row['gallery_media_id'];
+        }
+
+        return $byPost;
+    }
+}

--- a/modules/groups/src/Service/GroupFeedService.php
+++ b/modules/groups/src/Service/GroupFeedService.php
@@ -30,7 +30,8 @@ class GroupFeedService
     public function __construct(
         private PostRepository $postRepository,
         private PostAuthorResolver $authorResolver,
-        private PostService $postService
+        private PostService $postService,
+        private PostMediaService $postMediaService
     ) {
     }
 
@@ -45,28 +46,34 @@ class GroupFeedService
         $rows = array_slice($rows, 0, self::PAGE_SIZE);
 
         $pinned = $isFirstPage ? $this->postRepository->findPinned($group->id) : [];
+        $all = array_merge($pinned, $rows);
 
         // Author names for the pinned posts and the page together: still
         // two queries, whatever the page holds.
-        $labels = $this->authorResolver->resolve(
-            array_merge($pinned, $rows),
-            $group->scoutYearId ?? $context->effectiveScoutYearId
-        );
+        $labels = $this->authorResolver->resolve($all, $group->scoutYearId ?? $context->effectiveScoutYearId);
+
+        // Same "resolve once, decorate many" shape: the album's whole
+        // media list is fetched once (Service\PostMediaService::
+        // albumMediaById()), then mediaForPosts() maps it onto every post
+        // on this page in one more query, never once per post.
+        $mediaById = $this->postMediaService->albumMediaById($group);
+        $mediaByPost = $this->postMediaService->mediaForPosts(array_map(fn(Post $p) => $p->id, $all), $mediaById);
 
         $last = $rows === [] ? null : $rows[count($rows) - 1];
 
         return new FeedPage(
-            array_map(fn(Post $p) => $this->decorate($p, $labels, $context, $canModerate), $pinned),
-            array_map(fn(Post $p) => $this->decorate($p, $labels, $context, $canModerate), $rows),
+            array_map(fn(Post $p) => $this->decorate($p, $labels, $mediaByPost, $context, $canModerate), $pinned),
+            array_map(fn(Post $p) => $this->decorate($p, $labels, $mediaByPost, $context, $canModerate), $rows),
             $hasMore && $last !== null ? $this->encodeCursor($last) : null
         );
     }
 
     /**
      * @param array<int, array{display_name: string, account_name: string}> $labels
+     * @param array<int, \Modules\Gallery\Api\DelegatedMedia[]> $mediaByPost
      * @return array<string, mixed>
      */
-    private function decorate(Post $post, array $labels, GroupSessionContext $context, bool $canModerate): array
+    private function decorate(Post $post, array $labels, array $mediaByPost, GroupSessionContext $context, bool $canModerate): array
     {
         $label = $labels[$post->id] ?? ['display_name' => '', 'account_name' => ''];
 
@@ -74,6 +81,7 @@ class GroupFeedService
             'post' => $post,
             'display_name' => $label['display_name'],
             'account_name' => $label['account_name'],
+            'media' => $mediaByPost[$post->id] ?? [],
             // Every one of these is re-checked server-side by the action
             // itself — they only decide whether the kebab entry is shown.
             'can_edit' => $this->postService->canEdit($post, $context),

--- a/modules/groups/src/Service/PostMediaService.php
+++ b/modules/groups/src/Service/PostMediaService.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Groups\Service;
+
+use Modules\Gallery\Api\DelegatedAlbumManager;
+use Modules\Gallery\Api\DelegatedMedia;
+use Modules\Gallery\Service\GalleryException;
+use Modules\Groups\File\GroupFileOwnershipChecker;
+use Modules\Groups\Repository\DiscussionGroup;
+use Modules\Groups\Repository\GroupRepository;
+use Modules\Groups\Repository\PostMediaRepository;
+
+/**
+ * Attaches gallery media to a post through Api\DelegatedAlbumManager —
+ * the only entry point this module is allowed to call into gallery
+ * through (ARCHITECTURE.md §7.5); nothing here touches a
+ * Modules\Gallery\Service or Repository class directly. Every group's
+ * post media lives in one delegated album per group (owner_type
+ * File\GroupFileOwnershipChecker::OWNER_TYPE, owner_id = the group's id),
+ * created lazily on the group's first media post and cached on
+ * discussion_groups.gallery_album_id.
+ *
+ * Authorisation (may this session post/delete here at all) is entirely
+ * the Controller's job, exactly like Service\PostService — nothing here
+ * is a security boundary on its own; every method trusts the caller
+ * already decided the action is allowed. Read access to the resulting
+ * media is a separate concern, enforced by Gallery\
+ * GroupDelegatedAlbumAccessChecker on every /gallery/media/{id}/{size}
+ * request, not by anything in this class.
+ */
+class PostMediaService
+{
+    /**
+     * Server-side ceiling — the composer's own counter is a convenience,
+     * never the limit. A post over this is rejected whole by
+     * Controller\PostController::create(), never truncated to the first
+     * four (module spec).
+     */
+    public const MAX_MEDIA_PER_POST = 4;
+
+    public function __construct(
+        private DelegatedAlbumManager $delegatedAlbumManager,
+        private PostMediaRepository $postMediaRepository,
+        private GroupRepository $groupRepository
+    ) {
+    }
+
+    /**
+     * The group's delegated album, created on first use. gallery's own
+     * ensureAlbum() is safe under concurrency (a UNIQUE key on
+     * (owner_type, owner_id), gallery's schema.sql) — two members posting
+     * the group's first media at the same moment both land here, both
+     * call ensureAlbum(), and both get back the same album id; the
+     * second write to gallery_album_id below is a harmless no-op onto
+     * the same value.
+     *
+     * $createdByAccountId is a user_accounts.id, not a members.id —
+     * gallery_albums.created_by has a FK to user_accounts (schema.sql),
+     * the same "human who actually acted" identity Repository\Album's
+     * own createdBy already carries for an ordinary album.
+     */
+    public function ensureAlbumId(DiscussionGroup $group, int $createdByAccountId): int
+    {
+        if ($group->galleryAlbumId !== null) {
+            return $group->galleryAlbumId;
+        }
+
+        $album = $this->delegatedAlbumManager->ensureAlbum(
+            GroupFileOwnershipChecker::OWNER_TYPE,
+            $group->id,
+            $group->name,
+            date('Y-m-d'),
+            $createdByAccountId
+        );
+        $this->groupRepository->setGalleryAlbumId($group->id, $album->id);
+
+        return $album->id;
+    }
+
+    /**
+     * @param array<int, array{name: string, tmp_name: string, error: int, size: int, type: string}> $uploadedFiles
+     * @return int[] the gallery media ids attached, in attachment order
+     * @throws GalleryException on the first file that fails — the caller
+     *         (Controller\PostController::create()) rolls back the whole
+     *         post via deleteAllForPost() rather than leaving a partial
+     *         attachment (module spec: "reject the whole post rather than
+     *         silently truncating").
+     */
+    public function addMedia(DiscussionGroup $group, int $postId, array $uploadedFiles, int $accountId): array
+    {
+        $albumId = $this->ensureAlbumId($group, $accountId);
+
+        $mediaIds = [];
+        foreach (array_values($uploadedFiles) as $index => $file) {
+            $media = $this->delegatedAlbumManager->addMedia($albumId, $file, $accountId);
+            $this->postMediaRepository->attach($postId, $media->id, $index);
+            $mediaIds[] = $media->id;
+        }
+
+        return $mediaIds;
+    }
+
+    /**
+     * Removes every gallery media (row and stored object) already
+     * attached to a post — used both to roll back a post rejected
+     * partway through addMedia(), and on a genuine post deletion
+     * (Controller\PostController::delete(), called before
+     * Service\PostService::delete() removes the post row itself, since
+     * that cascades away this module's own join rows and the media ids
+     * would no longer be findable afterward).
+     *
+     * Re-reads the group's own gallery_album_id fresh from the
+     * repository rather than trusting $group->galleryAlbumId: when this
+     * runs as addMedia()'s own rollback on the group's very first media
+     * post, the album was only just created and persisted mid-request —
+     * the immutable $group instance the caller is still holding was
+     * fetched before that write and would otherwise read as null,
+     * skipping cleanup for exactly the media that needs it.
+     *
+     * Never throws: a media row already gone (deleteMedia() itself
+     * failing) must not block the post's own removal.
+     */
+    public function deleteAllForPost(DiscussionGroup $group, int $postId): void
+    {
+        $albumId = $this->groupRepository->findById($group->id)?->galleryAlbumId;
+        if ($albumId === null) {
+            return;
+        }
+
+        foreach ($this->postMediaRepository->findMediaIdsForPost($postId) as $mediaId) {
+            try {
+                $this->delegatedAlbumManager->deleteMedia($albumId, $mediaId);
+            } catch (GalleryException) {
+                // Already gone (or the album vanished) — nothing left to
+                // clean up either way.
+            }
+        }
+    }
+
+    /**
+     * Every DelegatedMedia the group's album currently holds, keyed by
+     * id — fetched once per feed page (Service\GroupFeedService) and
+     * reused to decorate every post on it, rather than once per post.
+     *
+     * @return array<int, DelegatedMedia>
+     */
+    public function albumMediaById(DiscussionGroup $group): array
+    {
+        if ($group->galleryAlbumId === null) {
+            return [];
+        }
+
+        $byId = [];
+        foreach ($this->delegatedAlbumManager->listMedia($group->galleryAlbumId) as $media) {
+            $byId[$media->id] = $media;
+        }
+
+        return $byId;
+    }
+
+    /**
+     * @param int[] $postIds
+     * @param array<int, DelegatedMedia> $mediaById the return of albumMediaById()
+     * @return array<int, DelegatedMedia[]> postId => its media, in
+     *         attachment order. A media id present in the join table but
+     *         absent from $mediaById (a race with a concurrent delete) is
+     *         silently skipped rather than breaking the whole post's render.
+     */
+    public function mediaForPosts(array $postIds, array $mediaById): array
+    {
+        $result = [];
+        foreach ($this->postMediaRepository->findMediaIdsForPosts($postIds) as $postId => $mediaIds) {
+            foreach ($mediaIds as $mediaId) {
+                if (isset($mediaById[$mediaId])) {
+                    $result[$postId][] = $mediaById[$mediaId];
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Whether the composer should offer video at all — Controller\
+     * GroupController::show() passes this to the template so the option
+     * is hidden proactively rather than only discovered from a rejected
+     * upload. addMedia() still refuses a video server-side regardless
+     * (Api\DelegatedAlbumManager::videoUploadAllowed()'s own docblock) —
+     * this is UI-only, never the enforcement.
+     */
+    public function videoUploadAllowed(): bool
+    {
+        return $this->delegatedAlbumManager->videoUploadAllowed();
+    }
+
+    /**
+     * "Galerie du groupe" (Controller\GroupController::gallery()): every
+     * media of the group's posts, newest first. listMedia() returns them
+     * in the album's own display order (oldest first, same as gallery's
+     * own grid) — this re-sorts by id (monotonic, always unique) for this
+     * page's own newest-first contract.
+     *
+     * @return DelegatedMedia[]
+     */
+    public function groupGalleryMedia(DiscussionGroup $group): array
+    {
+        if ($group->galleryAlbumId === null) {
+            return [];
+        }
+
+        $media = $this->delegatedAlbumManager->listMedia($group->galleryAlbumId);
+        usort($media, fn(DelegatedMedia $a, DelegatedMedia $b) => $b->id <=> $a->id);
+
+        return $media;
+    }
+}

--- a/modules/groups/src/Service/PostService.php
+++ b/modules/groups/src/Service/PostService.php
@@ -120,8 +120,14 @@ class PostService
         return mb_substr(trim($body), 0, self::MAX_BODY_LENGTH);
     }
 
-    public function isPostable(string $body): bool
+    /**
+     * A media-only post is valid (module spec); a post with neither text
+     * nor media is not. $mediaCount is trusted as-is — the caller
+     * (Controller\PostController::create()) is the one that already
+     * capped it against Service\PostMediaService::MAX_MEDIA_PER_POST.
+     */
+    public function isPostable(string $body, int $mediaCount = 0): bool
     {
-        return $this->normalize($body) !== '';
+        return $this->normalize($body) !== '' || $mediaCount > 0;
     }
 }

--- a/modules/groups/views/gallery.html.twig
+++ b/modules/groups/views/gallery.html.twig
@@ -1,0 +1,32 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Galerie — {{ group.name }} — {{ site_name }}{% endblock %}
+
+{% block stylesheets %}
+<link rel="stylesheet" href="/assets/css/components.css">
+{% endblock %}
+
+{% block content %}
+    <div class="d-flex align-items-start justify-content-between gap-2 flex-wrap mb-3">
+        <div>
+            <h1 class="h4 mb-1">Galerie — {{ group.name }}</h1>
+            <p class="text-body-secondary small mb-0">Tous les médias publiés dans ce groupe, du plus récent au plus ancien.</p>
+        </div>
+        <a class="btn btn-outline-secondary d-flex align-items-center" style="min-height:44px;" href="/groups/{{ group.id }}">
+            <i class="bi bi-arrow-left me-1"></i> Retour au groupe
+        </a>
+    </div>
+
+    {% if media is empty %}
+        <p class="text-body-secondary text-center py-5 mb-0">Aucun média n'a encore été publié dans ce groupe.</p>
+    {% else %}
+        <div class="groups-gallery-grid">
+            {% for m in media %}
+                <a href="/gallery/media/{{ m.id }}/{{ m.mediaType == 'video' ? 'original' : 'large' }}"
+                   target="_blank" rel="noopener" class="groups-media-cell text-decoration-none">
+                    {% include '@groups/partials/media_thumb.html.twig' with { media: m } %}
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endblock %}

--- a/modules/groups/views/partials/group_header.html.twig
+++ b/modules/groups/views/partials/group_header.html.twig
@@ -24,9 +24,14 @@
             {% endif %}
         </div>
     </div>
-    <a class="btn btn-outline-secondary d-flex align-items-center" style="min-height:44px;" href="/groups/{{ group.id }}/members">
-        <i class="bi bi-people me-1"></i> Membres
-    </a>
+    <div class="d-flex gap-2">
+        <a class="btn btn-outline-secondary d-flex align-items-center" style="min-height:44px;" href="/groups/{{ group.id }}/gallery">
+            <i class="bi bi-images me-1"></i> Galerie
+        </a>
+        <a class="btn btn-outline-secondary d-flex align-items-center" style="min-height:44px;" href="/groups/{{ group.id }}/members">
+            <i class="bi bi-people me-1"></i> Membres
+        </a>
+    </div>
 </div>
 
 {% if post_permission is defined and not post_permission.allowed %}

--- a/modules/groups/views/partials/media_thumb.html.twig
+++ b/modules/groups/views/partials/media_thumb.html.twig
@@ -1,0 +1,25 @@
+{#
+  One media cell's inner content — the caller wraps this in a
+  .groups-media-cell (position:relative, sized by its own grid). `media`
+  is a Modules\Gallery\Api\DelegatedMedia.
+
+  Never a broken image: 'pending'/'processing' shows a spinner, 'failed'
+  a discreet notice, and only 'done' actually renders the thumbnail —
+  matching modules/gallery's own album grid (album.html.twig).
+#}
+{% if media.processingStatus == 'done' %}
+    <img src="/gallery/media/{{ media.id }}/thumb" alt="" class="w-100 h-100" style="object-fit:cover;" loading="lazy">
+    {% if media.mediaType == 'video' %}
+        <span class="position-absolute top-50 start-50 translate-middle text-white" style="font-size:1.75rem;text-shadow:0 0 6px rgba(0,0,0,.6);">
+            <i class="bi bi-play-circle-fill"></i>
+        </span>
+    {% endif %}
+{% elseif media.processingStatus == 'failed' %}
+    <span class="d-flex align-items-center justify-content-center h-100 text-danger" title="Échec du traitement de ce média">
+        <i class="bi bi-exclamation-triangle"></i>
+    </span>
+{% else %}
+    <span class="d-flex align-items-center justify-content-center h-100 text-body-secondary" title="Traitement en cours">
+        <span class="spinner-border spinner-border-sm"></span>
+    </span>
+{% endif %}

--- a/modules/groups/views/partials/post_card.html.twig
+++ b/modules/groups/views/partials/post_card.html.twig
@@ -66,7 +66,11 @@
             {% endif %}
         </div>
 
-        <p class="mb-0 mt-2 groups-post-body" id="post-body-{{ row.post.id }}">{{ row.post.body|nl2br }}</p>
+        {% if row.post.body %}
+            <p class="mb-0 mt-2 groups-post-body" id="post-body-{{ row.post.id }}">{{ row.post.body|nl2br }}</p>
+        {% endif %}
+
+        {% include '@groups/partials/post_media_grid.html.twig' with { media: row.media } %}
 
         {% if row.can_edit %}
             <form method="post" action="/groups/{{ group.id }}/posts/{{ row.post.id }}/edit"

--- a/modules/groups/views/partials/post_media_grid.html.twig
+++ b/modules/groups/views/partials/post_media_grid.html.twig
@@ -1,0 +1,21 @@
+{#
+  A post's attached media (1 to 4) — module spec layout: 1 wide, 2 side
+  by side, 3 with one tall on the left, 4 in a 2x2 (public/assets/css/
+  components.css' .groups-media-grid-{count} rules). `media` is a
+  Modules\Gallery\Api\DelegatedMedia[], already in attachment order.
+
+  Not a lightbox: each cell opens the media's own large/original
+  rendition in a new tab — the simplest thing that actually works,
+  degrading to nothing (a dead link) only if JS never loads doesn't
+  apply here since there is no JS in the loop at all.
+#}
+{% if media is not empty %}
+    <div class="groups-media-grid groups-media-grid-{{ media|length }} mt-2">
+        {% for m in media %}
+            <a href="/gallery/media/{{ m.id }}/{{ m.mediaType == 'video' ? 'original' : 'large' }}"
+               target="_blank" rel="noopener" class="groups-media-cell text-decoration-none">
+                {% include '@groups/partials/media_thumb.html.twig' with { media: m } %}
+            </a>
+        {% endfor %}
+    </div>
+{% endif %}

--- a/modules/groups/views/show.html.twig
+++ b/modules/groups/views/show.html.twig
@@ -2,15 +2,19 @@
 
 {% block title %}{{ group.name }} — {{ site_name }}{% endblock %}
 
+{% block stylesheets %}
+<link rel="stylesheet" href="/assets/css/components.css">
+{% endblock %}
+
 {% block content %}
     {% include '@groups/partials/group_header.html.twig' %}
 
     {% if post_permission.allowed %}
-        <form method="post" action="/groups/{{ group.id }}/posts" class="card mb-3">
+        <form method="post" action="/groups/{{ group.id }}/posts" enctype="multipart/form-data" class="card mb-3" id="groups-post-form">
             <div class="card-body">
                 <label class="form-label small mb-1" for="post-body">Écrire un message</label>
                 {{ csrf_field()|raw }}
-                <textarea class="form-control mb-2" id="post-body" name="body" rows="3" required
+                <textarea class="form-control mb-2" id="post-body" name="body" rows="3"
                           maxlength="{{ max_body_length }}" placeholder="Votre message…"></textarea>
 
                 {% if author_options is not empty %}
@@ -22,7 +26,32 @@
                     </select>
                 {% endif %}
 
-                <button type="submit" class="btn btn-primary" style="min-height:44px;">Publier</button>
+                <div id="groups-media-previews" class="d-flex flex-wrap gap-2 mb-2"></div>
+                <input type="file" name="media[]" id="groups-media-hidden" class="d-none" multiple>
+
+                <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
+                    <div class="d-flex gap-2">
+                        <label class="btn btn-outline-secondary d-flex align-items-center mb-0" style="min-height:44px;">
+                            <i class="bi bi-image me-1"></i> Photos{{ video_upload_allowed ? '/vidéos' : '' }}
+                            <input type="file" id="groups-media-input" class="visually-hidden"
+                                   accept="{{ video_upload_allowed ? 'image/*,video/*' : 'image/*' }}" multiple>
+                        </label>
+                        <label class="btn btn-outline-secondary d-flex align-items-center mb-0" style="min-height:44px;">
+                            <i class="bi bi-camera me-1"></i> Appareil photo
+                            <input type="file" id="groups-media-capture" class="visually-hidden"
+                                   accept="image/*" capture="environment">
+                        </label>
+                    </div>
+                    <span class="small text-body-secondary" id="groups-media-count">0 / {{ max_media_per_post }} médias</span>
+                </div>
+                <p class="small text-danger mt-1 mb-0 d-none" id="groups-media-limit-warning">
+                    Maximum {{ max_media_per_post }} médias par message — les fichiers en trop n'ont pas été ajoutés.
+                </p>
+                {% if not video_upload_allowed %}
+                    <p class="small text-body-secondary mt-1 mb-0">L'envoi de vidéos est désactivé sur ce site.</p>
+                {% endif %}
+
+                <button type="submit" class="btn btn-primary mt-2" style="min-height:44px;">Publier</button>
             </div>
         </form>
     {% endif %}
@@ -45,6 +74,95 @@
 
 {% block scripts %}
 <script nonce="{{ csp_nonce }}">
+// Composer media picker: both visible <input type="file"> elements (the
+// gallery/camera pickers) are UI-only sources of File objects — never
+// submitted themselves. Selected files accumulate in selectedFiles[],
+// capped client-side at max_media_per_post (a convenience: the server
+// enforces the real ceiling and rejects the whole post over it, never
+// truncating — Service\PostMediaService::MAX_MEDIA_PER_POST). Before
+// submit, they're copied onto the one hidden <input name="media[]">
+// that actually gets posted, via the DataTransfer API (the only way to
+// programmatically set an <input>'s .files).
+(() => {
+    const maxMedia = {{ max_media_per_post|default(4) }};
+    const previews = document.getElementById('groups-media-previews');
+    const hiddenInput = document.getElementById('groups-media-hidden');
+    const countLabel = document.getElementById('groups-media-count');
+    const limitWarning = document.getElementById('groups-media-limit-warning');
+    const form = document.getElementById('groups-post-form');
+    if (!previews || !hiddenInput || !form) {
+        return;
+    }
+
+    let selectedFiles = [];
+
+    function render() {
+        previews.innerHTML = '';
+        selectedFiles.forEach((file, index) => {
+            const cell = document.createElement('div');
+            cell.className = 'position-relative';
+            cell.style.cssText = 'width:72px;height:72px;border-radius:.375rem;overflow:hidden;background:#eee;';
+
+            if (file.type.startsWith('image/')) {
+                const img = document.createElement('img');
+                img.src = URL.createObjectURL(file);
+                img.className = 'w-100 h-100';
+                img.style.objectFit = 'cover';
+                cell.appendChild(img);
+            } else {
+                const icon = document.createElement('div');
+                icon.className = 'd-flex align-items-center justify-content-center h-100 text-body-secondary';
+                icon.innerHTML = '<i class="bi bi-camera-video fs-4"></i>';
+                cell.appendChild(icon);
+            }
+
+            const remove = document.createElement('button');
+            remove.type = 'button';
+            remove.className = 'btn btn-sm btn-dark position-absolute top-0 end-0 p-0 d-flex align-items-center justify-content-center';
+            remove.style.cssText = 'width:22px;height:22px;border-radius:50%;opacity:.85;';
+            remove.setAttribute('aria-label', 'Retirer ce média');
+            remove.innerHTML = '<i class="bi bi-x" style="font-size:.9rem;"></i>';
+            remove.addEventListener('click', () => {
+                selectedFiles.splice(index, 1);
+                sync();
+            });
+            cell.appendChild(remove);
+
+            previews.appendChild(cell);
+        });
+    }
+
+    function sync() {
+        const dataTransfer = new DataTransfer();
+        selectedFiles.forEach((file) => dataTransfer.items.add(file));
+        hiddenInput.files = dataTransfer.files;
+        countLabel.textContent = selectedFiles.length + ' / ' + maxMedia + ' médias';
+        render();
+    }
+
+    function addFiles(fileList) {
+        let overflowed = false;
+        Array.from(fileList).forEach((file) => {
+            if (selectedFiles.length >= maxMedia) {
+                overflowed = true;
+                return;
+            }
+            selectedFiles.push(file);
+        });
+        limitWarning.classList.toggle('d-none', !overflowed);
+        sync();
+    }
+
+    ['groups-media-input', 'groups-media-capture'].forEach((id) => {
+        const input = document.getElementById(id);
+        if (!input) return;
+        input.addEventListener('change', () => {
+            if (input.files) addFiles(input.files);
+            input.value = '';
+        });
+    });
+})();
+
 // "Charger plus" appends the next keyset page in place, and the inline
 // edit form toggles without leaving the feed. Both degrade to a plain
 // page reload if this script never runs: the button is a real link target

--- a/public/assets/css/components.css
+++ b/public/assets/css/components.css
@@ -226,3 +226,62 @@
 .list-editor-drag-handle:active {
     cursor: grabbing;
 }
+
+/* Modules\Groups\views\partials\post_media_grid.html.twig — a post's
+   attached media (1 to 4), and the flat "Galerie du groupe" grid
+   (gallery.html.twig) reuses the single-cell rule below on its own
+   plain wrapping grid. Module spec: 1 media wide, 2 side by side, 3
+   with one tall on the left, 4 in a 2x2 — expressed with CSS grid
+   rather than Bootstrap's column system, since the 3-media layout's
+   spanning first cell has no equivalent there. */
+.groups-media-grid {
+    display: grid;
+    gap: 2px;
+    border-radius: 0.5rem;
+    overflow: hidden;
+}
+.groups-media-grid-1 {
+    grid-template-columns: 1fr;
+    aspect-ratio: 4 / 3;
+}
+.groups-media-grid-2 {
+    grid-template-columns: 1fr 1fr;
+    aspect-ratio: 16 / 9;
+}
+.groups-media-grid-3 {
+    grid-template-columns: 2fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    aspect-ratio: 4 / 3;
+}
+.groups-media-grid-3 .groups-media-cell:first-child {
+    grid-row: 1 / span 2;
+}
+.groups-media-grid-4 {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
+    aspect-ratio: 4 / 3;
+}
+.groups-media-cell {
+    position: relative;
+    display: block;
+    background-color: var(--bs-tertiary-bg);
+}
+
+/* Flat grid for gallery.html.twig ("Galerie du groupe") — every media of
+   the group's posts, same square-cell look as modules/gallery's own
+   album grid, laid out with plain wrapping instead of the 1-4 mosaic
+   above (there is no "one post" grouping to shape here). */
+.groups-gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 4px;
+}
+@media (min-width: 576px) {
+    .groups-gallery-grid { grid-template-columns: repeat(4, 1fr); }
+}
+@media (min-width: 768px) {
+    .groups-gallery-grid { grid-template-columns: repeat(6, 1fr); }
+}
+.groups-gallery-grid .groups-media-cell {
+    aspect-ratio: 1 / 1;
+}

--- a/public/index.php
+++ b/public/index.php
@@ -2209,32 +2209,59 @@ if (in_array('groups', $moduleManager->getEnabledModuleIds(), true)) {
     $groupsPostRepo = new \Modules\Groups\Repository\PostRepository($pdo);
     $groupsActivityService = new \Modules\Groups\Service\GroupActivityService($groupsGroupRepo, $groupsPostRepo);
     $groupsPostService = new \Modules\Groups\Service\PostService($groupsPostRepo, $groupsActivityService);
+
+    // gallery is a hard dependency (module.json's requires) — this block
+    // only ever runs when it is enabled, so $galleryDelegatedAlbumManager
+    // (built unconditionally inside gallery's own block above) is always
+    // available here; no nullable optional-dependency handling. The
+    // assert() below is a static-analysis narrowing hint only (PHPStan
+    // cannot see across the two independent `if` blocks) — same
+    // precedent as the \assert() calls already in DelegatedAlbumService
+    // and GalleryController.
+    \assert(isset($galleryDelegatedAlbumManager));
+    $groupsPostMediaRepo = new \Modules\Groups\Repository\PostMediaRepository($pdo);
+    $groupsPostMediaService = new \Modules\Groups\Service\PostMediaService(
+        $galleryDelegatedAlbumManager, $groupsPostMediaRepo, $groupsGroupRepo
+    );
+
     $groupsFeedService = new \Modules\Groups\Service\GroupFeedService(
         $groupsPostRepo,
         new \Modules\Groups\Service\PostAuthorResolver($memberService, $userAccountRepo),
-        $groupsPostService
+        $groupsPostService,
+        $groupsPostMediaService
     );
 
-    // Group files (group media, later) are readable only by the group's
-    // own members — ARCHITECTURE.md §8.3's owner_type registry, appended
-    // here so it reaches FileAccessGuard, which is built after every
-    // module block. Nothing stores such a file yet.
-    $fileOwnershipCheckers[] = new \Modules\Groups\File\GroupFileOwnershipChecker(
+    // Group files are readable only by the group's own members —
+    // ARCHITECTURE.md §8.3's owner_type registry, appended here so it
+    // reaches FileAccessGuard, which is built after every module block.
+    $groupsFileOwnershipChecker = new \Modules\Groups\File\GroupFileOwnershipChecker(
         $groupsGroupRepo, $groupsAccessService, $scoutYearResolver
+    );
+    $fileOwnershipCheckers[] = $groupsFileOwnershipChecker;
+
+    // The gallery-side twin of the checker above, appended to gallery's
+    // OWN registry (Service\DelegatedAlbumAccessRegistry — a SEPARATE
+    // registry from Core\File\FileAccessGuard's, see gallery prompt 5) so
+    // a group's delegated album is readable by exactly the same members.
+    // $galleryDelegatedAlbumAccessCheckers is seeded near the top of this
+    // file and only consumed at the very end, once every module block
+    // that might append to it — this one included — has run.
+    $galleryDelegatedAlbumAccessCheckers[] = new \Modules\Groups\Gallery\GroupDelegatedAlbumAccessChecker(
+        $groupsFileOwnershipChecker
     );
 
     $frontController->registerController(
         \Modules\Groups\Controller\GroupController::class,
         new \Modules\Groups\Controller\GroupController(
             $twig, $groupsGroupRepo, $groupsListService, $groupsAccessService, $groupsService,
-            $groupsContextFactory, $sectionService, $groupsFeedService, $memberService
+            $groupsContextFactory, $sectionService, $groupsFeedService, $memberService, $groupsPostMediaService
         )
     );
     $frontController->registerController(
         \Modules\Groups\Controller\PostController::class,
         new \Modules\Groups\Controller\PostController(
             $twig, $groupsGroupRepo, $groupsPostRepo, $groupsAccessService, $groupsFeedService,
-            $groupsPostService, $groupsContextFactory
+            $groupsPostService, $groupsContextFactory, $groupsPostMediaService
         )
     );
     $frontController->registerController(

--- a/tests/Core/File/UploadHandlerTest.php
+++ b/tests/Core/File/UploadHandlerTest.php
@@ -187,6 +187,39 @@ class UploadHandlerTest extends TestCase
         $this->assertSame(20, imagesy($stored));
     }
 
+    public function testOwnerTypeAndOwnerIdArePropagatedToTheFileRow(): void
+    {
+        $tmpFile = $this->createTempImage();
+
+        $fileId = $this->handler->handle(
+            ['tmp_name' => $tmpFile, 'name' => 'photo.jpg', 'size' => filesize($tmpFile), 'error' => UPLOAD_ERR_OK],
+            'test', ['image/jpeg'], 10 * 1024 * 1024, 'identified', 'gallery', 1,
+            'discussion_group', 42
+        );
+
+        $stmt = $this->pdo->prepare('SELECT owner_type, owner_id FROM files WHERE id = ?');
+        $stmt->execute([$fileId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertSame('discussion_group', $row['owner_type']);
+        $this->assertSame(42, (int) $row['owner_id']);
+    }
+
+    public function testOwnerTypeAndOwnerIdDefaultToNull(): void
+    {
+        $tmpFile = $this->createTempImage();
+
+        $fileId = $this->handler->handle(
+            ['tmp_name' => $tmpFile, 'name' => 'photo.jpg', 'size' => filesize($tmpFile), 'error' => UPLOAD_ERR_OK],
+            'test', ['image/jpeg'], 10 * 1024 * 1024, 'public'
+        );
+
+        $stmt = $this->pdo->prepare('SELECT owner_type, owner_id FROM files WHERE id = ?');
+        $stmt->execute([$fileId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertNull($row['owner_type']);
+        $this->assertNull($row['owner_id']);
+    }
+
     public function testUploadErrorThrowsException(): void
     {
         $this->expectException(UploadException::class);

--- a/tests/Modules/Gallery/GalleryTestHelper.php
+++ b/tests/Modules/Gallery/GalleryTestHelper.php
@@ -54,7 +54,8 @@ class GalleryTestHelper
             FOREIGN KEY (created_by) REFERENCES user_accounts(id),
             FOREIGN KEY (storage_location_id) REFERENCES gallery_storage_locations(id),
             FOREIGN KEY (migration_target_location_id) REFERENCES gallery_storage_locations(id),
-            FOREIGN KEY (og_image_file_id) REFERENCES files(id)
+            FOREIGN KEY (og_image_file_id) REFERENCES files(id),
+            UNIQUE (owner_type, owner_id)
         )');
 
         $pdo->exec('CREATE TABLE gallery_media (

--- a/tests/Modules/Gallery/Service/DelegatedAlbumServiceTest.php
+++ b/tests/Modules/Gallery/Service/DelegatedAlbumServiceTest.php
@@ -176,4 +176,55 @@ class DelegatedAlbumServiceTest extends TestCase
         $this->expectException(GalleryException::class);
         $this->service->deleteAlbum(999999);
     }
+
+    /**
+     * Simulates two requests racing to create the same owner's first
+     * album: findByOwner() misses (the competitor's row isn't there yet),
+     * then the competitor's INSERT lands first, so this call's own
+     * INSERT hits gallery_albums' UNIQUE(owner_type, owner_id) index and
+     * must recover by returning the competitor's album instead of
+     * throwing or creating a second one.
+     */
+    public function testEnsureAlbumIsSafeUnderAConcurrentRaceForTheSameOwner(): void
+    {
+        $racingRepository = new class ($this->pdo) extends AlbumRepository {
+            public ?int $competitorAlbumId = null;
+
+            public function create(
+                string $type, string $title, ?string $subtitle, string $albumDate, ?int $sectionId,
+                int $scoutYearId, ?string $externalUrl, ?int $storageLocationId, int $createdBy,
+                ?string $ownerType = null, ?int $ownerId = null
+            ): int {
+                // The "other request" wins the race, committing its own
+                // album for the same owner right before this call's INSERT
+                // runs — parent::create() below must now collide with it.
+                $this->competitorAlbumId = parent::create(
+                    $type, 'Compétiteur', $subtitle, $albumDate, $sectionId, $scoutYearId,
+                    $externalUrl, $storageLocationId, $createdBy, $ownerType, $ownerId
+                );
+
+                return parent::create(
+                    $type, $title, $subtitle, $albumDate, $sectionId, $scoutYearId,
+                    $externalUrl, $storageLocationId, $createdBy, $ownerType, $ownerId
+                );
+            }
+        };
+
+        $service = new DelegatedAlbumService(
+            $racingRepository, $this->mediaRepository, $this->createMock(MediaService::class),
+            $this->storageLocationRepository,
+            new StorageLocationService(
+                $this->storageLocationRepository, $racingRepository, $this->storageBackendFactory,
+                $this->createMock(SettingService::class), new S3SecretRepository($this->pdo, new EncryptionService(str_repeat('a', 32), str_repeat('b', 32))),
+                sys_get_temp_dir()
+            ),
+            $this->storageBackendFactory, new ScoutYearService($this->pdo)
+        );
+
+        $album = $service->ensureAlbum('some_owner_type', 42, 'Titre', '2026-01-01', $this->authorId);
+
+        $this->assertNotNull($racingRepository->competitorAlbumId);
+        $this->assertSame($racingRepository->competitorAlbumId, $album->id, 'the competitor\'s album must win, never a second one');
+        $this->assertSame(1, (int) $this->pdo->query('SELECT COUNT(*) FROM gallery_albums')->fetchColumn());
+    }
 }

--- a/tests/Modules/Gallery/Service/MediaServiceTest.php
+++ b/tests/Modules/Gallery/Service/MediaServiceTest.php
@@ -237,6 +237,36 @@ class MediaServiceTest extends TestCase
         $this->assertNotNull($this->mediaRepository->findById($media->id));
     }
 
+    public function testAddWithoutAuthorisationCheckPropagatesTheAlbumsOwnerOntoTheUploadedFile(): void
+    {
+        // So Core\File\FileAccessGuard's ownership registry — not just
+        // 'identified' — governs /files/{id} for a delegated album's raw
+        // original too, closing the same gap /gallery/media/{id}/{size}
+        // already closes for its renditions.
+        $album = $this->albumRepository->findById($this->createDelegatedAlbum());
+
+        $media = $this->service->addWithoutAuthorisationCheck($album, $this->fakeUploadedImage(), $this->authorId);
+
+        $stmt = $this->pdo->prepare('SELECT owner_type, owner_id FROM files WHERE id = ?');
+        $stmt->execute([$media->fileId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertSame('some_owner_type', $row['owner_type']);
+        $this->assertSame(42, (int) $row['owner_id']);
+    }
+
+    public function testUploadLeavesTheFilesOwnerColumnsNullForAnOrdinaryAlbum(): void
+    {
+        $album = $this->albumRepository->findById($this->albumId);
+
+        $media = $this->service->upload($album, $this->fakeUploadedImage(), Role::CHIEF, 'chief@test.com', $this->authorId);
+
+        $stmt = $this->pdo->prepare('SELECT owner_type, owner_id FROM files WHERE id = ?');
+        $stmt->execute([$media->fileId]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+        $this->assertNull($row['owner_type']);
+        $this->assertNull($row['owner_id']);
+    }
+
     public function testDeleteThrowsForADelegatedAlbum(): void
     {
         $albumId = $this->createDelegatedAlbum();

--- a/tests/Modules/Groups/Controller/GroupControllerTest.php
+++ b/tests/Modules/Groups/Controller/GroupControllerTest.php
@@ -15,10 +15,13 @@ use Core\Security\AuthSession;
 use Core\Security\UserAccount;
 use Core\Security\UserAccountRepository;
 use Core\View\TwigFactory;
+use Modules\Gallery\Api\DelegatedAlbumManager;
+use Modules\Gallery\Api\DelegatedMedia;
 use Modules\Groups\Controller\GroupController;
 use Modules\Groups\Repository\GroupMemberRepository;
 use Modules\Groups\Repository\GroupRepository;
 use Modules\Groups\Repository\GroupSectionRepository;
+use Modules\Groups\Repository\PostMediaRepository;
 use Modules\Groups\Repository\PostRepository;
 use Modules\Groups\Service\GroupAccessService;
 use Modules\Groups\Service\GroupActivityService;
@@ -27,6 +30,7 @@ use Modules\Groups\Service\GroupListService;
 use Modules\Groups\Service\GroupService;
 use Modules\Groups\Service\GroupSessionContextFactory;
 use Modules\Groups\Service\PostAuthorResolver;
+use Modules\Groups\Service\PostMediaService;
 use Modules\Groups\Service\PostService;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -78,8 +82,12 @@ class GroupControllerTest extends TestCase
     /**
      * @param int[] $linkedMemberIds
      */
-    private function controller(array $linkedMemberIds, string $role = 'identified', bool $completeProfile = true): GroupController
-    {
+    private function controller(
+        array $linkedMemberIds,
+        string $role = 'identified',
+        bool $completeProfile = true,
+        ?DelegatedAlbumManager $delegatedAlbumManager = null
+    ): GroupController {
         AuthSession::login(1, 'parent@test.be', $role);
 
         $sectionRepo = new GroupSectionRepository($this->pdo);
@@ -131,7 +139,13 @@ class GroupControllerTest extends TestCase
 
         $postRepo = new PostRepository($this->pdo);
         $postService = new PostService($postRepo, new GroupActivityService($this->groupRepo, $postRepo));
-        $feedService = new GroupFeedService($postRepo, new PostAuthorResolver($this->memberService, $accountRepo), $postService);
+        $postMediaService = new PostMediaService(
+            $delegatedAlbumManager ?? $this->createMock(DelegatedAlbumManager::class),
+            new PostMediaRepository($this->pdo), $this->groupRepo
+        );
+        $feedService = new GroupFeedService(
+            $postRepo, new PostAuthorResolver($this->memberService, $accountRepo), $postService, $postMediaService
+        );
 
         return new GroupController(
             $twig,
@@ -142,7 +156,8 @@ class GroupControllerTest extends TestCase
             new GroupSessionContextFactory($this->memberService, $accountRepo, $resolver),
             $sectionService,
             $feedService,
-            $this->memberService
+            $this->memberService,
+            $postMediaService
         );
     }
 
@@ -313,5 +328,70 @@ class GroupControllerTest extends TestCase
 
         $this->assertStringContainsString('Louveteaux 24-25', $body);
         $this->assertStringNotContainsString('Louveteaux 25-26', $body);
+    }
+
+    // --- media -----------------------------------------------------------
+
+    public function testGalleryReturns404ForANonMemberRatherThan403(): void
+    {
+        $creator = GroupsTestHelper::createMember($this->pdo, 'CG1');
+        $groupId = $this->groupService->createSectionGroup('Louveteaux', $this->sectionId, $this->currentYearId, $creator);
+        $outsider = GroupsTestHelper::createMember($this->pdo, 'OUTG1');
+
+        $response = $this->controller([$outsider])
+            ->gallery(new Request('GET', '/groups/' . $groupId . '/gallery', [], [], [], []), ['id' => (string) $groupId]);
+
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testGalleryRendersEveryMediaForAMember(): void
+    {
+        $creator = GroupsTestHelper::createMember($this->pdo, 'CG2');
+        $groupId = $this->groupService->createSectionGroup('Louveteaux', $this->sectionId, $this->currentYearId, $creator);
+        $this->groupRepo->setGalleryAlbumId($groupId, 42);
+        $member = GroupsTestHelper::createMemberWithPeriod($this->pdo, 'MG2', $this->sectionId, $this->currentYearId);
+
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->once())->method('listMedia')->with(42)->willReturn([
+            new DelegatedMedia(1, 'photo', 'done', 0, 'a.jpg', '2026-01-01 10:00:00'),
+            new DelegatedMedia(2, 'video', 'done', 1, 'b.mp4', '2026-01-02 10:00:00'),
+        ]);
+
+        $body = $this->controller([$member], 'identified', true, $manager)
+            ->gallery(new Request('GET', '/groups/' . $groupId . '/gallery', [], [], [], []), ['id' => (string) $groupId])
+            ->getBody();
+
+        $this->assertStringContainsString('/gallery/media/1/thumb', $body);
+        $this->assertStringContainsString('/gallery/media/2/thumb', $body);
+    }
+
+    /**
+     * DoD: "'pending' and 'failed' media render without breaking the
+     * feed, tested." — a media in either state must never produce a
+     * broken <img> or crash the page.
+     */
+    public function testShowRendersPendingAndFailedMediaWithoutBreakingThePage(): void
+    {
+        $creator = GroupsTestHelper::createMember($this->pdo, 'CG3');
+        $groupId = $this->groupService->createSectionGroup('Louveteaux', $this->sectionId, $this->currentYearId, $creator);
+        $this->groupRepo->setGalleryAlbumId($groupId, 42);
+        $member = GroupsTestHelper::createMemberWithPeriod($this->pdo, 'MG3', $this->sectionId, $this->currentYearId);
+        $postId = GroupsTestHelper::createPostAt($this->pdo, $groupId, 'Photos en cours', '2026-01-01 10:00:00', 1, $creator);
+        (new \Modules\Groups\Repository\PostMediaRepository($this->pdo))->attach($postId, 1, 0);
+        (new \Modules\Groups\Repository\PostMediaRepository($this->pdo))->attach($postId, 2, 1);
+
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('listMedia')->willReturn([
+            new DelegatedMedia(1, 'photo', 'pending', 0, 'a.jpg', '2026-01-01 10:00:00'),
+            new DelegatedMedia(2, 'photo', 'failed', 1, 'b.jpg', '2026-01-01 10:00:00'),
+        ]);
+
+        $response = $this->controller([$member], 'identified', true, $manager)
+            ->show(new Request('GET', '/groups/' . $groupId, [], [], [], []), ['id' => (string) $groupId]);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringNotContainsString('/gallery/media/1/thumb', $response->getBody(), 'a pending media never renders an <img>');
+        $this->assertStringContainsString('spinner-border', $response->getBody());
+        $this->assertStringContainsString('Échec du traitement', $response->getBody());
     }
 }

--- a/tests/Modules/Groups/Controller/PostControllerTest.php
+++ b/tests/Modules/Groups/Controller/PostControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Modules\Groups\Controller;
 
+use Core\Http\FlashMessage;
 use Core\Http\Request;
 use Core\Member\MemberProfile;
 use Core\Member\MemberService;
@@ -14,10 +15,15 @@ use Core\Security\AuthSession;
 use Core\Security\UserAccount;
 use Core\Security\UserAccountRepository;
 use Core\View\TwigFactory;
+use Modules\Gallery\Api\DelegatedAlbum;
+use Modules\Gallery\Api\DelegatedAlbumManager;
+use Modules\Gallery\Api\DelegatedMedia;
+use Modules\Gallery\Service\GalleryException;
 use Modules\Groups\Controller\PostController;
 use Modules\Groups\Repository\GroupMemberRepository;
 use Modules\Groups\Repository\GroupRepository;
 use Modules\Groups\Repository\GroupSectionRepository;
+use Modules\Groups\Repository\PostMediaRepository;
 use Modules\Groups\Repository\PostRepository;
 use Modules\Groups\Service\GroupAccessService;
 use Modules\Groups\Service\GroupActivityService;
@@ -25,6 +31,7 @@ use Modules\Groups\Service\GroupFeedService;
 use Modules\Groups\Service\GroupService;
 use Modules\Groups\Service\GroupSessionContextFactory;
 use Modules\Groups\Service\PostAuthorResolver;
+use Modules\Groups\Service\PostMediaService;
 use Modules\Groups\Service\PostService;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -84,13 +91,19 @@ class PostControllerTest extends TestCase
     {
         AuthSession::logout();
         $_POST = [];
+        $_FILES = [];
     }
 
     /**
      * @param int[] $linkedMemberIds
      */
-    private function controller(array $linkedMemberIds, int $accountId = self::AUTHOR_ACCOUNT, string $role = 'identified', bool $completeProfile = true): PostController
-    {
+    private function controller(
+        array $linkedMemberIds,
+        int $accountId = self::AUTHOR_ACCOUNT,
+        string $role = 'identified',
+        bool $completeProfile = true,
+        ?DelegatedAlbumManager $delegatedAlbumManager = null
+    ): PostController {
         AuthSession::login($accountId, 'parent@test.be', $role);
 
         $sectionRepo = new GroupSectionRepository($this->pdo);
@@ -117,7 +130,13 @@ class PostControllerTest extends TestCase
         $resolver->method('getEffectiveYear')->willReturn(new EffectiveScoutYear($this->currentYearId, '2025-2026', null));
 
         $postService = new PostService($this->postRepo, new GroupActivityService($this->groupRepo, $this->postRepo));
-        $feedService = new GroupFeedService($this->postRepo, new PostAuthorResolver($memberService, $accountRepo), $postService);
+        $postMediaService = new PostMediaService(
+            $delegatedAlbumManager ?? $this->createMock(DelegatedAlbumManager::class),
+            new PostMediaRepository($this->pdo), $this->groupRepo
+        );
+        $feedService = new GroupFeedService(
+            $this->postRepo, new PostAuthorResolver($memberService, $accountRepo), $postService, $postMediaService
+        );
 
         $twig = TwigFactory::create(
             dirname(__DIR__, 4) . '/core/View/templates',
@@ -138,7 +157,8 @@ class PostControllerTest extends TestCase
             $access,
             $feedService,
             $postService,
-            new GroupSessionContextFactory($memberService, $accountRepo, $resolver)
+            new GroupSessionContextFactory($memberService, $accountRepo, $resolver),
+            $postMediaService
         );
     }
 
@@ -160,6 +180,23 @@ class PostControllerTest extends TestCase
     private function request(): Request
     {
         return new Request('POST', '/groups/' . $this->groupId . '/posts', [], $_POST, [], []);
+    }
+
+    /**
+     * Populates $_FILES['media'] in PHP's own multi-file shape (one array
+     * per property, not one array per file) — same shape a real
+     * <input type="file" name="media[]" multiple> submits, which is what
+     * Core\Http\Request::getFiles() expects to unpack.
+     */
+    private function withMediaFiles(int $count): void
+    {
+        $_FILES['media'] = [
+            'name' => array_fill(0, $count, 'photo.jpg'),
+            'tmp_name' => array_fill(0, $count, '/tmp/fake'),
+            'error' => array_fill(0, $count, 0),
+            'size' => array_fill(0, $count, 100),
+            'type' => array_fill(0, $count, 'image/jpeg'),
+        ];
     }
 
     /**
@@ -252,6 +289,97 @@ class PostControllerTest extends TestCase
         $posts = $this->postRepo->findPage($this->groupId, 10);
         $this->assertCount(1, $posts);
         $this->assertSame($this->memberId, $posts[0]->authorMemberId, 'the forged author_member_id must be ignored');
+    }
+
+    // --- media -----------------------------------------------------------
+
+    public function testCreateRejectsAFifthMediaWithoutCreatingThePostAtAll(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->never())->method('ensureAlbum');
+        $manager->expects($this->never())->method('addMedia');
+
+        $this->withMediaFiles(5);
+        $this->withCsrf(['body' => 'Cinq médias']);
+
+        $response = $this->controller([$this->memberId], self::AUTHOR_ACCOUNT, 'identified', true, $manager)
+            ->create($this->request(), $this->params());
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame([], $this->postRepo->findPage($this->groupId, 10), 'the whole post must be rejected, not truncated to 4');
+        $flash = FlashMessage::get();
+        $this->assertNotNull($flash);
+        $this->assertSame('error', $flash['type']);
+        $this->assertStringContainsString('4', $flash['message']);
+    }
+
+    public function testCreateAcceptsExactlyFourMedia(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('ensureAlbum')->willReturn(new DelegatedAlbum(1, 'Louveteaux', '2026-01-01'));
+        $manager->method('addMedia')->willReturnCallback(
+            fn() => new DelegatedMedia(random_int(1000, 9999), 'photo', 'pending', 0, 'photo.jpg', '2026-01-01 10:00:00')
+        );
+
+        $this->withMediaFiles(4);
+        $this->withCsrf(['body' => 'Quatre médias']);
+
+        $response = $this->controller([$this->memberId], self::AUTHOR_ACCOUNT, 'identified', true, $manager)
+            ->create($this->request(), $this->params());
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertCount(1, $this->postRepo->findPage($this->groupId, 10));
+    }
+
+    public function testCreateAcceptsAMediaOnlyPostWithNoBodyText(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('ensureAlbum')->willReturn(new DelegatedAlbum(1, 'Louveteaux', '2026-01-01'));
+        $manager->method('addMedia')->willReturn(new DelegatedMedia(1, 'photo', 'pending', 0, 'photo.jpg', '2026-01-01 10:00:00'));
+
+        $this->withMediaFiles(1);
+        $this->withCsrf(['body' => '']);
+
+        $this->controller([$this->memberId], self::AUTHOR_ACCOUNT, 'identified', true, $manager)
+            ->create($this->request(), $this->params());
+
+        $posts = $this->postRepo->findPage($this->groupId, 10);
+        $this->assertCount(1, $posts);
+        $this->assertSame('', $posts[0]->body);
+    }
+
+    public function testCreateWithNeitherBodyNorMediaSavesNothing(): void
+    {
+        $this->withCsrf(['body' => '']);
+
+        $this->controller([$this->memberId])->create($this->request(), $this->params());
+
+        $this->assertSame([], $this->postRepo->findPage($this->groupId, 10));
+    }
+
+    public function testCreateRollsBackTheWholePostWhenAVideoIsRefusedServerSide(): void
+    {
+        // Reproduces the "videos disabled" case: gallery's own addMedia()
+        // already refuses server-side (Api\DelegatedAlbumManager::
+        // videoUploadAllowed()'s docblock) — this asserts the whole post
+        // disappears, not just the media, matching the module spec
+        // ("never a silent failure or a stuck upload").
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('ensureAlbum')->willReturn(new DelegatedAlbum(1, 'Louveteaux', '2026-01-01'));
+        $manager->method('addMedia')->willThrowException(new GalleryException("L'envoi de vidéos est désactivé."));
+
+        $this->withMediaFiles(1);
+        $this->withCsrf(['body' => 'Une vidéo']);
+
+        $response = $this->controller([$this->memberId], self::AUTHOR_ACCOUNT, 'identified', true, $manager)
+            ->create($this->request(), $this->params());
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame([], $this->postRepo->findPage($this->groupId, 10), 'no half-saved post');
+        $flash = FlashMessage::get();
+        $this->assertNotNull($flash);
+        $this->assertSame('error', $flash['type']);
+        $this->assertStringContainsString('vidéo', $flash['message']);
     }
 
     // --- edit ----------------------------------------------------------

--- a/tests/Modules/Groups/GroupsTestHelper.php
+++ b/tests/Modules/Groups/GroupsTestHelper.php
@@ -23,7 +23,8 @@ class GroupsTestHelper
             last_activity_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
             created_by_member_id INTEGER NOT NULL,
             created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
-            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            gallery_album_id INTEGER NULL
         )');
 
         $pdo->exec('CREATE TABLE discussion_group_sections (
@@ -57,6 +58,16 @@ class GroupsTestHelper
             last_activity_at TEXT NOT NULL,
             created_at TEXT NOT NULL,
             FOREIGN KEY (group_id) REFERENCES discussion_groups(id) ON DELETE CASCADE
+        )');
+
+        $pdo->exec('CREATE TABLE discussion_group_post_media (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            post_id INTEGER NOT NULL,
+            gallery_media_id INTEGER NOT NULL,
+            sort_order INTEGER NOT NULL DEFAULT 0,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            UNIQUE(post_id, gallery_media_id),
+            FOREIGN KEY (post_id) REFERENCES discussion_group_posts(id) ON DELETE CASCADE
         )');
     }
 

--- a/tests/Modules/Groups/ModuleManifestTest.php
+++ b/tests/Modules/Groups/ModuleManifestTest.php
@@ -37,7 +37,7 @@ class ModuleManifestTest extends TestCase
      */
     public function testTheVersionIsBumpedWheneverTheSchemaChanges(): void
     {
-        $this->assertSame('1.1.0', $this->manifest->version);
+        $this->assertSame('1.2.0', $this->manifest->version);
     }
 
     public function testThePostActionsAreDeclaredAsPostRoutesOnly(): void

--- a/tests/Modules/Groups/PostMediaIntegrationTest.php
+++ b/tests/Modules/Groups/PostMediaIntegrationTest.php
@@ -1,0 +1,356 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Groups;
+
+use Core\File\FileAccessGuard;
+use Core\File\FileRepository;
+use Core\File\UploadHandler;
+use Core\Member\MemberService;
+use Core\Member\SectionMembershipRepository;
+use Core\Member\SectionService;
+use Core\ScoutYear\EffectiveScoutYear;
+use Core\ScoutYear\ScoutYearResolver;
+use Core\Config\ScoutYearService;
+use Core\Config\SettingService;
+use Core\Security\EncryptionService;
+use Core\Security\Role;
+use Modules\Gallery\Repository\AlbumRepository;
+use Modules\Gallery\Repository\MediaRepository;
+use Modules\Gallery\Repository\S3SecretRepository;
+use Modules\Gallery\Repository\StorageLocation;
+use Modules\Gallery\Repository\StorageLocationRepository;
+use Modules\Gallery\Service\DelegatedAlbumService;
+use Modules\Gallery\Service\FfmpegAvailability;
+use Modules\Gallery\Service\GalleryAccessService;
+use Modules\Gallery\Service\MediaService;
+use Modules\Gallery\Service\Storage\StorageBackendFactory;
+use Modules\Gallery\Service\Storage\StorageBackendInterface;
+use Modules\Gallery\Service\StorageLocationService;
+use Modules\Groups\File\GroupFileOwnershipChecker;
+use Modules\Groups\Repository\GroupRepository;
+use Modules\Groups\Repository\PostMediaRepository;
+use Modules\Groups\Service\GroupAccessService;
+use Modules\Groups\Service\GroupService;
+use Modules\Groups\Service\GroupSessionContext;
+use Modules\Groups\Service\PostMediaService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Gallery\GalleryTestHelper;
+
+/**
+ * PostMediaService wired against the REAL gallery stack (unlike
+ * Service\PostMediaServiceTest, which mocks Api\DelegatedAlbumManager) —
+ * the only place this module's DoD items about actual cross-module
+ * behaviour are exercised: concurrency-safe album creation, /files/{id}
+ * scoping through Core\File\FileAccessGuard, and genuine deletion of
+ * stored objects (local and S3).
+ *
+ * @group database
+ */
+#[Group('database')]
+class PostMediaIntegrationTest extends TestCase
+{
+    private \PDO $pdo;
+    private GroupRepository $groupRepo;
+    private StorageLocationRepository $storageLocationRepo;
+    private AlbumRepository $albumRepo;
+    private MediaRepository $mediaRepo;
+    private FileRepository $fileRepo;
+    private StorageBackendFactory $storageBackendFactory;
+    private int $groupId;
+    private int $creatorMemberId;
+    private int $creatorAccountId;
+    private string $storagePath;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        GalleryTestHelper::createTables($this->pdo);
+        GroupsTestHelper::createTables($this->pdo);
+        // The rest of the suite leaves SQLite's FK enforcement off (its
+        // default), so ON DELETE CASCADE is normally inert in tests —
+        // enabled here only for this file, which specifically verifies
+        // that a deleted post's join rows are actually gone afterward.
+        $this->pdo->exec('PRAGMA foreign_keys = ON');
+
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+
+        $this->groupRepo = new GroupRepository($this->pdo);
+        $this->creatorMemberId = GroupsTestHelper::createMember($this->pdo, 'CREATOR');
+        $this->groupId = $this->groupRepo->create('Louveteaux', null, null, $this->creatorMemberId);
+
+        $stmt = $this->pdo->prepare('INSERT INTO user_accounts (email_encrypted, email_blind_index) VALUES (?, ?)');
+        $stmt->execute(['enc', 'idx']);
+        // gallery_albums.created_by is a user_accounts.id (FK), never a
+        // members.id — Service\PostMediaService::ensureAlbumId() passes
+        // the account id through for exactly this reason.
+        $this->creatorAccountId = (int) $this->pdo->lastInsertId();
+
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->storageLocationRepo = new StorageLocationRepository($this->pdo, $encryption);
+        $this->albumRepo = new AlbumRepository($this->pdo);
+        $this->mediaRepo = new MediaRepository($this->pdo);
+        $this->fileRepo = new FileRepository($this->pdo);
+
+        $this->storagePath = sys_get_temp_dir() . '/groups_media_integration_' . uniqid();
+        mkdir($this->storagePath, 0755, true);
+        $this->storageBackendFactory = new StorageBackendFactory($this->storageLocationRepo, $this->storagePath);
+
+        $this->storageLocationRepo->create(
+            StorageLocation::TYPE_LOCAL, 'Stockage local', 'gallery', null, null, null, null, null, null, null
+        );
+    }
+
+    private function delegatedAlbumService(?AlbumRepository $albumRepository = null): DelegatedAlbumService
+    {
+        $albumRepository ??= $this->albumRepo;
+        $settingService = $this->createMock(SettingService::class);
+        $settingService->method('get')->willReturnCallback(fn($key, $module, $default) => $default);
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+
+        $storageLocationService = new StorageLocationService(
+            $this->storageLocationRepo, $albumRepository, $this->storageBackendFactory,
+            $settingService, new S3SecretRepository($this->pdo, $encryption), $this->storagePath
+        );
+        $accessService = $this->createMock(GalleryAccessService::class);
+        $uploadHandler = new UploadHandler($this->fileRepo, $this->storagePath);
+        $mediaService = new MediaService(
+            $this->mediaRepo, $albumRepository, $uploadHandler, $this->createMock(\Core\Scheduler\SchedulerService::class),
+            $settingService, $accessService, $this->storageBackendFactory, $storageLocationService,
+            $this->createMock(FfmpegAvailability::class)
+        );
+
+        return new DelegatedAlbumService(
+            $albumRepository, $this->mediaRepo, $mediaService, $this->storageLocationRepo,
+            $storageLocationService, $this->storageBackendFactory, new ScoutYearService($this->pdo)
+        );
+    }
+
+    private function postMediaService(?AlbumRepository $albumRepository = null): PostMediaService
+    {
+        return new PostMediaService(
+            $this->delegatedAlbumService($albumRepository), new PostMediaRepository($this->pdo), $this->groupRepo
+        );
+    }
+
+    private function fakeUploadedImage(): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'groups_media_') . '.jpg';
+        $image = imagecreatetruecolor(10, 10);
+        imagejpeg($image, $path);
+        imagedestroy($image);
+
+        return ['name' => 'photo.jpg', 'tmp_name' => $path, 'error' => UPLOAD_ERR_OK, 'size' => filesize($path), 'type' => 'image/jpeg'];
+    }
+
+    private function fileOwnershipChecker(int $effectiveYearId): GroupFileOwnershipChecker
+    {
+        $sectionRepo = new \Modules\Groups\Repository\GroupSectionRepository($this->pdo);
+        $memberRepo = new \Modules\Groups\Repository\GroupMemberRepository($this->pdo);
+        $access = new GroupAccessService($memberRepo, $sectionRepo, new SectionMembershipRepository($this->pdo));
+        $resolver = $this->createMock(ScoutYearResolver::class);
+        $resolver->method('getEffectiveYear')->willReturn(new EffectiveScoutYear($effectiveYearId, '2025-2026', null));
+
+        return new GroupFileOwnershipChecker($this->groupRepo, $access, $resolver);
+    }
+
+    /**
+     * DoD: "Concurrent first-media posts create exactly one album,
+     * tested." Same race-simulation technique as gallery's own
+     * DelegatedAlbumServiceTest, exercised this time through
+     * Service\PostMediaService::ensureAlbumId() — the actual call site a
+     * concurrent first media post goes through.
+     */
+    public function testConcurrentFirstMediaPostsCreateExactlyOneAlbum(): void
+    {
+        $racingRepository = new class ($this->pdo) extends AlbumRepository {
+            public function create(
+                string $type, string $title, ?string $subtitle, string $albumDate, ?int $sectionId,
+                int $scoutYearId, ?string $externalUrl, ?int $storageLocationId, int $createdBy,
+                ?string $ownerType = null, ?int $ownerId = null
+            ): int {
+                // Another member's post wins the race for the same
+                // group's first album, landing its own INSERT first.
+                parent::create(
+                    $type, 'Compétiteur', $subtitle, $albumDate, $sectionId, $scoutYearId,
+                    $externalUrl, $storageLocationId, $createdBy, $ownerType, $ownerId
+                );
+
+                return parent::create(
+                    $type, $title, $subtitle, $albumDate, $sectionId, $scoutYearId,
+                    $externalUrl, $storageLocationId, $createdBy, $ownerType, $ownerId
+                );
+            }
+        };
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $albumId = $this->postMediaService($racingRepository)->ensureAlbumId($group, $this->creatorAccountId);
+
+        $this->assertSame(1, (int) $this->pdo->query('SELECT COUNT(*) FROM gallery_albums')->fetchColumn());
+        // The group's cached id points at whichever row actually exists.
+        $this->assertSame($albumId, $this->groupRepo->findById($this->groupId)->galleryAlbumId);
+    }
+
+    /**
+     * DoD: "The uploaded original is inaccessible to a non-member
+     * through /files/{id}, tested."
+     */
+    public function testTheUploadedOriginalIsInaccessibleToANonMemberThroughFileAccessGuard(): void
+    {
+        $currentYearId = (int) $this->pdo->query('SELECT id FROM scout_years LIMIT 1')->fetchColumn();
+        $member = GroupsTestHelper::createMember($this->pdo, 'M1');
+        // Explicit membership (not section-derived) so the checker's
+        // "member of the group" path is exercised directly.
+        $memberRepo = new \Modules\Groups\Repository\GroupMemberRepository($this->pdo);
+        $memberRepo->add($this->groupId, $member, false, null);
+        $outsider = GroupsTestHelper::createMember($this->pdo, 'OUT');
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $service = $this->postMediaService();
+        $media = $service->addMedia($group, $this->post(), [$this->fakeUploadedImage()], $this->creatorAccountId)[0];
+        $fileId = $this->mediaRepo->findById($media)->fileId;
+
+        $checker = $this->fileOwnershipChecker($currentYearId);
+
+        $memberGuard = new FileAccessGuard($this->fileRepo, Role::IDENTIFIED, [$member], [$checker]);
+        $outsiderGuard = new FileAccessGuard($this->fileRepo, Role::IDENTIFIED, [$outsider], [$checker]);
+
+        $this->assertNotNull($memberGuard->check($fileId));
+        $this->assertNull($outsiderGuard->check($fileId));
+    }
+
+    /**
+     * DoD: "Deleting a post removes join rows, media rows and stored
+     * objects, tested on both a local and an S3-configured location with
+     * no orphan left." — local half; the S3 half is
+     * testDeletingAPostRemovesStoredObjectsOnAnS3Location() below.
+     */
+    public function testDeletingAPostRemovesStoredObjectsOnALocalLocation(): void
+    {
+        $group = $this->groupRepo->findById($this->groupId);
+        $postMediaService = $this->postMediaService();
+        $postId = $this->post();
+
+        $mediaIds = $postMediaService->addMedia($group, $postId, [$this->fakeUploadedImage()], $this->creatorAccountId);
+        $mediaId = $mediaIds[0];
+        $group = $this->groupRepo->findById($this->groupId); // refreshed: now carries galleryAlbumId
+
+        // Simulates Task\ProcessPhotoHandler having already produced the
+        // three renditions gallery actually manages (and unlinked the raw
+        // original — a separate, gallery-internal lifecycle stage this
+        // test isn't exercising): writes real files through the same
+        // local backend production code uses, so their disappearance is
+        // genuinely observed rather than asserted against paths that
+        // were never populated in the first place.
+        $location = $this->storageLocationRepo->findDefault();
+        $backend = $this->storageBackendFactory->create($location);
+        $albumId = $group->galleryAlbumId;
+        $backend->put("{$albumId}/thumb_{$mediaId}.jpg", 'thumb-bytes', 'image/jpeg');
+        $backend->put("{$albumId}/med_{$mediaId}.jpg", 'med-bytes', 'image/jpeg');
+        $backend->put("{$albumId}/lg_{$mediaId}.jpg", 'lg-bytes', 'image/jpeg');
+        $this->mediaRepo->markPhotoDone(
+            $mediaId, "{$albumId}/thumb_{$mediaId}.jpg", "{$albumId}/med_{$mediaId}.jpg", "{$albumId}/lg_{$mediaId}.jpg", 100, 100
+        );
+        $thumbPath = $this->storagePath . "/gallery/{$albumId}/thumb_{$mediaId}.jpg";
+        $mediumPath = $this->storagePath . "/gallery/{$albumId}/med_{$mediaId}.jpg";
+        $largePath = $this->storagePath . "/gallery/{$albumId}/lg_{$mediaId}.jpg";
+        $this->assertFileExists($thumbPath);
+        $this->assertFileExists($mediumPath);
+        $this->assertFileExists($largePath);
+
+        // Mirrors Controller\PostController::delete()'s own sequence:
+        // media first (needs the still-existing join row to know what to
+        // remove), then the post row itself, whose ON DELETE CASCADE is
+        // what actually clears discussion_group_post_media.
+        $postMediaService->deleteAllForPost($group, $postId);
+        (new \Modules\Groups\Repository\PostRepository($this->pdo))->delete($postId);
+
+        $this->assertNull($this->mediaRepo->findById($mediaId));
+        $this->assertFileDoesNotExist($thumbPath);
+        $this->assertFileDoesNotExist($mediumPath);
+        $this->assertFileDoesNotExist($largePath);
+        $this->assertSame([], (new PostMediaRepository($this->pdo))->findMediaIdsForPost($postId));
+    }
+
+    /**
+     * S3 half of the DoD item above — asserts the storage backend
+     * actually receives delete()/deletePrefix() calls for the stored
+     * renditions, same mocking precedent gallery's own tests use for S3.
+     */
+    public function testDeletingAPostRemovesStoredObjectsOnAnS3Location(): void
+    {
+        $s3LocationId = $this->storageLocationRepo->create(
+            StorageLocation::TYPE_S3, 'Bucket privé', null, 'custom', 'https://s3.example.com', 'eu',
+            'bucket', 'ak', null, 'sk'
+        );
+
+        $backend = $this->createMock(StorageBackendInterface::class);
+        $backend->method('put');
+        $factory = $this->createMock(StorageBackendFactory::class);
+        $factory->method('create')->willReturn($backend);
+        $this->storageBackendFactory = $factory;
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $postMediaService = $this->postMediaService();
+        $postId = $this->post();
+
+        $album = $this->delegatedAlbumServiceEnsureAlbumOnLocation($s3LocationId);
+        $this->groupRepo->setGalleryAlbumId($this->groupId, $album);
+
+        $mediaId = $this->mediaRepo->create($album, 'photo', $this->seedFile(), 0, null);
+        $this->mediaRepo->markPhotoDone($mediaId, 'thumb.jpg', 'med.jpg', 'lg.jpg', 100, 100);
+        (new PostMediaRepository($this->pdo))->attach($postId, $mediaId, 0);
+
+        $backend->expects($this->exactly(3))->method('delete')
+            ->with($this->logicalOr('thumb.jpg', 'med.jpg', 'lg.jpg'));
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $postMediaService->deleteAllForPost($group, $postId);
+
+        $this->assertNull($this->mediaRepo->findById($mediaId));
+    }
+
+    private function delegatedAlbumServiceEnsureAlbumOnLocation(int $locationId): int
+    {
+        $service = $this->delegatedAlbumService();
+        $album = $service->ensureAlbum('discussion_group', $this->groupId, 'Louveteaux', '2026-01-01', $this->creatorAccountId, $locationId);
+        return $album->id;
+    }
+
+    private function seedFile(): int
+    {
+        return $this->fileRepo->create('a', 'a', 'image/jpeg', 1, 'identified', 'gallery', $this->creatorMemberId);
+    }
+
+    private function post(): int
+    {
+        return GroupsTestHelper::createPostAt($this->pdo, $this->groupId, 'Bonjour', '2026-01-01 10:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->recursiveDelete($this->storagePath);
+    }
+
+    private function recursiveDelete(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->recursiveDelete($path) : unlink($path);
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Modules/Groups/PostMediaIntegrationTest.php
+++ b/tests/Modules/Groups/PostMediaIntegrationTest.php
@@ -191,7 +191,9 @@ class PostMediaIntegrationTest extends TestCase
 
         $this->assertSame(1, (int) $this->pdo->query('SELECT COUNT(*) FROM gallery_albums')->fetchColumn());
         // The group's cached id points at whichever row actually exists.
-        $this->assertSame($albumId, $this->groupRepo->findById($this->groupId)->galleryAlbumId);
+        $persisted = $this->groupRepo->findById($this->groupId);
+        $this->assertNotNull($persisted);
+        $this->assertSame($albumId, $persisted->galleryAlbumId);
     }
 
     /**
@@ -211,7 +213,9 @@ class PostMediaIntegrationTest extends TestCase
         $group = $this->groupRepo->findById($this->groupId);
         $service = $this->postMediaService();
         $media = $service->addMedia($group, $this->post(), [$this->fakeUploadedImage()], $this->creatorAccountId)[0];
-        $fileId = $this->mediaRepo->findById($media)->fileId;
+        $mediaRow = $this->mediaRepo->findById($media);
+        $this->assertNotNull($mediaRow);
+        $fileId = $mediaRow->fileId;
 
         $checker = $this->fileOwnershipChecker($currentYearId);
 

--- a/tests/Modules/Groups/Service/GroupFeedServiceTest.php
+++ b/tests/Modules/Groups/Service/GroupFeedServiceTest.php
@@ -7,13 +7,16 @@ namespace Tests\Modules\Groups\Service;
 use Core\Member\MemberService;
 use Core\Security\Role;
 use Core\Security\UserAccountRepository;
+use Modules\Gallery\Api\DelegatedAlbumManager;
 use Modules\Groups\Repository\GroupRepository;
 use Modules\Groups\Repository\Post;
+use Modules\Groups\Repository\PostMediaRepository;
 use Modules\Groups\Repository\PostRepository;
 use Modules\Groups\Service\GroupActivityService;
 use Modules\Groups\Service\GroupFeedService;
 use Modules\Groups\Service\GroupSessionContext;
 use Modules\Groups\Service\PostAuthorResolver;
+use Modules\Groups\Service\PostMediaService;
 use Modules\Groups\Service\PostService;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
@@ -50,10 +53,20 @@ class GroupFeedServiceTest extends TestCase
         $this->feedService = new GroupFeedService(
             $this->postRepo,
             new PostAuthorResolver($memberService, $accountRepo),
-            new PostService($this->postRepo, new GroupActivityService($this->groupRepo, $this->postRepo))
+            new PostService($this->postRepo, new GroupActivityService($this->groupRepo, $this->postRepo)),
+            $this->postMediaService()
         );
 
         $this->groupId = $this->groupRepo->create('Louveteaux', null, null, 1);
+    }
+
+    private function postMediaService(): PostMediaService
+    {
+        return new PostMediaService(
+            $this->createMock(DelegatedAlbumManager::class),
+            new PostMediaRepository($this->pdo),
+            $this->groupRepo
+        );
     }
 
     private function context(): GroupSessionContext
@@ -231,7 +244,8 @@ class GroupFeedServiceTest extends TestCase
         $feedService = new GroupFeedService(
             $this->postRepo,
             new PostAuthorResolver($memberService, $accountRepo),
-            new PostService($this->postRepo, new GroupActivityService($this->groupRepo, $this->postRepo))
+            new PostService($this->postRepo, new GroupActivityService($this->groupRepo, $this->postRepo)),
+            $this->postMediaService()
         );
 
         $this->seed(GroupFeedService::PAGE_SIZE);

--- a/tests/Modules/Groups/Service/PostMediaServiceTest.php
+++ b/tests/Modules/Groups/Service/PostMediaServiceTest.php
@@ -63,7 +63,9 @@ class PostMediaServiceTest extends TestCase
         $albumId = $this->service($manager)->ensureAlbumId($group, 7);
 
         $this->assertSame(55, $albumId);
-        $this->assertSame(55, $this->groupRepo->findById($this->groupId)->galleryAlbumId);
+        $persisted = $this->groupRepo->findById($this->groupId);
+        $this->assertNotNull($persisted);
+        $this->assertSame(55, $persisted->galleryAlbumId);
     }
 
     public function testEnsureAlbumIdNeverCallsGalleryAgainOnceCached(): void

--- a/tests/Modules/Groups/Service/PostMediaServiceTest.php
+++ b/tests/Modules/Groups/Service/PostMediaServiceTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Groups\Service;
+
+use Modules\Gallery\Api\DelegatedAlbum;
+use Modules\Gallery\Api\DelegatedAlbumManager;
+use Modules\Gallery\Api\DelegatedMedia;
+use Modules\Gallery\Service\GalleryException;
+use Modules\Groups\Repository\GroupRepository;
+use Modules\Groups\Repository\PostMediaRepository;
+use Modules\Groups\Service\PostMediaService;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Groups\GroupsTestHelper;
+
+/**
+ * PostMediaService's own orchestration against a mocked
+ * Api\DelegatedAlbumManager — gallery's real behaviour (concurrency
+ * safety, actual deletion of stored objects, /files/{id} scoping) is
+ * proven in tests/Modules/Groups/PostMediaIntegrationTest.php against
+ * the real gallery stack; this file only checks what this module itself
+ * is responsible for: which calls it makes, in what order, and how it
+ * reacts to failure.
+ *
+ * @group database
+ */
+#[Group('database')]
+class PostMediaServiceTest extends TestCase
+{
+    private \PDO $pdo;
+    private GroupRepository $groupRepo;
+    private PostMediaRepository $postMediaRepo;
+    private int $groupId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        GroupsTestHelper::createTables($this->pdo);
+
+        $this->groupRepo = new GroupRepository($this->pdo);
+        $this->postMediaRepo = new PostMediaRepository($this->pdo);
+
+        $creator = GroupsTestHelper::createMember($this->pdo, 'CREATOR');
+        $this->groupId = $this->groupRepo->create('Louveteaux', null, null, $creator);
+    }
+
+    private function service(DelegatedAlbumManager $manager): PostMediaService
+    {
+        return new PostMediaService($manager, $this->postMediaRepo, $this->groupRepo);
+    }
+
+    public function testEnsureAlbumIdCreatesTheAlbumOnFirstUseAndCachesIt(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->once())->method('ensureAlbum')
+            ->with('discussion_group', $this->groupId, 'Louveteaux', $this->anything(), 7)
+            ->willReturn(new DelegatedAlbum(55, 'Louveteaux', '2026-01-01'));
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $albumId = $this->service($manager)->ensureAlbumId($group, 7);
+
+        $this->assertSame(55, $albumId);
+        $this->assertSame(55, $this->groupRepo->findById($this->groupId)->galleryAlbumId);
+    }
+
+    public function testEnsureAlbumIdNeverCallsGalleryAgainOnceCached(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->never())->method('ensureAlbum');
+
+        $this->groupRepo->setGalleryAlbumId($this->groupId, 99);
+        $group = $this->groupRepo->findById($this->groupId);
+
+        $this->assertSame(99, $this->service($manager)->ensureAlbumId($group, 7));
+    }
+
+    public function testAddMediaAttachesEachFileInOrderAndReturnsTheirIds(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('ensureAlbum')->willReturn(new DelegatedAlbum(1, 'Louveteaux', '2026-01-01'));
+        $manager->method('addMedia')->willReturnOnConsecutiveCalls(
+            $this->delegatedMedia(10),
+            $this->delegatedMedia(11)
+        );
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $postId = $this->createPost();
+
+        $mediaIds = $this->service($manager)->addMedia($group, $postId, [$this->fakeFile(), $this->fakeFile()], 3);
+
+        $this->assertSame([10, 11], $mediaIds);
+        $this->assertSame([10, 11], $this->postMediaRepo->findMediaIdsForPost($postId));
+    }
+
+    /**
+     * @return DelegatedAlbumManager&\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function managerFailingOnSecondAddMedia(): DelegatedAlbumManager
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('ensureAlbum')->willReturn(new DelegatedAlbum(1, 'Louveteaux', '2026-01-01'));
+        $call = 0;
+        $manager->method('addMedia')->willReturnCallback(function () use (&$call) {
+            $call++;
+            if ($call === 2) {
+                throw new GalleryException('Type de fichier non autorisé.');
+            }
+            return $this->delegatedMedia(10);
+        });
+
+        return $manager;
+    }
+
+    public function testAddMediaLetsAGalleryExceptionPropagateForTheCallerToRollBack(): void
+    {
+        $group = $this->groupRepo->findById($this->groupId);
+        $postId = $this->createPost();
+
+        $this->expectException(GalleryException::class);
+        $this->service($this->managerFailingOnSecondAddMedia())
+            ->addMedia($group, $postId, [$this->fakeFile(), $this->fakeFile()], 3);
+    }
+
+    public function testAddMediaLeavesTheFirstFilesAttachmentInPlaceWhenTheSecondFails(): void
+    {
+        // addMedia() itself never rolls back — that is
+        // Controller\PostController::create()'s job, via
+        // deleteAllForPost(). This documents the boundary: after a
+        // partial failure, the join row for what did succeed is still
+        // there until the caller explicitly cleans up.
+        $group = $this->groupRepo->findById($this->groupId);
+        $postId = $this->createPost();
+
+        try {
+            $this->service($this->managerFailingOnSecondAddMedia())
+                ->addMedia($group, $postId, [$this->fakeFile(), $this->fakeFile()], 3);
+            $this->fail('expected GalleryException');
+        } catch (GalleryException) {
+        }
+
+        $this->assertSame([10], $this->postMediaRepo->findMediaIdsForPost($postId));
+    }
+
+    public function testDeleteAllForPostRemovesEveryAttachedMediaThroughTheApi(): void
+    {
+        $this->groupRepo->setGalleryAlbumId($this->groupId, 42);
+        $postId = $this->createPost();
+        $this->postMediaRepo->attach($postId, 10, 0);
+        $this->postMediaRepo->attach($postId, 11, 1);
+
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->exactly(2))->method('deleteMedia')
+            ->with(42, $this->logicalOr(10, 11));
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $this->service($manager)->deleteAllForPost($group, $postId);
+    }
+
+    public function testDeleteAllForPostReadsTheAlbumIdFreshEvenWhenTheCallersGroupInstanceIsStale(): void
+    {
+        // Reproduces addMedia()'s own rollback path: the album is created
+        // (and gallery_album_id persisted) mid-request, but the $group
+        // instance PostController is still holding was fetched before
+        // that write and reads galleryAlbumId as null.
+        $staleGroup = $this->groupRepo->findById($this->groupId);
+        $this->assertNull($staleGroup->galleryAlbumId, 'precondition: fetched before the album existed');
+
+        $this->groupRepo->setGalleryAlbumId($this->groupId, 77);
+        $postId = $this->createPost();
+        $this->postMediaRepo->attach($postId, 10, 0);
+
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->once())->method('deleteMedia')->with(77, 10);
+
+        $this->service($manager)->deleteAllForPost($staleGroup, $postId);
+    }
+
+    public function testDeleteAllForPostNeverThrowsWhenTheMediaIsAlreadyGone(): void
+    {
+        $this->groupRepo->setGalleryAlbumId($this->groupId, 42);
+        $postId = $this->createPost();
+        $this->postMediaRepo->attach($postId, 10, 0);
+
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('deleteMedia')->willThrowException(new GalleryException('déjà supprimé'));
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $this->service($manager)->deleteAllForPost($group, $postId);
+
+        $this->addToAssertionCount(1); // reaching here without throwing is the assertion
+    }
+
+    public function testDeleteAllForPostIsANoOpWhenTheGroupHasNoAlbumYet(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->never())->method('deleteMedia');
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $this->service($manager)->deleteAllForPost($group, $this->createPost());
+    }
+
+    public function testMediaForPostsMapsEachPostToItsOwnMediaInAttachmentOrderAndSkipsARaceDeletedId(): void
+    {
+        $postA = $this->createPost();
+        $postB = $this->createPost();
+        $this->postMediaRepo->attach($postA, 10, 0);
+        $this->postMediaRepo->attach($postA, 11, 1);
+        $this->postMediaRepo->attach($postB, 12, 0);
+
+        // 11 is missing from $mediaById entirely — a concurrent delete
+        // between listMedia() and this call — and must be skipped rather
+        // than breaking postA's whole render.
+        $mediaById = [10 => $this->delegatedMedia(10), 12 => $this->delegatedMedia(12)];
+
+        $result = $this->service($this->createMock(DelegatedAlbumManager::class))
+            ->mediaForPosts([$postA, $postB], $mediaById);
+
+        $this->assertSame([10], array_map(fn(DelegatedMedia $m) => $m->id, $result[$postA]));
+        $this->assertSame([12], array_map(fn(DelegatedMedia $m) => $m->id, $result[$postB]));
+    }
+
+    public function testAlbumMediaByIdIsEmptyWhenTheGroupHasNoAlbumYet(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->never())->method('listMedia');
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $this->assertSame([], $this->service($manager)->albumMediaById($group));
+    }
+
+    public function testGroupGalleryMediaSortsNewestFirstById(): void
+    {
+        $this->groupRepo->setGalleryAlbumId($this->groupId, 42);
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->expects($this->once())->method('listMedia')->with(42)->willReturn([
+            $this->delegatedMedia(10), $this->delegatedMedia(11), $this->delegatedMedia(9),
+        ]);
+
+        $group = $this->groupRepo->findById($this->groupId);
+        $media = $this->service($manager)->groupGalleryMedia($group);
+
+        $this->assertSame([11, 10, 9], array_map(fn(DelegatedMedia $m) => $m->id, $media));
+    }
+
+    public function testVideoUploadAllowedDelegatesToTheApi(): void
+    {
+        $manager = $this->createMock(DelegatedAlbumManager::class);
+        $manager->method('videoUploadAllowed')->willReturn(true);
+
+        $this->assertTrue($this->service($manager)->videoUploadAllowed());
+    }
+
+    private function createPost(): int
+    {
+        return GroupsTestHelper::createPostAt($this->pdo, $this->groupId, 'Bonjour', '2026-01-01 10:00:00');
+    }
+
+    private function delegatedMedia(int $id): DelegatedMedia
+    {
+        return new DelegatedMedia($id, 'photo', 'done', 0, 'photo.jpg', '2026-01-01 10:00:00');
+    }
+
+    /**
+     * @return array{name: string, tmp_name: string, error: int, size: int, type: string}
+     */
+    private function fakeFile(): array
+    {
+        return ['name' => 'photo.jpg', 'tmp_name' => '/tmp/x', 'error' => 0, 'size' => 100, 'type' => 'image/jpeg'];
+    }
+}


### PR DESCRIPTION
## Description

Posts in `groups` may now carry 1 to 4 images/videos, stored in a delegated gallery album belonging to the group (`Modules\Gallery\Api\DelegatedAlbumManager`, `owner_type` `'discussion_group'`) — built on the delegated-album capability merged in #27. Plus a "Galerie du groupe" view listing every media of the group's posts, newest first.

- `discussion_groups` gains a nullable `gallery_album_id` (no cross-module FK — documented why — set lazily on the group's first media post); a new `discussion_group_post_media` join table maps a post to its media, in display order.
- `Service\PostMediaService` is the only place this module talks to gallery, entirely through the `Api` namespace: `ensureAlbumId()` (cached once resolved), `addMedia()`/`deleteAllForPost()` for the composer and post deletion, and `albumMediaById()`/`mediaForPosts()` for the feed (resolved once per page, not once per post).
- `Gallery\GroupDelegatedAlbumAccessChecker` registers into gallery's own `DelegatedAlbumAccessRegistry`, delegating to the same decision `File\GroupFileOwnershipChecker` already makes for group files — a member who can read the group can always see its media, through either registry.
- `Controller\PostController::create()` enforces the 4-media ceiling and requires text or media (never neither) before writing anything, and rolls the whole post back — media and all — on any gallery failure (over quota, disabled video, bad MIME), rather than a partial save.
- Feed rendering (`partials/post_media_grid.html.twig`) follows the 1/2/3/4 mosaic layout (verified at 375px and 1280px); a pending media shows a spinner, a failed one a discreet notice, a video a play affordance — never a broken image.
- Composer UI: file picker + mobile camera capture, client-side thumbnails with remove-before-publish, a live count against the 4 ceiling.

Two prerequisite gallery-side fixes, needed for this to be correct rather than just functional:
- `gallery_albums.owner_type`/`owner_id` gained a `UNIQUE` index (was non-unique) so two members posting a group's first media at once cannot create two albums; `DelegatedAlbumService::ensureAlbum()` now recovers from the resulting race instead of throwing or leaving a duplicate.
- `MediaService::store()` now propagates a delegated album's own `owner_type`/`owner_id` onto the uploaded original's `files` row, so `Core\File\FileAccessGuard`'s ownership registry (not just the flat `'identified'` floor) governs `/files/{id}` for it too — the same gap already closed for `/gallery/media/{id}/{size}` in #27.

## Test plan
- Concurrent first-media posts create exactly one album (race simulated the same way as gallery's own equivalent test).
- The 5th media on a post is rejected server-side without creating the post at all; exactly 4 is accepted; a media-only post (no text) is accepted; neither text nor media saves nothing.
- A video is refused server-side when disabled, rolling back the whole post.
- The uploaded original is inaccessible to a non-member through `Core\File\FileAccessGuard` (real integration test, not mocked).
- Deleting a post removes join rows, media rows and stored objects — tested against both a local and an S3-configured location, no orphan left.
- `pending`/`failed` media render without breaking the feed or the group gallery page; a non-member gets 404 on both the group page and the group gallery view.
- 228 gallery + groups tests pass, full suite (2866 tests) green aside from pre-existing MySQL-connectivity failures unrelated to this change (no MySQL server in this sandbox).

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YN5Rc7HpVAjo7rpFoDNHke)_