### PR TITLE
Fix 16 defects found reviewing the AI connector and everything that depends on it

### DIFF
--- a/core/Http/Controller/RgpdConfigController.php
+++ b/core/Http/Controller/RgpdConfigController.php
@@ -51,7 +51,11 @@ class RgpdConfigController extends AbstractController
             }
         }
 
-        $llmAvailable = in_array('llm_connector', $this->moduleManager->getEnabledModuleIds(), true);
+        // Real availability, not just "the module is installed": an enabled
+        // llm_connector with no provider configured (or no model on the
+        // CAPABLE tier this document is generated on) used to still show the
+        // "Générer" button, and only fail after the click.
+        $llmAvailable = $this->rgpdContentService->isAvailable();
 
         return $this->render('config/rgpd.html.twig', [
             'mode' => $mode,
@@ -134,6 +138,13 @@ class RgpdConfigController extends AbstractController
 
         if (!in_array('llm_connector', $this->moduleManager->getEnabledModuleIds(), true)) {
             return $this->json(['success' => false, 'error' => 'Module IA non activé.'], 400);
+        }
+
+        if (!$this->rgpdContentService->isAvailable()) {
+            return $this->json([
+                'success' => false,
+                'error' => "Aucun fournisseur IA utilisable n'est configuré pour la génération de ce document.",
+            ], 400);
         }
 
         // Wrap the ENTIRE flow (generation + auto-save) so that ANY exception,

--- a/core/View/RgpdContentService.php
+++ b/core/View/RgpdContentService.php
@@ -82,11 +82,25 @@ class RgpdContentService
     }
 
     /**
+     * Whether AI generation can actually run — the CAPABLE tier specifically,
+     * since that is the only tier this document is ever generated on.
+     * isAvailable() alone only says "some tier is configured", so a provider
+     * offering only small models passed it and then failed inside complete()
+     * with "Aucun modèle assigné au tier « capable »" after the button had
+     * already been offered.
+     */
+    public function isAvailable(): bool
+    {
+        return $this->llmConnector !== null
+            && $this->llmConnector->isTierAvailable(LlmTier::CAPABLE);
+    }
+
+    /**
      * Generate RGPD content via AI based on active modules and user prompt
      */
     public function generateWithAi(string $userPrompt): string
     {
-        if ($this->llmConnector === null || !$this->llmConnector->isAvailable()) {
+        if (!$this->isAvailable()) {
             throw new \RuntimeException('Service IA non disponible.');
         }
 

--- a/modules/finance/src/Service/BulkCategorizationService.php
+++ b/modules/finance/src/Service/BulkCategorizationService.php
@@ -26,9 +26,35 @@ use Modules\Finance\Repository\TransactionRepository;
 class BulkCategorizationService
 {
     private const AI_ENABLED_SETTING_KEY = 'ai_categorization_enabled';
-    private const RUNNING_SETTING_KEY = 'bulk_categorization_running';
+    /**
+     * Unix timestamp of the currently-claimed run, or '0'. A distinct key
+     * from the boolean 'bulk_categorization_running' this replaces: an
+     * existing install already carries that row typed as `boolean`, and
+     * SettingRepository::upsert() never changes an existing row's type while
+     * SettingService::setInternal() validates against it — writing a
+     * timestamp there would throw on every upgraded site. The old row simply
+     * falls out of use.
+     */
+    private const RUNNING_SETTING_KEY = 'bulk_categorization_started_at';
+
+    /**
+     * The key the one above replaces. Only ever read, never written: an
+     * install from before this change already carries that row typed as
+     * `boolean`, SettingRepository::upsert() never re-types an existing row,
+     * and SettingService::setInternal() validates against the stored type —
+     * so writing a timestamp there throws on exactly the sites that have one.
+     */
+    private const LEGACY_RUNNING_SETTING_KEY = 'bulk_categorization_running';
     private const LAST_RESULT_SETTING_KEY = 'bulk_categorization_last_result';
     private const RUN_TASK_KEY = 'run_categorization_rules';
+
+    /**
+     * Ceiling for a background run. The poor man's cron executes this inside
+     * a normal web request, whose default max_execution_time (often 30s) is
+     * far below what one LLM call per uncategorized movement needs — and
+     * exceeding it is a fatal error that skips the finally block below.
+     */
+    private const RUN_TIME_LIMIT_SECONDS = 1800;
 
     public function __construct(
         private TransactionRepository $transactionRepository,
@@ -70,23 +96,35 @@ class BulkCategorizationService
      * cleared once runInBackground() finishes, success or failure.
      *
      * A marker older than RUNNING_STALE_AFTER_SECONDS is reported as not
-     * running: see that constant for why one can be left behind.
+     * running: see that constant for why one can be left behind. The most
+     * likely way that happens is not an exception at all — the poor man's
+     * cron runs the batch inside an ordinary web request, and exceeding
+     * max_execution_time is a fatal error, which skips runInBackground()'s
+     * finally block entirely.
      */
     public function isRunning(): bool
     {
-        $value = $this->settingService->get(self::RUNNING_SETTING_KEY, 'finance', '0');
-        if ($value === null || $value === '' || $value === '0') {
+        $startedAt = (int) ($this->settingService->get(self::RUNNING_SETTING_KEY, 'finance', '0') ?: '0');
+        if ($startedAt > 0) {
+            return (time() - $startedAt) < self::RUNNING_STALE_AFTER_SECONDS;
+        }
+
+        return $this->hasLegacyRunningMarker();
+    }
+
+    /**
+     * A bare '1' written under the old key by a version that recorded no
+     * timestamp. Still honoured, so upgrading mid-run does not immediately
+     * start a second one — but only while the scheduled task it refers to is
+     * actually still queued, since the marker carries no expiry of its own.
+     */
+    private function hasLegacyRunningMarker(): bool
+    {
+        if ($this->settingService->get(self::LEGACY_RUNNING_SETTING_KEY, 'finance', '0') !== '1') {
             return false;
         }
 
-        // Historic marker from before the timestamp was recorded: treated
-        // as running, and the next completed run rewrites it as '0'.
-        if ($value === '1') {
-            return true;
-        }
-
-        $startedAt = (int) $value;
-        return $startedAt > 0 && (time() - $startedAt) < self::RUNNING_STALE_AFTER_SECONDS;
+        return $this->schedulerService->find('finance', self::RUN_TASK_KEY) !== null;
     }
 
     /**
@@ -101,7 +139,7 @@ class BulkCategorizationService
 
     private function registerRunningSetting(): void
     {
-        $this->settingService->register(self::RUNNING_SETTING_KEY, '0', 'text', 'Exécution des règles en cours', 'Indicateur interne — ne pas modifier.', 'finance', null, null, false);
+        $this->settingService->register(self::RUNNING_SETTING_KEY, '0', 'number', 'Exécution des règles en cours depuis', 'Indicateur interne — ne pas modifier.', 'finance', null, null, false);
     }
 
     /**
@@ -151,13 +189,39 @@ class BulkCategorizationService
      */
     public function runInBackground(): void
     {
+        // Same reasoning as Core\View\RgpdContentService::generateWithAi():
+        // max_execution_time is a hard script timeout, not a catchable
+        // exception, so it must be raised before the work rather than
+        // handled after it.
+        $previousLimit = (int) ini_get('max_execution_time');
+        @set_time_limit(self::RUN_TIME_LIMIT_SECONDS);
+
         try {
             $result = $this->runOnUncategorized();
             $this->storeLastResult($result);
         } finally {
-            $this->registerRunningSetting();
-            $this->settingService->setInternal(self::RUNNING_SETTING_KEY, '0', 'finance');
+            $this->clearRunning();
+            @set_time_limit($previousLimit);
         }
+    }
+
+    /**
+     * Public so a stuck lock can also be released deliberately — see
+     * Controller\ConfigRuleController's "run_status" branch, which reports
+     * the lock as free once it has expired.
+     */
+    public function clearRunning(): void
+    {
+        $this->registerRunningSetting();
+        $this->settingService->setInternal(self::RUNNING_SETTING_KEY, '0', 'finance');
+
+        // Retire the legacy marker too, so a site upgraded mid-run stops
+        // falling back to it once this run has finished. '0' is a valid
+        // value whichever type that row happens to carry — only a timestamp
+        // would fail validation on a `boolean` row, which is precisely why
+        // the timestamp lives under its own key.
+        $this->settingService->register(self::LEGACY_RUNNING_SETTING_KEY, '0', 'boolean', 'Exécution des règles en cours (obsolète)', 'Indicateur interne — ne pas modifier.', 'finance', null, null, false);
+        $this->settingService->setInternal(self::LEGACY_RUNNING_SETTING_KEY, '0', 'finance');
     }
 
     private function storeLastResult(BulkCategorizationResult $result): void
@@ -187,7 +251,18 @@ class BulkCategorizationService
             }
 
             if ($aiEnabled) {
-                $aiCategoryId = $this->aiCategorizationService->categorize($transaction);
+                // One unusable movement must never abort the whole batch.
+                // AiCategorizationService::categorize() only catches
+                // LlmException, and a movement can fail in other ways — a
+                // label carrying non-UTF-8 bytes from a Latin-1 bank export,
+                // for one. Everything before this point has already been
+                // committed, so the batch continues with the next movement.
+                try {
+                    $aiCategoryId = $this->aiCategorizationService->categorize($transaction);
+                } catch (\Throwable) {
+                    $aiCategoryId = null;
+                }
+
                 if ($aiCategoryId !== null) {
                     $this->transactionRepository->setCategoryId($transaction->id, $aiCategoryId);
                     $byAi++;

--- a/modules/llm_connector/module.json
+++ b/modules/llm_connector/module.json
@@ -2,7 +2,7 @@
   "id": "llm_connector",
   "name": "Connecteur IA",
   "description": "Connecteur IA générique et réutilisable — encapsule toute la logique spécifique à un fournisseur de LLM (sélection de modèle, appels API, gestion des erreurs).",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "routes": [
     {
       "path": "/config/llm",

--- a/modules/llm_connector/src/Api/LlmConnectorInterface.php
+++ b/modules/llm_connector/src/Api/LlmConnectorInterface.php
@@ -17,8 +17,25 @@ interface LlmConnectorInterface
     /**
      * Whether the connector is operational (at least one active provider
      * with at least one model assigned to a tier).
+     *
+     * Never throws: a provider whose stored API key cannot be decrypted (the
+     * encryption key changed, e.g. after restoring a backup onto another
+     * install) counts as unavailable, not as an error. Callers use this to
+     * decide whether to offer a feature at all, and several do so while
+     * rendering a page — including the public retrospective board.
      */
     public function isAvailable(): bool;
+
+    /**
+     * Whether a request for this specific tier would find a model.
+     *
+     * isAvailable() only answers "is anything configured at all", so a caller
+     * that always asks for one particular tier (RGPD generation is the only
+     * consumer of CAPABLE) could pass that check and still have complete()
+     * throw NO_MODEL. Applies the same OCR → CHEAP fallback complete() does.
+     * Never throws, for the same reason as isAvailable().
+     */
+    public function isTierAvailable(LlmTier $tier): bool;
 
     /**
      * Send a completion request to the configured LLM.

--- a/modules/llm_connector/src/Controller/ConfigController.php
+++ b/modules/llm_connector/src/Controller/ConfigController.php
@@ -48,12 +48,21 @@ class ConfigController extends AbstractController
 
         $providers = $this->providerRepo->findAll();
 
-        // Group providers and models by driver
+        // Group providers and models by driver. On the rare install that
+        // already carries two rows for one driver (nothing enforced
+        // uniqueness before), keep the lowest id — that is the row
+        // ProviderRepository::findFirstActive() and findByDriver() both pick,
+        // so the page shows the provider actually in use rather than a
+        // shadowed duplicate.
         $providersByDriver = [];
         $modelsByDriver = [];
         foreach ($providers as $provider) {
-            $providersByDriver[$provider['driver']] = $provider;
-            $modelsByDriver[$provider['driver']] = $this->modelRepo->findByProvider($provider['id']);
+            $driver = $provider['driver'];
+            if (isset($providersByDriver[$driver]) && $providersByDriver[$driver]['id'] <= $provider['id']) {
+                continue;
+            }
+            $providersByDriver[$driver] = $provider;
+            $modelsByDriver[$driver] = $this->modelRepo->findByProvider($provider['id']);
         }
 
         $activeProvider = null;
@@ -123,19 +132,49 @@ class ConfigController extends AbstractController
             return $this->json(['success' => false, 'error' => 'Driver invalide.']);
         }
 
-        // Deactivate all providers first, then activate the one being saved
-        $this->providerRepo->deactivateAll();
-
-        if ($providerId !== null && $providerId > 0) {
-            // Update existing — apiKey null means "keep existing"
-            $keyToStore = $apiKey !== '' ? $apiKey : null;
-            $this->providerRepo->update($providerId, $name, $driver, $apiEndpoint, $keyToStore, true);
-        } else {
-            if ($apiKey === '') {
-                return $this->json(['success' => false, 'error' => 'La clé API est obligatoire pour un nouveau fournisseur.']);
-            }
-            $providerId = $this->providerRepo->create($name, $driver, $apiEndpoint, $apiKey, true);
+        if (!$this->isValidEndpoint($apiEndpoint)) {
+            return $this->json(['success' => false, 'error' => "L'adresse de l'API doit être une URL https valide."]);
         }
+
+        // The page is one-provider-per-driver, but the client only sends an
+        // id when its dropdown already knew about a saved provider. Without
+        // this, a save that lost the id created a second row for the same
+        // driver — invisible in the UI (which keys by driver) yet still
+        // reachable by findFirstActive()'s id ASC ordering.
+        if (($providerId === null || $providerId <= 0)) {
+            $existing = $this->providerRepo->findByDriver($driver);
+            if ($existing !== null) {
+                $providerId = $existing['id'];
+            }
+        }
+
+        // Every validation happens BEFORE the deactivate-then-activate block
+        // below. Deactivating first meant a rejected save (missing API key,
+        // unknown id) still turned every provider off: the administrator saw
+        // an error, assumed nothing had changed, and every AI feature on the
+        // site went quiet until the next successful save.
+        if ($providerId !== null && $providerId > 0) {
+            if ($this->providerRepo->findById($providerId) === null) {
+                return $this->json(['success' => false, 'error' => 'Fournisseur introuvable.']);
+            }
+        } elseif ($apiKey === '') {
+            return $this->json(['success' => false, 'error' => 'La clé API est obligatoire pour un nouveau fournisseur.']);
+        }
+
+        // "Exactly one active provider" is maintained by a deactivate-then-
+        // activate pair, so the two writes belong in one transaction — a
+        // failure between them would otherwise leave no provider active.
+        $this->providerRepo->transactional(function () use (&$providerId, $name, $driver, $apiEndpoint, $apiKey): void {
+            $this->providerRepo->deactivateAll();
+
+            if ($providerId !== null && $providerId > 0) {
+                // Update existing — apiKey null means "keep existing"
+                $keyToStore = $apiKey !== '' ? $apiKey : null;
+                $this->providerRepo->update($providerId, $name, $driver, $apiEndpoint, $keyToStore, true);
+            } else {
+                $providerId = $this->providerRepo->create($name, $driver, $apiEndpoint, $apiKey, true);
+            }
+        });
 
         $this->journalService->log(
             'llm_connector',
@@ -233,6 +272,24 @@ class ConfigController extends AbstractController
             ['id' => 'mistral', 'label' => 'Mistral AI', 'default_endpoint' => 'https://api.mistral.ai'],
             ['id' => 'scaleway', 'label' => 'Scaleway', 'default_endpoint' => 'https://api.scaleway.ai'],
         ];
+    }
+
+    /**
+     * The endpoint is concatenated into a URL and handed to the HTTP layer,
+     * so it must be a real https URL with a host — not merely non-empty. The
+     * dropdown only supplies a default client-side; the posted value is
+     * whatever the client chose to send.
+     */
+    private function isValidEndpoint(string $apiEndpoint): bool
+    {
+        if (filter_var($apiEndpoint, FILTER_VALIDATE_URL) === false) {
+            return false;
+        }
+
+        $scheme = parse_url($apiEndpoint, PHP_URL_SCHEME);
+        $host = parse_url($apiEndpoint, PHP_URL_HOST);
+
+        return $scheme === 'https' && is_string($host) && $host !== '';
     }
 
     private function createDriver(string $driver, string $apiEndpoint, string $apiKey): \Modules\LlmConnector\Provider\LlmProviderInterface

--- a/modules/llm_connector/src/Provider/AnthropicProvider.php
+++ b/modules/llm_connector/src/Provider/AnthropicProvider.php
@@ -19,10 +19,31 @@ class AnthropicProvider implements LlmProviderInterface
     private const DEFAULT_TIMEOUT = 30;
     private const API_VERSION = '2023-06-01';
 
+    /** Page size requested from /v1/models (the API's own maximum). */
+    private const MODELS_PAGE_SIZE = 1000;
+
+    /** Hard stop on pagination, so a misbehaving has_more can never loop forever. */
+    private const MAX_MODEL_PAGES = 20;
+
+    private HttpTransport $http;
+
     public function __construct(
         private string $apiEndpoint,
         private string $apiKey
     ) {
+        $this->http = new HttpTransport();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function headers(): array
+    {
+        return [
+            'x-api-key: ' . $this->apiKey,
+            'anthropic-version: ' . self::API_VERSION,
+            'Content-Type: application/json',
+        ];
     }
 
     /**
@@ -30,19 +51,42 @@ class AnthropicProvider implements LlmProviderInterface
      */
     public function listModels(): array
     {
-        $url = rtrim($this->apiEndpoint, '/') . '/v1/models';
-        $response = $this->httpGet($url);
-
-        if (!isset($response['data']) || !is_array($response['data'])) {
-            throw LlmException::apiError('Invalid response from models endpoint.');
-        }
+        $base = rtrim($this->apiEndpoint, '/') . '/v1/models?limit=' . self::MODELS_PAGE_SIZE;
 
         $models = [];
-        foreach ($response['data'] as $model) {
-            $models[] = [
-                'id' => (string) ($model['id'] ?? ''),
-                'display_name' => (string) ($model['display_name'] ?? $model['id'] ?? ''),
-            ];
+        $afterId = null;
+
+        // This endpoint paginates (has_more / last_id, 20 per page by
+        // default). Reading only the first page silently hid every model past
+        // it — and since Controller\ConfigController::testConnection() prunes
+        // with deleteModelsNotIn(), an unread page's models were deleted from
+        // the local catalogue on every connection test.
+        for ($page = 0; $page < self::MAX_MODEL_PAGES; $page++) {
+            $url = $afterId === null ? $base : $base . '&after_id=' . rawurlencode($afterId);
+            $response = $this->http->getJson($url, $this->headers(), self::DEFAULT_TIMEOUT);
+
+            if (!isset($response['data']) || !is_array($response['data'])) {
+                throw LlmException::apiError('Invalid response from models endpoint.');
+            }
+
+            foreach ($response['data'] as $model) {
+                $id = (string) ($model['id'] ?? '');
+                if ($id === '') {
+                    // A model with no usable identifier cannot be called and
+                    // must never reach llm_provider_models.model_id.
+                    continue;
+                }
+                $models[] = [
+                    'id' => $id,
+                    'display_name' => (string) ($model['display_name'] ?? $id),
+                ];
+            }
+
+            $lastId = isset($response['last_id']) ? (string) $response['last_id'] : '';
+            if (($response['has_more'] ?? false) !== true || $lastId === '') {
+                break;
+            }
+            $afterId = $lastId;
         }
 
         return $models;
@@ -62,8 +106,10 @@ class AnthropicProvider implements LlmProviderInterface
 
         $body = $this->buildRequestBody($modelId, $content, $effectiveSystem, $options);
 
-        $response = $this->httpPost($url, $body, $timeout);
+        $response = $this->http->postJson($url, $this->headers(), $body, $timeout);
 
+        // A non-2xx never reaches this point (HttpTransport rejects it); this
+        // still catches an error object returned with a 200.
         if (isset($response['error'])) {
             $errorMsg = $response['error']['message'] ?? 'Unknown error';
             $errorType = $response['error']['type'] ?? '';
@@ -190,128 +236,5 @@ class AnthropicProvider implements LlmProviderInterface
         }
 
         return implode("\n", $texts);
-    }
-
-    /**
-     * @param array<int, string> $modelIds
-     * @return array{cheap: string|null, capable: string|null, ocr: string|null}
-     */
-    public function resolveTiers(array $modelIds): array
-    {
-        $bestHaiku = null;
-        $bestSonnet = null;
-        $bestOcr = null;
-
-        foreach ($modelIds as $id) {
-            $lower = strtolower($id);
-
-            if (str_contains($lower, 'ocr')) {
-                if ($bestOcr === null || $this->extractDate($id) > $this->extractDate($bestOcr)) {
-                    $bestOcr = $id;
-                }
-            }
-
-            if (str_contains($lower, 'haiku')) {
-                if ($bestHaiku === null || $this->extractDate($id) > $this->extractDate($bestHaiku)) {
-                    $bestHaiku = $id;
-                }
-            } elseif (str_contains($lower, 'sonnet')) {
-                if ($bestSonnet === null || $this->extractDate($id) > $this->extractDate($bestSonnet)) {
-                    $bestSonnet = $id;
-                }
-            }
-        }
-
-        return [
-            'cheap' => $bestHaiku,
-            'capable' => $bestSonnet,
-            'ocr' => $bestOcr,
-        ];
-    }
-
-    /**
-     * Extract the YYYYMMDD date suffix from an Anthropic model ID.
-     * Models with "latest" in the name are considered the most recent.
-     * e.g. "claude-3-5-haiku-20241022" → "20241022"
-     * e.g. "claude-haiku-latest" → "99999999"
-     */
-    private function extractDate(string $modelId): string
-    {
-        if (stripos($modelId, 'latest') !== false) {
-            return '99999999';
-        }
-        if (preg_match('/(\d{8})/', $modelId, $matches)) {
-            return $matches[1];
-        }
-        return '00000000';
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function httpGet(string $url): array
-    {
-        $context = stream_context_create([
-            'http' => [
-                'method' => 'GET',
-                'header' => implode("\r\n", [
-                    'x-api-key: ' . $this->apiKey,
-                    'anthropic-version: ' . self::API_VERSION,
-                    'Content-Type: application/json',
-                ]),
-                'timeout' => self::DEFAULT_TIMEOUT,
-                'ignore_errors' => true,
-            ],
-        ]);
-
-        $body = @file_get_contents($url, false, $context);
-
-        if ($body === false) {
-            throw LlmException::timeout();
-        }
-
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            throw LlmException::apiError('Invalid JSON response from provider.');
-        }
-
-        return $decoded;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     * @return array<string, mixed>
-     */
-    private function httpPost(string $url, array $data, int $timeout): array
-    {
-        $jsonBody = json_encode($data, JSON_UNESCAPED_UNICODE);
-
-        $context = stream_context_create([
-            'http' => [
-                'method' => 'POST',
-                'header' => implode("\r\n", [
-                    'x-api-key: ' . $this->apiKey,
-                    'anthropic-version: ' . self::API_VERSION,
-                    'Content-Type: application/json',
-                    'Content-Length: ' . strlen($jsonBody),
-                ]),
-                'content' => $jsonBody,
-                'timeout' => $timeout,
-                'ignore_errors' => true,
-            ],
-        ]);
-
-        $body = @file_get_contents($url, false, $context);
-
-        if ($body === false) {
-            throw LlmException::timeout();
-        }
-
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            throw LlmException::apiError('Invalid JSON response from provider.');
-        }
-
-        return $decoded;
     }
 }

--- a/modules/llm_connector/src/Provider/HttpTransport.php
+++ b/modules/llm_connector/src/Provider/HttpTransport.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\LlmConnector\Provider;
+
+use Modules\LlmConnector\Api\LlmException;
+
+/**
+ * The JSON-over-HTTP transport shared by every provider driver — the three
+ * drivers only ever differed in their auth headers, and each carried its own
+ * copy of this logic.
+ *
+ * It exists as one class because the two failure modes it guards against were
+ * silently wrong in all three copies at once:
+ *
+ * 1. `ignore_errors` is required (a 4xx/5xx body carries the provider's own
+ *    error description, which file_get_contents would otherwise discard), but
+ *    it also means a failed call returns a body like any other. Every driver
+ *    then only recognised errors shaped exactly as `{"error": {...}}`, so a
+ *    401/429/502 shaped any other way — a bare `{"message": "..."}`, a
+ *    gateway's error page — parsed as a successful response with no choices,
+ *    i.e. an empty completion reported as success. The HTTP status is checked
+ *    here first, before any caller gets to interpret the body.
+ * 2. json_encode() returns false for a payload containing invalid UTF-8 (a
+ *    bank statement imported from a Latin-1 export reaches the prompt as raw
+ *    bytes — the label columns are encrypted BLOBs, so nothing validates
+ *    their encoding on the way in). Passing that false to strlen() under
+ *    strict_types raises a TypeError, which is not an LlmException and so
+ *    escapes every consumer's catch block, aborting a whole categorization
+ *    batch over one bad row.
+ */
+final class HttpTransport
+{
+    /**
+     * Longest provider error body kept in an exception message — enough to
+     * carry the provider's own explanation, short enough not to dump a full
+     * HTML error page into the journal.
+     */
+    private const MAX_ERROR_BODY_CHARS = 500;
+
+    /**
+     * @param array<int, string> $headers
+     * @return array<string, mixed>
+     */
+    public function getJson(string $url, array $headers, int $timeout): array
+    {
+        return $this->request($url, [
+            'method' => 'GET',
+            'header' => implode("\r\n", $headers),
+            'timeout' => $timeout,
+            'ignore_errors' => true,
+        ]);
+    }
+
+    /**
+     * @param array<int, string> $headers
+     * @param array<string, mixed> $body
+     * @return array<string, mixed>
+     */
+    public function postJson(string $url, array $headers, array $body, int $timeout): array
+    {
+        $jsonBody = json_encode($body, JSON_UNESCAPED_UNICODE);
+        if ($jsonBody === false) {
+            throw LlmException::apiError(
+                'Encodage JSON de la requête impossible : ' . json_last_error_msg()
+            );
+        }
+
+        $headers[] = 'Content-Length: ' . strlen($jsonBody);
+
+        return $this->request($url, [
+            'method' => 'POST',
+            'header' => implode("\r\n", $headers),
+            'content' => $jsonBody,
+            'timeout' => $timeout,
+            'ignore_errors' => true,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $httpOptions
+     * @return array<string, mixed>
+     */
+    private function request(string $url, array $httpOptions): array
+    {
+        $context = stream_context_create(['http' => $httpOptions]);
+
+        $body = @file_get_contents($url, false, $context);
+
+        if ($body === false) {
+            // No response at all: connection refused, DNS failure, or the
+            // timeout elapsed. Checked first, because $http_response_header
+            // below is only populated once a response actually arrived.
+            throw LlmException::timeout();
+        }
+
+        // Populated by the HTTP wrapper in this scope. Reaching this line
+        // means a response was received, so it is set.
+        $status = $this->statusCode($http_response_header);
+
+        if ($status === 429) {
+            throw LlmException::rateLimited($this->shorten($body));
+        }
+
+        // 0 means no status line could be read at all — the body came from
+        // somewhere other than an HTTP response (a file:// URL, a stub in a
+        // test). Nothing to reject on, so it is left to the JSON check below.
+        if ($status !== 0 && ($status < 200 || $status >= 300)) {
+            throw LlmException::apiError("HTTP {$status} — " . $this->shorten($body));
+        }
+
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            throw LlmException::apiError('Invalid JSON response from provider.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * The last status line in the header list — a redirect chain leaves the
+     * earlier ones in place, and it is the final response that matters.
+     *
+     * @param array<int, string> $responseHeaders
+     */
+    private function statusCode(array $responseHeaders): int
+    {
+        $status = 0;
+        foreach ($responseHeaders as $header) {
+            if (preg_match('#^HTTP/\S+\s+(\d{3})#', $header, $matches) === 1) {
+                $status = (int) $matches[1];
+            }
+        }
+
+        return $status;
+    }
+
+    private function shorten(string $body): string
+    {
+        $trimmed = trim($body);
+        if ($trimmed === '') {
+            return '(réponse vide)';
+        }
+
+        return mb_strimwidth($trimmed, 0, self::MAX_ERROR_BODY_CHARS, '…');
+    }
+}

--- a/modules/llm_connector/src/Provider/LlmProviderInterface.php
+++ b/modules/llm_connector/src/Provider/LlmProviderInterface.php
@@ -11,6 +11,13 @@ namespace Modules\LlmConnector\Provider;
 /**
  * Internal interface for LLM provider implementations.
  * Private to the module — never imported by consuming modules.
+ *
+ * Deliberately carries no tier-resolution method: which model backs which
+ * tier is decided once, for every provider alike, by
+ * Service\OcrModelSelector. Each driver used to also implement its own
+ * resolveTiers() heuristic, which nothing ever called — the two disagreed
+ * (notably about the OCR tier), so editing a driver's version looked like it
+ * changed behaviour while changing nothing at all.
  */
 interface LlmProviderInterface
 {
@@ -29,12 +36,4 @@ interface LlmProviderInterface
      * @param array<string, mixed> $options Additional options (system_prompt, attachments, response_schema, timeout)
      */
     public function complete(string $modelId, string $prompt, array $options = []): ProviderResponse;
-
-    /**
-     * Given a list of model IDs, return the best model for each tier.
-     *
-     * @param array<int, string> $modelIds List of available model IDs
-     * @return array{cheap: string|null, capable: string|null, ocr: string|null}
-     */
-    public function resolveTiers(array $modelIds): array;
 }

--- a/modules/llm_connector/src/Provider/MistralProvider.php
+++ b/modules/llm_connector/src/Provider/MistralProvider.php
@@ -18,10 +18,24 @@ class MistralProvider implements LlmProviderInterface
 {
     private const DEFAULT_TIMEOUT = 30;
 
+    private HttpTransport $http;
+
     public function __construct(
         private string $apiEndpoint,
         private string $apiKey
     ) {
+        $this->http = new HttpTransport();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function headers(): array
+    {
+        return [
+            'Authorization: Bearer ' . $this->apiKey,
+            'Content-Type: application/json',
+        ];
     }
 
     /**
@@ -30,7 +44,7 @@ class MistralProvider implements LlmProviderInterface
     public function listModels(): array
     {
         $url = rtrim($this->apiEndpoint, '/') . '/v1/models';
-        $response = $this->httpGet($url);
+        $response = $this->http->getJson($url, $this->headers(), self::DEFAULT_TIMEOUT);
 
         if (!isset($response['data']) || !is_array($response['data'])) {
             throw LlmException::apiError('Invalid response from models endpoint.');
@@ -39,6 +53,11 @@ class MistralProvider implements LlmProviderInterface
         $models = [];
         foreach ($response['data'] as $model) {
             $id = (string) ($model['id'] ?? '');
+            if ($id === '') {
+                // A model with no usable identifier cannot be called and must
+                // never reach llm_provider_models.model_id.
+                continue;
+            }
             $models[] = [
                 'id' => $id,
                 'display_name' => $id,
@@ -67,8 +86,10 @@ class MistralProvider implements LlmProviderInterface
 
         $body = $this->buildRequestBody($modelId, $messages, $options);
 
-        $response = $this->httpPost($url, $body, $timeout);
+        $response = $this->http->postJson($url, $this->headers(), $body, $timeout);
 
+        // A non-2xx never reaches this point (HttpTransport rejects it);
+        // this still catches an error object returned with a 200.
         if (isset($response['error'])) {
             $errorMsg = $response['error']['message'] ?? 'Unknown error';
             throw LlmException::apiError($errorMsg);
@@ -119,52 +140,6 @@ class MistralProvider implements LlmProviderInterface
         $truncated = ($choices[0]['finish_reason'] ?? null) === 'length';
 
         return [$content, $truncated];
-    }
-
-    /**
-     * @param array<int, string> $modelIds
-     * @return array{cheap: string|null, capable: string|null, ocr: string|null}
-     */
-    public function resolveTiers(array $modelIds): array
-    {
-        $bestSmall = null;
-        $bestLarge = null;
-        $bestOcr = null;
-
-        foreach ($modelIds as $id) {
-            $lower = strtolower($id);
-
-            // OCR detection
-            if (str_contains($lower, 'ocr')) {
-                if ($bestOcr === null || $this->extractDate($id) > $this->extractDate($bestOcr)) {
-                    $bestOcr = $id;
-                }
-            }
-
-            // Skip non-chat models, fine-tuned models, embedding models
-            if (str_contains($lower, 'embed')
-                || str_contains($lower, 'moderation')
-                || str_contains($lower, 'codestral')
-            ) {
-                continue;
-            }
-
-            if (str_contains($lower, 'small')) {
-                if ($bestSmall === null || $this->extractDate($id) > $this->extractDate($bestSmall)) {
-                    $bestSmall = $id;
-                }
-            } elseif (str_contains($lower, 'large') || str_contains($lower, 'medium')) {
-                if ($bestLarge === null || $this->extractDate($id) > $this->extractDate($bestLarge)) {
-                    $bestLarge = $id;
-                }
-            }
-        }
-
-        return [
-            'cheap' => $bestSmall,
-            'capable' => $bestLarge,
-            'ocr' => $bestOcr,
-        ];
     }
 
     /**
@@ -220,90 +195,5 @@ class MistralProvider implements LlmProviderInterface
         }
 
         return $parts !== [] ? implode("\n\n", $parts) : null;
-    }
-
-    /**
-     * Extract a YYYYMMDD date from a model ID, or a YYMM pattern.
-     * Models with "latest" in the name are considered the most recent.
-     */
-    private function extractDate(string $modelId): string
-    {
-        if (stripos($modelId, 'latest') !== false) {
-            return '99999999';
-        }
-        if (preg_match('/(\d{8})/', $modelId, $matches)) {
-            return $matches[1];
-        }
-        if (preg_match('/(\d{4})$/', $modelId, $matches)) {
-            return $matches[1] . '0000';
-        }
-        return '00000000';
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function httpGet(string $url): array
-    {
-        $context = stream_context_create([
-            'http' => [
-                'method' => 'GET',
-                'header' => implode("\r\n", [
-                    'Authorization: Bearer ' . $this->apiKey,
-                    'Content-Type: application/json',
-                ]),
-                'timeout' => self::DEFAULT_TIMEOUT,
-                'ignore_errors' => true,
-            ],
-        ]);
-
-        $body = @file_get_contents($url, false, $context);
-
-        if ($body === false) {
-            throw LlmException::timeout();
-        }
-
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            throw LlmException::apiError('Invalid JSON response from provider.');
-        }
-
-        return $decoded;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     * @return array<string, mixed>
-     */
-    private function httpPost(string $url, array $data, int $timeout): array
-    {
-        $jsonBody = json_encode($data, JSON_UNESCAPED_UNICODE);
-
-        $context = stream_context_create([
-            'http' => [
-                'method' => 'POST',
-                'header' => implode("\r\n", [
-                    'Authorization: Bearer ' . $this->apiKey,
-                    'Content-Type: application/json',
-                    'Content-Length: ' . strlen($jsonBody),
-                ]),
-                'content' => $jsonBody,
-                'timeout' => $timeout,
-                'ignore_errors' => true,
-            ],
-        ]);
-
-        $body = @file_get_contents($url, false, $context);
-
-        if ($body === false) {
-            throw LlmException::timeout();
-        }
-
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            throw LlmException::apiError('Invalid JSON response from provider.');
-        }
-
-        return $decoded;
     }
 }

--- a/modules/llm_connector/src/Provider/ScalewayProvider.php
+++ b/modules/llm_connector/src/Provider/ScalewayProvider.php
@@ -19,10 +19,24 @@ class ScalewayProvider implements LlmProviderInterface
 {
     private const DEFAULT_TIMEOUT = 30;
 
+    private HttpTransport $http;
+
     public function __construct(
         private string $apiEndpoint,
         private string $apiKey
     ) {
+        $this->http = new HttpTransport();
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function headers(): array
+    {
+        return [
+            'Authorization: Bearer ' . $this->apiKey,
+            'Content-Type: application/json',
+        ];
     }
 
     /**
@@ -31,7 +45,7 @@ class ScalewayProvider implements LlmProviderInterface
     public function listModels(): array
     {
         $url = rtrim($this->apiEndpoint, '/') . '/v1/models';
-        $response = $this->httpGet($url);
+        $response = $this->http->getJson($url, $this->headers(), self::DEFAULT_TIMEOUT);
 
         if (!isset($response['data']) || !is_array($response['data'])) {
             throw LlmException::apiError('Invalid response from models endpoint.');
@@ -40,6 +54,11 @@ class ScalewayProvider implements LlmProviderInterface
         $models = [];
         foreach ($response['data'] as $model) {
             $id = (string) ($model['id'] ?? '');
+            if ($id === '') {
+                // A model with no usable identifier cannot be called and must
+                // never reach llm_provider_models.model_id.
+                continue;
+            }
             $displayName = (string) ($model['name'] ?? $id);
             $models[] = [
                 'id' => $id,
@@ -69,8 +88,10 @@ class ScalewayProvider implements LlmProviderInterface
 
         $body = $this->buildRequestBody($modelId, $messages, $options);
 
-        $response = $this->httpPost($url, $body, $timeout);
+        $response = $this->http->postJson($url, $this->headers(), $body, $timeout);
 
+        // A non-2xx never reaches this point (HttpTransport rejects it);
+        // this still catches an error object returned with a 200.
         if (isset($response['error'])) {
             $errorMsg = $response['error']['message'] ?? 'Unknown error';
             throw LlmException::apiError($errorMsg);
@@ -128,56 +149,6 @@ class ScalewayProvider implements LlmProviderInterface
     }
 
     /**
-     * @param array<int, string> $modelIds
-     * @return array{cheap: string|null, capable: string|null, ocr: string|null}
-     */
-    public function resolveTiers(array $modelIds): array
-    {
-        $bestSmall = null;
-        $bestLarge = null;
-        $bestOcr = null;
-
-        foreach ($modelIds as $id) {
-            $lower = strtolower($id);
-
-            // OCR detection
-            if (str_contains($lower, 'ocr')) {
-                if ($bestOcr === null || $this->extractDate($id) > $this->extractDate($bestOcr)) {
-                    $bestOcr = $id;
-                }
-            }
-
-            // Skip non-chat models
-            if (str_contains($lower, 'embed')
-                || str_contains($lower, 'moderation')
-                || str_contains($lower, 'whisper')
-                || str_contains($lower, 'tts')
-            ) {
-                continue;
-            }
-
-            // Cheap tier: small models (mistral-small, ministral, llama-small, etc.)
-            if (str_contains($lower, 'small') || str_contains($lower, 'ministral') || str_contains($lower, 'nemo')) {
-                if ($bestSmall === null || $this->extractDate($id) > $this->extractDate($bestSmall)) {
-                    $bestSmall = $id;
-                }
-            }
-            // Capable tier: large/medium models
-            elseif (str_contains($lower, 'large') || str_contains($lower, 'medium')) {
-                if ($bestLarge === null || $this->extractDate($id) > $this->extractDate($bestLarge)) {
-                    $bestLarge = $id;
-                }
-            }
-        }
-
-        return [
-            'cheap' => $bestSmall,
-            'capable' => $bestLarge,
-            'ocr' => $bestOcr,
-        ];
-    }
-
-    /**
      * OpenAI-compatible multi-part content: image attachments as
      * image_url blocks (data URI), followed by the text prompt. Falls
      * back to a plain string when there are no image attachments,
@@ -226,90 +197,5 @@ class ScalewayProvider implements LlmProviderInterface
         }
 
         return $parts !== [] ? implode("\n\n", $parts) : null;
-    }
-
-    /**
-     * Extract a date from a model ID.
-     * Models with "latest" in the name are considered the most recent.
-     */
-    private function extractDate(string $modelId): string
-    {
-        if (stripos($modelId, 'latest') !== false) {
-            return '99999999';
-        }
-        if (preg_match('/(\d{8})/', $modelId, $matches)) {
-            return $matches[1];
-        }
-        if (preg_match('/(\d{4})$/', $modelId, $matches)) {
-            return $matches[1] . '0000';
-        }
-        return '00000000';
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function httpGet(string $url): array
-    {
-        $context = stream_context_create([
-            'http' => [
-                'method' => 'GET',
-                'header' => implode("\r\n", [
-                    'Authorization: Bearer ' . $this->apiKey,
-                    'Content-Type: application/json',
-                ]),
-                'timeout' => self::DEFAULT_TIMEOUT,
-                'ignore_errors' => true,
-            ],
-        ]);
-
-        $body = @file_get_contents($url, false, $context);
-
-        if ($body === false) {
-            throw LlmException::timeout();
-        }
-
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            throw LlmException::apiError('Invalid JSON response from provider.');
-        }
-
-        return $decoded;
-    }
-
-    /**
-     * @param array<string, mixed> $data
-     * @return array<string, mixed>
-     */
-    private function httpPost(string $url, array $data, int $timeout): array
-    {
-        $jsonBody = json_encode($data, JSON_UNESCAPED_UNICODE);
-
-        $context = stream_context_create([
-            'http' => [
-                'method' => 'POST',
-                'header' => implode("\r\n", [
-                    'Authorization: Bearer ' . $this->apiKey,
-                    'Content-Type: application/json',
-                    'Content-Length: ' . strlen($jsonBody),
-                ]),
-                'content' => $jsonBody,
-                'timeout' => $timeout,
-                'ignore_errors' => true,
-            ],
-        ]);
-
-        $body = @file_get_contents($url, false, $context);
-
-        if ($body === false) {
-            throw LlmException::timeout();
-        }
-
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            throw LlmException::apiError('Invalid JSON response from provider.');
-        }
-
-        return $decoded;
     }
 }

--- a/modules/llm_connector/src/Repository/ProviderRepository.php
+++ b/modules/llm_connector/src/Repository/ProviderRepository.php
@@ -157,4 +157,65 @@ class ProviderRepository
     {
         $this->pdo->exec('UPDATE llm_providers SET is_active = 0');
     }
+
+    /**
+     * Run $work inside a transaction. Used for the deactivate-then-activate
+     * pair that maintains "exactly one active provider": those two writes
+     * must not be separable, or a failure between them leaves the site with
+     * no active provider at all.
+     *
+     * Tolerates an outer transaction already being open (the caller then owns
+     * the commit) rather than failing on a nested begin.
+     *
+     * @param callable(): void $work
+     */
+    public function transactional(callable $work): void
+    {
+        if ($this->pdo->inTransaction()) {
+            $work();
+            return;
+        }
+
+        $this->pdo->beginTransaction();
+        try {
+            $work();
+            $this->pdo->commit();
+        } catch (\Throwable $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * The single provider row for a driver, if any.
+     *
+     * The configuration page is one-provider-per-driver by construction, but
+     * nothing in the schema enforced it: a second row for the same driver
+     * became invisible in the UI (the page keys providers by driver, so the
+     * later row overwrote the earlier one) while findFirstActive() orders by
+     * id ASC and could still pick it. Callers use this to reuse the existing
+     * row for a driver instead of silently creating a rival one.
+     *
+     * @return array{id: int, name: string, driver: string, api_endpoint: string, is_active: bool}|null
+     */
+    public function findByDriver(string $driver): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT id, name, driver, api_endpoint, is_active FROM llm_providers WHERE driver = ? ORDER BY id ASC LIMIT 1'
+        );
+        $stmt->execute([$driver]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        if ($row === false) {
+            return null;
+        }
+
+        return [
+            'id' => (int) $row['id'],
+            'name' => (string) $row['name'],
+            'driver' => (string) $row['driver'],
+            'api_endpoint' => (string) $row['api_endpoint'],
+            'is_active' => (bool) $row['is_active'],
+        ];
+    }
 }

--- a/modules/llm_connector/src/Service/LlmConnectorService.php
+++ b/modules/llm_connector/src/Service/LlmConnectorService.php
@@ -44,32 +44,38 @@ class LlmConnectorService implements LlmConnectorInterface
 
     public function isAvailable(): bool
     {
-        $provider = $this->providerRepo->findFirstActive();
+        $provider = $this->activeProvider();
         if ($provider === null) {
             return false;
         }
 
-        $cheapModel = $this->modelRepo->findByProviderAndTier($provider['id'], LlmTier::CHEAP);
-        $capableModel = $this->modelRepo->findByProviderAndTier($provider['id'], LlmTier::CAPABLE);
-        $ocrModel = $this->modelRepo->findByProviderAndTier($provider['id'], LlmTier::OCR);
+        foreach (LlmTier::cases() as $tier) {
+            if ($this->modelRepo->findByProviderAndTier($provider['id'], $tier) !== null) {
+                return true;
+            }
+        }
 
-        return $cheapModel !== null || $capableModel !== null || $ocrModel !== null;
+        return false;
+    }
+
+    public function isTierAvailable(LlmTier $tier): bool
+    {
+        $provider = $this->activeProvider();
+        if ($provider === null) {
+            return false;
+        }
+
+        return $this->resolveModel($provider['id'], $tier) !== null;
     }
 
     public function complete(LlmRequest $request): LlmResponse
     {
-        $provider = $this->providerRepo->findFirstActive();
+        $provider = $this->activeProvider();
         if ($provider === null) {
             throw LlmException::noProvider();
         }
 
-        $model = $this->modelRepo->findByProviderAndTier($provider['id'], $request->tier);
-        
-        // Fallback: if OCR tier is requested but no OCR model is assigned, use CHEAP
-        if ($model === null && $request->tier === LlmTier::OCR) {
-            $model = $this->modelRepo->findByProviderAndTier($provider['id'], LlmTier::CHEAP);
-        }
-        
+        $model = $this->resolveModel($provider['id'], $request->tier);
         if ($model === null) {
             throw LlmException::noModel($request->tier);
         }
@@ -137,6 +143,48 @@ class LlmConnectorService implements LlmConnectorInterface
             outputTokens: $providerResponse->outputTokens,
             truncated: $providerResponse->truncated
         );
+    }
+
+    /**
+     * The active provider, or null when there is none — including when its
+     * stored API key cannot be decrypted.
+     *
+     * ProviderRepository decrypts the key eagerly, so a wrong/rotated
+     * encryption key makes findFirstActive() throw DecryptionException. That
+     * used to escape isAvailable(), which several callers invoke while
+     * rendering a page: it turned an unusable API key into a 500 on the
+     * PUBLIC retrospective board (Modules\Retro\Controller\
+     * RetroBoardController::show()), the news editor and the gallery config
+     * page. An unreadable key means "no AI", never "the site is down".
+     *
+     * @return array{id: int, name: string, driver: string, api_endpoint: string, api_key: string}|null
+     */
+    private function activeProvider(): ?array
+    {
+        try {
+            return $this->providerRepo->findFirstActive();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * The model backing a tier, applying the OCR → CHEAP fallback (no OCR
+     * model assigned still leaves a real chat model to read a receipt with).
+     * Shared by complete() and isTierAvailable() so the two can never
+     * disagree about whether a tier is usable.
+     *
+     * @return array{id: int, provider_id: int, model_id: string, display_name: string}|null
+     */
+    private function resolveModel(int $providerId, LlmTier $tier): ?array
+    {
+        $model = $this->modelRepo->findByProviderAndTier($providerId, $tier);
+
+        if ($model === null && $tier === LlmTier::OCR) {
+            $model = $this->modelRepo->findByProviderAndTier($providerId, LlmTier::CHEAP);
+        }
+
+        return $model;
     }
 
     /**

--- a/modules/llm_connector/views/config/index.html.twig
+++ b/modules/llm_connector/views/config/index.html.twig
@@ -243,7 +243,7 @@ function updateModelsList(driver) {
 
 function escapeHtml(text) {
     const div = document.createElement('div');
-    div.textContent = text;
+    div.textContent = text ?? '';
     return div.innerHTML;
 }
 
@@ -282,7 +282,7 @@ document.getElementById('provider-form')?.addEventListener('submit', async (e) =
     });
     const data = await res.json();
     if (!data.success) {
-        msgEl.innerHTML = '<div class="alert alert-danger mb-0">' + data.error + '</div>';
+        msgEl.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(data.error) + '</div>';
         return;
     }
 
@@ -334,10 +334,10 @@ async function testConnection(providerId, shouldActivate = false) {
         }
         
         updateSummary(data);
-        msgEl.innerHTML = '<div class="alert alert-success mb-0">Connexion réussie — ' + data.message.replace('Connexion réussie — ', '') + '</div>';
+        msgEl.innerHTML = '<div class="alert alert-success mb-0">Connexion réussie — ' + escapeHtml(String(data.message || '').replace('Connexion réussie — ', '')) + '</div>';
         setTimeout(() => window.location.reload(), 800);
     } else {
-        msgEl.innerHTML = '<div class="alert alert-danger mb-0">' + data.error + '</div>';
+        msgEl.innerHTML = '<div class="alert alert-danger mb-0">' + escapeHtml(data.error) + '</div>';
     }
 }
 

--- a/modules/retro/src/Controller/RetroBoardController.php
+++ b/modules/retro/src/Controller/RetroBoardController.php
@@ -49,6 +49,14 @@ class RetroBoardController extends AbstractController
     private const VOTER_COOKIE = 'retro_voter';
     private const VOTER_COOKIE_DAYS = 365;
 
+    /**
+     * How far past the board's own comment limit a text may still be handed
+     * to shorten(). Rewriting a slightly-too-long comment is the whole point,
+     * so the cap has to sit above maxCommentLength — but "shorten this novel"
+     * is not a real use of the feature, just a way to run up the AI bill.
+     */
+    private const SHORTEN_MAX_INPUT_FACTOR = 4;
+
     public function __construct(
         Environment $twig,
         private BoardRepository $boardRepository,
@@ -281,8 +289,32 @@ class RetroBoardController extends AbstractController
             return $this->json(['success' => false, 'error' => 'Service IA non disponible.'], 422);
         }
 
+        // Same three guards Service\CommentService::postComment() applies
+        // before it reaches the LLM, and for the same reason: this route is
+        // role_min "public", so without them any visitor holding a board URL
+        // could spend the unit's AI budget in a loop, on a closed board, with
+        // a body of unbounded size.
+        if (!$board->isOpen()) {
+            return $this->json(['success' => false, 'error' => 'Ce board est clôturé.'], 422);
+        }
+
+        $body = trim((string) ($data['body'] ?? ''));
+        if ($body === '') {
+            return $this->json(['success' => false, 'error' => 'Le commentaire ne peut pas être vide.'], 422);
+        }
+        if (mb_strlen($body) > $board->maxCommentLength * self::SHORTEN_MAX_INPUT_FACTOR) {
+            return $this->json([
+                'success' => false,
+                'error' => 'Message beaucoup trop long pour être raccourci — réduis-le d\'abord.',
+            ], 422);
+        }
+
         try {
-            $shortened = $this->moderationService->shorten((string) ($data['body'] ?? ''), $board->maxCommentLength);
+            $this->rateLimitService->checkAndRecord(
+                $this->rateLimitService->identifierHash($this->readVoterCookie($request), session_id()),
+                'shorten'
+            );
+            $shortened = $this->moderationService->shorten($body, $board->maxCommentLength);
         } catch (RetroException $e) {
             return $this->json(['success' => false, 'error' => $e->getMessage()], 422);
         }

--- a/modules/retro/src/Service/ModerationService.php
+++ b/modules/retro/src/Service/ModerationService.php
@@ -92,7 +92,13 @@ class ModerationService
             return null;
         }
 
-        if (!($parsed['flagged'] ?? false)) {
+        // Structured output is prompt-instructed, not enforced by the API
+        // (see Service\LlmConnectorService::extractJson()), so a model may
+        // answer with the string "false" — which is truthy in PHP and used to
+        // flag a perfectly civil comment. Only a real boolean true counts;
+        // anything else means "not flagged", the safe direction for a
+        // courtesy check that must never block a legitimate participant.
+        if (($parsed['flagged'] ?? false) !== true) {
             return ['flagged' => false, 'reason' => null, 'suggestion' => null];
         }
 

--- a/modules/retro/src/Service/RateLimitService.php
+++ b/modules/retro/src/Service/RateLimitService.php
@@ -26,10 +26,19 @@ class RateLimitService
 {
     private const WINDOW_MINUTES = 10;
 
-    /** @var array<string, int> */
+    /**
+     * An action type absent from this map is unlimited (checkAndRecord()
+     * falls back to PHP_INT_MAX), so every throttled action must be listed
+     * here — adding the call site alone silently does nothing.
+     *
+     * @var array<string, int>
+     */
     private const LIMITS = [
         'comment' => 10,
         'vote' => 40,
+        // Each one is a paid LLM round-trip on a route open to anonymous
+        // visitors, so it is the tightest of the three.
+        'shorten' => 5,
     ];
 
     public function __construct(

--- a/tests/Core/Http/Controller/RgpdConfigControllerAvailabilityTest.php
+++ b/tests/Core/Http/Controller/RgpdConfigControllerAvailabilityTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Http\Controller;
+
+use Core\Config\SettingService;
+use Core\Http\Controller\RgpdConfigController;
+use Core\Http\Request;
+use Core\Journal\JournalService;
+use Core\Module\ModuleManager;
+use Core\Security\AuthSession;
+use Core\Security\CsrfGuard;
+use Core\View\EditableContentService;
+use Core\View\RgpdContentService;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+/**
+ * The page used to offer "Générer avec l'IA" whenever llm_connector was merely
+ * installed. An enabled module with no provider — or with no model on the
+ * CAPABLE tier this document is generated on — then failed only after the
+ * click. Both surfaces now ask RgpdContentService whether generation can
+ * actually run.
+ */
+class RgpdConfigControllerAvailabilityTest extends TestCase
+{
+    private function controller(
+        RgpdContentService $rgpdContentService,
+        bool $moduleEnabled = true
+    ): RgpdConfigController {
+        $moduleManager = $this->createStub(ModuleManager::class);
+        $moduleManager->method('getEnabledModuleIds')
+            ->willReturn($moduleEnabled ? ['llm_connector'] : []);
+
+        $settingService = $this->createStub(SettingService::class);
+        $settingService->method('get')->willReturn('default');
+
+        $editableContentService = $this->createStub(EditableContentService::class);
+        $editableContentService->method('get')->willReturn('');
+
+        // The template only has to echo the flag under test.
+        $twig = new Environment(new ArrayLoader([
+            'config/rgpd.html.twig' => '{{ llm_available ? "IA_DISPONIBLE" : "IA_INDISPONIBLE" }}',
+        ]));
+
+        return new RgpdConfigController(
+            $twig,
+            $editableContentService,
+            $rgpdContentService,
+            $settingService,
+            $moduleManager,
+            $this->createStub(JournalService::class)
+        );
+    }
+
+    private function rgpdService(bool $available): RgpdContentService
+    {
+        $service = $this->createStub(RgpdContentService::class);
+        $service->method('isAvailable')->willReturn($available);
+        $service->method('getDefaultContent')->willReturn('<h2>Politique</h2>');
+
+        return $service;
+    }
+
+    protected function tearDown(): void
+    {
+        AuthSession::logout();
+        unset($_SESSION['_csrf_token']);
+    }
+
+    public function testThePageOffersGenerationWhenATierIsActuallyUsable(): void
+    {
+        $response = $this->controller($this->rgpdService(true))
+            ->index(new Request('GET', '/config/rgpd', [], [], [], []), []);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('IA_DISPONIBLE', $response->getBody());
+    }
+
+    public function testThePageHidesGenerationWhenTheModuleIsInstalledButUnusable(): void
+    {
+        $response = $this->controller($this->rgpdService(false))
+            ->index(new Request('GET', '/config/rgpd', [], [], [], []), []);
+
+        $this->assertStringContainsString('IA_INDISPONIBLE', $response->getBody());
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function jsonRequest(array $data): Request
+    {
+        return $this->createConfiguredStub(Request::class, [
+            'getRawBody' => (string) json_encode($data),
+        ]);
+    }
+
+    private function csrfToken(): string
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $token = bin2hex(random_bytes(32));
+        $_SESSION['_csrf_token'] = $token;
+
+        return $token;
+    }
+
+    public function testGenerateRefusesCleanlyWhenNoTierIsUsable(): void
+    {
+        AuthSession::login(1, 'super@example.org', 'superadmin');
+
+        $response = $this->controller($this->rgpdService(false))->generate(
+            $this->jsonRequest(['_csrf_token' => $this->csrfToken(), 'prompt' => '']),
+            []
+        );
+
+        $this->assertSame(400, $response->getStatusCode());
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertFalse($decoded['success']);
+        $this->assertStringContainsString('fournisseur IA', $decoded['error']);
+    }
+
+    public function testGenerateStillReportsAnEntirelyDisabledModuleSeparately(): void
+    {
+        AuthSession::login(1, 'super@example.org', 'superadmin');
+
+        $response = $this->controller($this->rgpdService(false), moduleEnabled: false)->generate(
+            $this->jsonRequest(['_csrf_token' => $this->csrfToken(), 'prompt' => '']),
+            []
+        );
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertStringContainsString('non activé', json_decode($response->getBody(), true)['error']);
+    }
+
+    /**
+     * The availability gate must sit behind authentication and CSRF, not in
+     * front of them — otherwise it answers questions about the site's AI
+     * configuration to anyone who can reach the route.
+     */
+    public function testGenerateRejectsABadCsrfTokenBeforeCheckingAvailability(): void
+    {
+        AuthSession::login(1, 'super@example.org', 'superadmin');
+        $this->csrfToken();
+
+        $response = $this->controller($this->rgpdService(false))->generate(
+            $this->jsonRequest(['_csrf_token' => 'wrong', 'prompt' => '']),
+            []
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+}

--- a/tests/Core/View/RgpdContentServiceTest.php
+++ b/tests/Core/View/RgpdContentServiceTest.php
@@ -30,6 +30,7 @@ class RgpdContentServiceTest extends TestCase
     {
         $llmConnector = $this->createMock(LlmConnectorInterface::class);
         $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('isTierAvailable')->willReturn(true);
         $llmConnector->expects($this->once())->method('complete')
             ->with($this->callback(fn(LlmRequest $request) => $request->maxTokens === 8192))
             ->willReturn(new LlmResponse(content: '<h2>Titre</h2><p>Contenu. Unité scoute est responsable du traitement.</p>', parsed: null, inputTokens: 10, outputTokens: 20, truncated: false));
@@ -45,6 +46,7 @@ class RgpdContentServiceTest extends TestCase
     {
         $llmConnector = $this->createMock(LlmConnectorInterface::class);
         $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('isTierAvailable')->willReturn(true);
         $llmConnector->expects($this->exactly(2))->method('complete')
             ->willReturnOnConsecutiveCalls(
                 new LlmResponse(content: '<h2>Titre</h2><p>Début du contenu', parsed: null, inputTokens: 10, outputTokens: 8192, truncated: true),
@@ -62,6 +64,7 @@ class RgpdContentServiceTest extends TestCase
     {
         $llmConnector = $this->createMock(LlmConnectorInterface::class);
         $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('isTierAvailable')->willReturn(true);
 
         $capturedContinuationRequest = null;
         $llmConnector->expects($this->exactly(2))->method('complete')
@@ -85,6 +88,7 @@ class RgpdContentServiceTest extends TestCase
     {
         $llmConnector = $this->createMock(LlmConnectorInterface::class);
         $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('isTierAvailable')->willReturn(true);
         // MAX_CONTINUATIONS = 2 → 1 initial call + 2 continuations = 3 total.
         $llmConnector->expects($this->exactly(3))->method('complete')->willReturn(
             new LlmResponse(content: '<h2>Titre</h2><p>Contenu incompl', parsed: null, inputTokens: 10, outputTokens: 8192, truncated: true)
@@ -114,6 +118,7 @@ class RgpdContentServiceTest extends TestCase
 
         $llmConnector = $this->createMock(LlmConnectorInterface::class);
         $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('isTierAvailable')->willReturn(true);
         $llmConnector->method('complete')->willReturn(
             new LlmResponse(content: '<h2>Titre</h2><p>Le site traite vos données.</p>', parsed: null, inputTokens: 10, outputTokens: 20, truncated: false)
         );

--- a/tests/Modules/Finance/Service/BulkCategorizationServiceTest.php
+++ b/tests/Modules/Finance/Service/BulkCategorizationServiceTest.php
@@ -195,9 +195,11 @@ class BulkCategorizationServiceTest extends TestCase
     /**
      * Regression: the marker was a bare '1' cleared only by
      * runInBackground()'s finally block. If the scheduled task was never
-     * picked up (the poor man's cron needs a page load) or the process died
-     * first, it stayed set for ever and the config page's "Exécuter les
-     * règles" button was permanently disabled, with no way to reset it.
+     * picked up (the poor man's cron needs a page load), the process died
+     * first, or — the most likely case — the batch was killed by PHP's
+     * max_execution_time (a fatal error, which skips finally entirely), it
+     * stayed set for ever and the config page's "Exécuter les règles" button
+     * was permanently disabled, with no way to reset it.
      */
     public function testAStaleRunningMarkerIsNotReportedAsRunning(): void
     {
@@ -205,7 +207,7 @@ class BulkCategorizationServiceTest extends TestCase
         $this->assertTrue($this->service()->isRunning());
 
         $this->settingService->setInternal(
-            'bulk_categorization_running',
+            'bulk_categorization_started_at',
             (string) (time() - 7200),
             'finance'
         );
@@ -223,15 +225,54 @@ class BulkCategorizationServiceTest extends TestCase
     }
 
     /**
-     * A marker written before the timestamp existed is a bare '1' — it must
-     * still read as running rather than crashing or silently resetting.
+     * A marker written before the timestamp existed is a bare '1' under the
+     * old key — it must still read as running rather than crashing or
+     * silently resetting, for as long as the task it refers to is queued.
      */
     public function testALegacyBareOneMarkerIsStillReportedAsRunning(): void
     {
         $this->settingService->register('bulk_categorization_running', '0', 'text', 'x', 'x', 'finance', null, null, false);
         $this->settingService->setInternal('bulk_categorization_running', '1', 'finance');
+        (new SchedulerService(new SchedulerRepository($this->pdo)))->scheduleAfter('finance', 'run_categorization_rules', 0);
 
         $this->assertTrue($this->service()->isRunning());
+    }
+
+    /**
+     * ...but it carries no expiry of its own, so once the task it referred to
+     * is gone it must not block a new run for ever either.
+     */
+    public function testALegacyMarkerWithNoQueuedTaskDoesNotBlockANewRun(): void
+    {
+        $this->settingService->register('bulk_categorization_running', '0', 'text', 'x', 'x', 'finance', null, null, false);
+        $this->settingService->setInternal('bulk_categorization_running', '1', 'finance');
+
+        $this->assertFalse($this->service()->isRunning());
+        $this->assertTrue($this->service()->scheduleBackgroundRun());
+    }
+
+    /**
+     * The upgrade path the legacy tests above cannot reach: a site that ran
+     * the previous version carries 'bulk_categorization_running' registered
+     * as a `boolean` setting. SettingRepository::upsert() never re-types an
+     * existing row and SettingService::setInternal() validates against the
+     * stored type, so writing a timestamp into that key throws on exactly the
+     * sites that have one. The timestamp lives under its own numeric key for
+     * that reason.
+     */
+    public function testWorksOnAnInstallThatStillCarriesTheOldBooleanFlag(): void
+    {
+        $this->settingService->register('bulk_categorization_running', '0', 'boolean', 'Ancien indicateur', 'x', 'finance', null, null, false);
+        $this->settingService->setInternal('bulk_categorization_running', '1', 'finance');
+
+        $service = $this->service();
+
+        $this->assertTrue($service->scheduleBackgroundRun());
+        $this->assertTrue($service->isRunning());
+
+        $service->runInBackground();
+        $this->assertFalse($service->isRunning());
+        $this->assertNotNull($service->getLastResult());
     }
 
     public function testRunInBackgroundClearsTheMarkerEvenWhenNothingToDo(): void
@@ -241,6 +282,39 @@ class BulkCategorizationServiceTest extends TestCase
         $this->service()->runInBackground();
 
         $this->assertFalse($this->service()->isRunning());
+    }
+
+    /**
+     * A movement whose data breaks the AI call — a label carrying non-UTF-8
+     * bytes from a Latin-1 bank export is the real-world case — must not
+     * abort the batch. AiCategorizationService only catches LlmException.
+     */
+    public function testOneFailingMovementDoesNotAbortTheBatch(): void
+    {
+        $categoryId = $this->categoryRepository->create('Fournitures');
+        $this->createTransaction('Premier mouvement');
+        $secondId = $this->createTransaction('Deuxième mouvement');
+
+        $calls = 0;
+        $llmConnector = $this->createMock(LlmConnectorInterface::class);
+        $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('complete')->willReturnCallback(function () use (&$calls) {
+            $calls++;
+            if ($calls === 1) {
+                throw new \TypeError('strlen(): Argument #1 ($string) must be of type string, false given');
+            }
+            return new LlmResponse('{}', ['category' => 'Fournitures', 'new_category_suggestion' => null], 10, 5);
+        });
+
+        $service = $this->service($llmConnector);
+        $service->setAiRuleEnabled(true);
+
+        $result = $service->runOnUncategorized();
+
+        $this->assertSame(2, $calls, 'The batch must reach the second movement.');
+        $this->assertSame(1, $result->categorizedByAi);
+        $this->assertSame(1, $result->stillUncategorized);
+        $this->assertSame($categoryId, $this->transactionRepository->findById($secondId)->categoryId);
     }
 
 }

--- a/tests/Modules/LlmConnector/Controller/ConfigControllerTest.php
+++ b/tests/Modules/LlmConnector/Controller/ConfigControllerTest.php
@@ -1,0 +1,439 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\LlmConnector\Controller;
+
+use Core\Http\Request;
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Scheduler\SchedulerRepository;
+use Core\Scheduler\SchedulerService;
+use Core\Security\AuthSession;
+use Core\Security\EncryptionService;
+use Core\Security\RbacGuard;
+use Core\Security\Role;
+use Modules\LlmConnector\Controller\ConfigController;
+use Modules\LlmConnector\Repository\ProviderModelRepository;
+use Modules\LlmConnector\Repository\ProviderRepository;
+use Modules\LlmConnector\Service\OcrModelSelector;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFunction;
+
+/**
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class ConfigControllerTest extends TestCase
+{
+    private \PDO $pdo;
+    private ProviderRepository $providerRepository;
+    private ProviderModelRepository $modelRepository;
+    private ConfigController $controller;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        $this->createLlmTables();
+
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->providerRepository = new ProviderRepository($this->pdo, $encryption);
+        $this->modelRepository = new ProviderModelRepository($this->pdo);
+
+        $templateDir = dirname(__DIR__, 4) . '/core/View/templates';
+        $loader = new FilesystemLoader($templateDir);
+        $loader->addPath(dirname(__DIR__, 4) . '/modules/llm_connector/views', 'llm_connector');
+        $twig = new Environment($loader, ['cache' => false, 'autoescape' => 'html']);
+        foreach ([
+            'site_name' => 'Test', 'is_authenticated' => true, 'current_user_role' => 'superadmin',
+            'config_mode' => true, 'cookie_consent_given' => true, 'menus' => null, 'csp_nonce' => 'test-nonce',
+        ] as $key => $value) {
+            $twig->addGlobal($key, $value);
+        }
+        $twig->addFunction(new TwigFunction('csrf_field', fn() => '', ['is_safe' => ['html']]));
+        $twig->addFunction(new TwigFunction('get_flash', fn() => null));
+        $twig->addFunction(new TwigFunction('csrf_token', fn() => 'test'));
+        $twig->addFunction(new TwigFunction('file_url', fn() => ''));
+        $twig->addFunction(new TwigFunction('param', fn() => ''));
+
+        $this->controller = new ConfigController(
+            $twig,
+            $this->providerRepository,
+            $this->modelRepository,
+            new OcrModelSelector(),
+            new SchedulerService(new SchedulerRepository($this->pdo)),
+            new JournalService(new JournalRepository($this->pdo))
+        );
+
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        AuthSession::logout();
+    }
+
+    private function createLlmTables(): void
+    {
+        $this->pdo->exec('CREATE TABLE llm_providers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            driver TEXT NOT NULL,
+            api_endpoint TEXT NOT NULL,
+            api_key BLOB NOT NULL,
+            is_active INTEGER NOT NULL DEFAULT 1,
+            created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )');
+
+        $this->pdo->exec('CREATE TABLE llm_provider_models (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            provider_id INTEGER NOT NULL,
+            model_id TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            is_tier_cheap INTEGER NOT NULL DEFAULT 0,
+            is_tier_capable INTEGER NOT NULL DEFAULT 0,
+            is_tier_ocr INTEGER NOT NULL DEFAULT 0,
+            last_seen_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        )');
+    }
+
+    private function csrfToken(): string
+    {
+        $token = bin2hex(random_bytes(32));
+        $_SESSION['_csrf_token'] = $token;
+
+        return $token;
+    }
+
+    /**
+     * Request::getRawBody() reads php://input directly, so the body has to be
+     * supplied by a double. A stub rather than a mock: these tests assert on
+     * the controller's response, never on how it consulted the request.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function jsonRequest(array $data): Request
+    {
+        return $this->createConfiguredStub(Request::class, [
+            'getRawBody' => (string) json_encode($data),
+        ]);
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function manifestRoutes(): array
+    {
+        $manifest = json_decode(
+            (string) file_get_contents(dirname(__DIR__, 4) . '/modules/llm_connector/module.json'),
+            true
+        );
+
+        return $manifest['routes'];
+    }
+
+    // ---------------------------------------------------------------- RBAC
+
+    /**
+     * The routes handle API keys, so every one of them must be superadmin.
+     * The guard itself is applied by the Router (never by the controller), so
+     * the manifest declaration IS the boundary — pin it.
+     */
+    public function testEveryRouteIsDeclaredSuperadminOnly(): void
+    {
+        $routes = $this->manifestRoutes();
+
+        $this->assertCount(3, $routes);
+        foreach ($routes as $route) {
+            $this->assertSame('superadmin', $route['role_min'], "Route {$route['path']} must be superadmin.");
+        }
+    }
+
+    public function testAccessIsGrantedAtRoleMinAndDeniedOneLevelBelow(): void
+    {
+        $guard = new RbacGuard();
+
+        AuthSession::login(1, 'super@example.org', Role::SUPERADMIN->value);
+        foreach ($this->manifestRoutes() as $route) {
+            $this->assertNull(
+                $guard->enforce(Role::from($route['role_min'])),
+                "Superadmin must reach {$route['path']}."
+            );
+        }
+
+        // One level below superadmin is admin ("Chef d'Unité").
+        AuthSession::login(2, 'admin@example.org', Role::ADMIN->value);
+        foreach ($this->manifestRoutes() as $route) {
+            $response = $guard->enforce(Role::from($route['role_min']));
+            $this->assertNotNull($response, "Admin must be refused {$route['path']}.");
+            $this->assertSame(403, $response->getStatusCode());
+        }
+    }
+
+    public function testAnAnonymousVisitorIsRedirectedToLogin(): void
+    {
+        $response = (new RbacGuard())->enforce(Role::SUPERADMIN);
+
+        $this->assertNotNull($response);
+        $this->assertSame(302, $response->getStatusCode());
+    }
+
+    // --------------------------------------------------------------- index
+
+    public function testIndexRendersWithNoProviderConfigured(): void
+    {
+        $response = $this->controller->index(new Request('GET', '/config/llm', [], [], [], []), []);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('Intelligence artificielle', $response->getBody());
+    }
+
+    public function testIndexShowsTheAssignedTierModels(): void
+    {
+        $providerId = $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-test', true);
+        $this->modelRepository->upsert($providerId, 'claude-haiku', 'Claude Haiku');
+        $this->modelRepository->autoAssignTiers($providerId, ['cheap' => 'claude-haiku', 'capable' => null, 'ocr' => null]);
+
+        $response = $this->controller->index(new Request('GET', '/config/llm', [], [], [], []), []);
+
+        $this->assertStringContainsString('Claude Haiku', $response->getBody());
+    }
+
+    /**
+     * Nothing enforced one-row-per-driver, and the page keys providers by
+     * driver — a second row used to overwrite the first in the view while
+     * findFirstActive() (id ASC) still picked the first. The page must show
+     * the provider actually in use.
+     */
+    public function testIndexShowsTheProviderThatFindFirstActiveWouldPick(): void
+    {
+        $firstId = $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-first', true);
+        $this->providerRepository->create('Anthropic bis', 'anthropic', 'https://api.anthropic.com', 'sk-second', false);
+        $this->modelRepository->upsert($firstId, 'claude-haiku', 'Modèle du premier');
+        $this->modelRepository->autoAssignTiers($firstId, ['cheap' => 'claude-haiku', 'capable' => null, 'ocr' => null]);
+
+        $response = $this->controller->index(new Request('GET', '/config/llm', [], [], [], []), []);
+
+        $this->assertStringContainsString('Modèle du premier', $response->getBody());
+    }
+
+    // --------------------------------------------------------- saveProvider
+
+    public function testSaveProviderRejectsAMissingCsrfToken(): void
+    {
+        $response = $this->controller->saveProvider(
+            $this->jsonRequest([
+                'name' => 'Anthropic', 'driver' => 'anthropic',
+                'api_endpoint' => 'https://api.anthropic.com', 'api_key' => 'sk-test',
+            ]),
+            []
+        );
+
+        $this->assertFalse(json_decode($response->getBody(), true)['success']);
+    }
+
+    public function testSaveProviderCreatesAndActivatesANewProvider(): void
+    {
+        $response = $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'name' => 'Anthropic', 'driver' => 'anthropic',
+                'api_endpoint' => 'https://api.anthropic.com', 'api_key' => 'sk-test',
+            ]),
+            []
+        );
+
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertTrue($decoded['success']);
+
+        $active = $this->providerRepository->findFirstActive();
+        $this->assertNotNull($active);
+        $this->assertSame('anthropic', $active['driver']);
+        $this->assertSame('sk-test', $active['api_key']);
+    }
+
+    public function testSaveProviderRejectsAnUnknownDriver(): void
+    {
+        $response = $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'name' => 'Rogue', 'driver' => 'rogue',
+                'api_endpoint' => 'https://example.org', 'api_key' => 'k',
+            ]),
+            []
+        );
+
+        $this->assertFalse(json_decode($response->getBody(), true)['success']);
+    }
+
+    /**
+     * The endpoint is concatenated into a URL and handed to the HTTP layer,
+     * so "not empty" was never enough — the posted value is whatever the
+     * client chose to send, not what the dropdown offered.
+     *
+     */
+    #[DataProvider('invalidEndpointProvider')]
+    public function testSaveProviderRejectsANonHttpsEndpoint(string $endpoint): void
+    {
+        $response = $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'name' => 'Anthropic', 'driver' => 'anthropic',
+                'api_endpoint' => $endpoint, 'api_key' => 'sk-test',
+            ]),
+            []
+        );
+
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertFalse($decoded['success'], "Endpoint '{$endpoint}' should be refused.");
+        $this->assertNull($this->providerRepository->findFirstActive());
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function invalidEndpointProvider(): array
+    {
+        return [
+            'plain http' => ['http://api.anthropic.com'],
+            'file scheme' => ['file:///etc/passwd'],
+            'no scheme' => ['api.anthropic.com'],
+            'garbage' => ['not a url at all'],
+        ];
+    }
+
+    /**
+     * The regression this route needed most: deactivateAll() used to run
+     * before validation, so a refused save still switched every AI feature
+     * on the site off — with an error message that implied nothing had
+     * happened.
+     */
+    public function testARefusedSaveLeavesTheExistingProviderActive(): void
+    {
+        $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-existing', true);
+
+        // A new provider for a different driver, with no API key: refused.
+        $response = $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'name' => 'Mistral AI', 'driver' => 'mistral',
+                'api_endpoint' => 'https://api.mistral.ai', 'api_key' => '',
+            ]),
+            []
+        );
+
+        $this->assertFalse(json_decode($response->getBody(), true)['success']);
+
+        $active = $this->providerRepository->findFirstActive();
+        $this->assertNotNull($active, 'The previously working provider must still be active.');
+        $this->assertSame('anthropic', $active['driver']);
+    }
+
+    public function testASaveForAnUnknownProviderIdIsRefusedAndChangesNothing(): void
+    {
+        $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-existing', true);
+
+        $response = $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'id' => 4242, 'name' => 'Mistral AI', 'driver' => 'mistral',
+                'api_endpoint' => 'https://api.mistral.ai', 'api_key' => 'sk-new',
+            ]),
+            []
+        );
+
+        $this->assertFalse(json_decode($response->getBody(), true)['success']);
+
+        $active = $this->providerRepository->findFirstActive();
+        $this->assertNotNull($active);
+        $this->assertSame('anthropic', $active['driver']);
+    }
+
+    public function testSavingAgainWithoutAnIdReusesTheDriverRowInsteadOfCreatingARival(): void
+    {
+        $existingId = $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-existing', true);
+
+        $response = $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'name' => 'Anthropic', 'driver' => 'anthropic',
+                'api_endpoint' => 'https://api.anthropic.com', 'api_key' => '',
+            ]),
+            []
+        );
+
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertTrue($decoded['success']);
+        $this->assertSame($existingId, $decoded['provider_id']);
+        $this->assertCount(1, $this->providerRepository->findAll());
+        // An empty key means "keep the existing one".
+        $this->assertSame('sk-existing', $this->providerRepository->findById($existingId)['api_key']);
+    }
+
+    public function testSwitchingDriverLeavesExactlyOneActiveProvider(): void
+    {
+        $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'name' => 'Anthropic', 'driver' => 'anthropic',
+                'api_endpoint' => 'https://api.anthropic.com', 'api_key' => 'sk-a',
+            ]),
+            []
+        );
+        $this->controller->saveProvider(
+            $this->jsonRequest([
+                '_csrf_token' => $this->csrfToken(), 'name' => 'Mistral AI', 'driver' => 'mistral',
+                'api_endpoint' => 'https://api.mistral.ai', 'api_key' => 'sk-m',
+            ]),
+            []
+        );
+
+        $this->assertCount(1, $this->providerRepository->findAllActive());
+        $this->assertSame('mistral', $this->providerRepository->findFirstActive()['driver']);
+    }
+
+    // -------------------------------------------------------- testConnection
+
+    public function testTestConnectionRejectsAMissingCsrfToken(): void
+    {
+        $providerId = $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-test', true);
+
+        $response = $this->controller->testConnection(
+            $this->jsonRequest([]),
+            ['id' => (string) $providerId]
+        );
+
+        $this->assertFalse(json_decode($response->getBody(), true)['success']);
+    }
+
+    public function testTestConnectionReportsAnUnknownProvider(): void
+    {
+        $response = $this->controller->testConnection(
+            $this->jsonRequest(['_csrf_token' => $this->csrfToken()]),
+            ['id' => '999']
+        );
+
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertFalse($decoded['success']);
+        $this->assertStringContainsString('introuvable', $decoded['error']);
+    }
+
+    /**
+     * An unreachable endpoint must come back as a clean JSON failure, never
+     * as an uncaught exception — the page reads this with response.json().
+     */
+    public function testTestConnectionReportsAnUnreachableEndpointAsJson(): void
+    {
+        $providerId = $this->providerRepository->create('Anthropic', 'anthropic', 'http://127.0.0.1:19', 'sk-test', true);
+
+        $response = $this->controller->testConnection(
+            $this->jsonRequest(['_csrf_token' => $this->csrfToken()]),
+            ['id' => (string) $providerId]
+        );
+
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertIsArray($decoded);
+        $this->assertFalse($decoded['success']);
+        $this->assertStringContainsString('Échec de connexion', $decoded['error']);
+    }
+}

--- a/tests/Modules/LlmConnector/Controller/ConfigControllerTest.php
+++ b/tests/Modules/LlmConnector/Controller/ConfigControllerTest.php
@@ -436,4 +436,74 @@ class ConfigControllerTest extends TestCase
         $this->assertFalse($decoded['success']);
         $this->assertStringContainsString('Échec de connexion', $decoded['error']);
     }
+
+    // --------------------------------------------------- ProviderRepository
+
+    /**
+     * The deactivate-then-activate pair must be atomic: a failure between the
+     * two would otherwise leave the site with no active provider at all.
+     */
+    public function testTransactionalRollsBackEverythingWhenTheWorkThrows(): void
+    {
+        $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-a', true);
+
+        try {
+            $this->providerRepository->transactional(function (): void {
+                $this->providerRepository->deactivateAll();
+                throw new \RuntimeException('mid-flight failure');
+            });
+            $this->fail('The exception must propagate.');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('mid-flight failure', $e->getMessage());
+        }
+
+        $active = $this->providerRepository->findFirstActive();
+        $this->assertNotNull($active, 'deactivateAll() must have been rolled back.');
+        $this->assertSame('anthropic', $active['driver']);
+    }
+
+    public function testTransactionalCommitsWhenTheWorkSucceeds(): void
+    {
+        $this->providerRepository->transactional(function (): void {
+            $this->providerRepository->create('Mistral AI', 'mistral', 'https://api.mistral.ai', 'sk-m', true);
+        });
+
+        $this->assertCount(1, $this->providerRepository->findAll());
+    }
+
+    /**
+     * A caller may already own a transaction; the helper must join it rather
+     * than fail on a nested begin, leaving the commit to that caller.
+     */
+    public function testTransactionalJoinsAnAlreadyOpenTransaction(): void
+    {
+        $this->pdo->beginTransaction();
+
+        $this->providerRepository->transactional(function (): void {
+            $this->providerRepository->create('Scaleway', 'scaleway', 'https://api.scaleway.ai', 'sk-s', true);
+        });
+
+        $this->assertTrue($this->pdo->inTransaction(), 'The outer transaction must still be open.');
+        $this->pdo->commit();
+
+        $this->assertCount(1, $this->providerRepository->findAll());
+    }
+
+    public function testFindByDriverReturnsNullWhenNoRowExists(): void
+    {
+        $this->assertNull($this->providerRepository->findByDriver('anthropic'));
+    }
+
+    public function testFindByDriverReturnsTheLowestIdForThatDriver(): void
+    {
+        $firstId = $this->providerRepository->create('Anthropic', 'anthropic', 'https://api.anthropic.com', 'sk-1', false);
+        $this->providerRepository->create('Anthropic bis', 'anthropic', 'https://api.anthropic.com', 'sk-2', true);
+        $this->providerRepository->create('Mistral AI', 'mistral', 'https://api.mistral.ai', 'sk-m', false);
+
+        $found = $this->providerRepository->findByDriver('anthropic');
+
+        $this->assertNotNull($found);
+        $this->assertSame($firstId, $found['id']);
+        $this->assertSame('mistral', $this->providerRepository->findByDriver('mistral')['driver']);
+    }
 }

--- a/tests/Modules/LlmConnector/Provider/AnthropicProviderTest.php
+++ b/tests/Modules/LlmConnector/Provider/AnthropicProviderTest.php
@@ -65,51 +65,6 @@ class AnthropicProviderTest extends TestCase
         $provider->listModels();
     }
 
-    public function testResolveTiersPicksMostRecentHaikuAndSonnet(): void
-    {
-        $models = [
-            'claude-3-haiku-20240307',
-            'claude-3-5-haiku-20241022',
-            'claude-3-sonnet-20240229',
-            'claude-3-5-sonnet-20241022',
-            'claude-sonnet-4-20250514',
-            'claude-3-opus-20240229',
-        ];
-
-        $tiers = $this->provider->resolveTiers($models);
-
-        $this->assertSame('claude-3-5-haiku-20241022', $tiers['cheap']);
-        $this->assertSame('claude-sonnet-4-20250514', $tiers['capable']);
-    }
-
-    public function testResolveTiersReturnsNullWhenNoMatch(): void
-    {
-        $models = ['claude-3-opus-20240229'];
-
-        $tiers = $this->provider->resolveTiers($models);
-
-        $this->assertNull($tiers['cheap']);
-        $this->assertNull($tiers['capable']);
-    }
-
-    public function testResolveTiersWithSingleHaikuOnly(): void
-    {
-        $models = ['claude-3-haiku-20240307'];
-
-        $tiers = $this->provider->resolveTiers($models);
-
-        $this->assertSame('claude-3-haiku-20240307', $tiers['cheap']);
-        $this->assertNull($tiers['capable']);
-    }
-
-    public function testResolveTiersWithEmptyList(): void
-    {
-        $tiers = $this->provider->resolveTiers([]);
-
-        $this->assertNull($tiers['cheap']);
-        $this->assertNull($tiers['capable']);
-    }
-
     public function testBuildRequestBodyDefaultsMaxTokensTo4096(): void
     {
         $method = new \ReflectionMethod(AnthropicProvider::class, 'buildRequestBody');

--- a/tests/Modules/LlmConnector/Provider/HttpTransportTest.php
+++ b/tests/Modules/LlmConnector/Provider/HttpTransportTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\LlmConnector\Provider;
+
+use Modules\LlmConnector\Api\LlmException;
+use Modules\LlmConnector\Provider\HttpTransport;
+use PHPUnit\Framework\TestCase;
+use Tests\Modules\LlmConnector\StubHttpServer;
+
+/**
+ * The shared transport is where "the call failed" is decided, so these tests
+ * drive a real HTTP server rather than a mock — the whole point is the
+ * status line, which only a real response carries.
+ */
+class HttpTransportTest extends TestCase
+{
+    private ?StubHttpServer $server = null;
+
+    protected function tearDown(): void
+    {
+        $this->server?->stop();
+        $this->server = null;
+    }
+
+    public function testDecodesASuccessfulJsonResponse(): void
+    {
+        $this->server = StubHttpServer::start([['status' => 200, 'body' => '{"ok":true,"n":3}']]);
+
+        $decoded = (new HttpTransport())->getJson($this->server->baseUrl() . '/x', ['X-Test: 1'], 5);
+
+        self::assertSame(['ok' => true, 'n' => 3], $decoded);
+    }
+
+    /**
+     * The regression this whole class exists for: a non-2xx whose body is not
+     * shaped as {"error": {...}} used to sail through every driver's error
+     * check and surface as a successful, empty completion.
+     */
+    public function testRejectsANonSuccessStatusEvenWhenTheBodyIsNotAnErrorObject(): void
+    {
+        $this->server = StubHttpServer::start([
+            ['status' => 401, 'body' => '{"message":"Unauthorized","request_id":"abc123"}'],
+        ]);
+
+        $this->expectException(LlmException::class);
+        $this->expectExceptionCode(LlmException::API_ERROR);
+        $this->expectExceptionMessageMatches('/HTTP 401/');
+
+        (new HttpTransport())->getJson($this->server->baseUrl() . '/x', [], 5);
+    }
+
+    public function testCarriesTheProviderExplanationIntoTheExceptionMessage(): void
+    {
+        $this->server = StubHttpServer::start([
+            ['status' => 400, 'body' => '{"message":"model not found: bogus-model"}'],
+        ]);
+
+        try {
+            (new HttpTransport())->postJson($this->server->baseUrl() . '/x', [], ['a' => 1], 5);
+            self::fail('Expected an LlmException.');
+        } catch (LlmException $e) {
+            self::assertStringContainsString('model not found: bogus-model', $e->getMessage());
+        }
+    }
+
+    public function testMapsTooManyRequestsToTheRateLimitedCode(): void
+    {
+        $this->server = StubHttpServer::start([['status' => 429, 'body' => '{"message":"slow down"}']]);
+
+        $this->expectException(LlmException::class);
+        $this->expectExceptionCode(LlmException::RATE_LIMITED);
+
+        (new HttpTransport())->postJson($this->server->baseUrl() . '/x', [], ['a' => 1], 5);
+    }
+
+    public function testRejectsAServerErrorThatIsNotEvenJson(): void
+    {
+        $this->server = StubHttpServer::start([
+            ['status' => 502, 'body' => '<html><body>Bad Gateway</body></html>', 'headers' => ['Content-Type: text/html']],
+        ]);
+
+        $this->expectException(LlmException::class);
+        $this->expectExceptionMessageMatches('/HTTP 502/');
+
+        (new HttpTransport())->getJson($this->server->baseUrl() . '/x', [], 5);
+    }
+
+    public function testTruncatesAVeryLongErrorBody(): void
+    {
+        $this->server = StubHttpServer::start([['status' => 500, 'body' => str_repeat('x', 5000)]]);
+
+        try {
+            (new HttpTransport())->getJson($this->server->baseUrl() . '/x', [], 5);
+            self::fail('Expected an LlmException.');
+        } catch (LlmException $e) {
+            self::assertLessThan(700, strlen($e->getMessage()));
+        }
+    }
+
+    public function testStillRejectsA200WhoseBodyIsNotJson(): void
+    {
+        $this->server = StubHttpServer::start([['status' => 200, 'body' => 'not json at all']]);
+
+        $this->expectException(LlmException::class);
+        $this->expectExceptionMessageMatches('/Invalid JSON/');
+
+        (new HttpTransport())->getJson($this->server->baseUrl() . '/x', [], 5);
+    }
+
+    /**
+     * Invalid UTF-8 anywhere in the payload makes json_encode() return false;
+     * passing that to strlen() under strict_types raised a TypeError, which
+     * is not an LlmException and so escaped every consumer's catch block.
+     */
+    public function testTurnsAnUnencodablePayloadIntoAnLlmException(): void
+    {
+        $this->server = StubHttpServer::start([['status' => 200, 'body' => '{}']]);
+
+        $this->expectException(LlmException::class);
+        $this->expectExceptionMessageMatches('/Encodage JSON/');
+
+        (new HttpTransport())->postJson(
+            $this->server->baseUrl() . '/x',
+            [],
+            ['prompt' => "Caf\xE9 du coin"], // "Café" as a Latin-1 bank export writes it
+            5
+        );
+    }
+
+    public function testSendsTheBodyWithAMatchingContentLength(): void
+    {
+        $this->server = StubHttpServer::start([['status' => 200, 'body' => '{"ok":true}']]);
+
+        (new HttpTransport())->postJson(
+            $this->server->baseUrl() . '/x',
+            ['Authorization: Bearer k'],
+            ['prompt' => 'Bonjour à toutes et à tous'],
+            5
+        );
+
+        $request = $this->server->lastRequest();
+        self::assertSame('POST', $request['method']);
+        self::assertSame(strlen($request['body']), (int) $request['headers']['CONTENT_LENGTH']);
+        self::assertSame('Bearer k', $request['headers']['HTTP_AUTHORIZATION']);
+        self::assertStringContainsString('Bonjour à toutes', $request['body']);
+    }
+
+    public function testReportsAnUnreachableEndpointAsATimeout(): void
+    {
+        $this->expectException(LlmException::class);
+        $this->expectExceptionCode(LlmException::TIMEOUT);
+
+        (new HttpTransport())->getJson('http://127.0.0.1:19/x', [], 1);
+    }
+}

--- a/tests/Modules/LlmConnector/Provider/MistralProviderTest.php
+++ b/tests/Modules/LlmConnector/Provider/MistralProviderTest.php
@@ -84,54 +84,6 @@ class MistralProviderTest extends TestCase
         $this->assertSame('Hello', $content);
     }
 
-    public function testResolveTiersPicksMostRecentSmallAndLarge(): void
-    {
-        $models = [
-            'mistral-small-2402',
-            'mistral-small-latest',
-            'mistral-large-2411',
-            'mistral-large-latest',
-            'mistral-medium-latest',
-            'mistral-embed',
-            'codestral-latest',
-        ];
-
-        $tiers = $this->provider->resolveTiers($models);
-
-        // "latest" is treated as most recent → extractDate returns '99999999'
-        // "2402" → '24020000', "2411" → '24110000'
-        $this->assertSame('mistral-small-latest', $tiers['cheap']);
-        $this->assertSame('mistral-large-latest', $tiers['capable']);
-    }
-
-    public function testResolveTiersReturnsNullWhenNoMatch(): void
-    {
-        $models = ['mistral-embed', 'codestral-latest'];
-
-        $tiers = $this->provider->resolveTiers($models);
-
-        $this->assertNull($tiers['cheap']);
-        $this->assertNull($tiers['capable']);
-    }
-
-    public function testResolveTiersWithEmptyList(): void
-    {
-        $tiers = $this->provider->resolveTiers([]);
-
-        $this->assertNull($tiers['cheap']);
-        $this->assertNull($tiers['capable']);
-    }
-
-    public function testResolveTiersMediumCountsAsCapable(): void
-    {
-        $models = ['mistral-medium-20250514'];
-
-        $tiers = $this->provider->resolveTiers($models);
-
-        $this->assertNull($tiers['cheap']);
-        $this->assertSame('mistral-medium-20250514', $tiers['capable']);
-    }
-
     public function testBuildRequestBodyAlwaysIncludesMaxTokens(): void
     {
         $method = new \ReflectionMethod(MistralProvider::class, 'buildRequestBody');

--- a/tests/Modules/LlmConnector/Provider/ProviderHttpBehaviourTest.php
+++ b/tests/Modules/LlmConnector/Provider/ProviderHttpBehaviourTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\LlmConnector\Provider;
+
+use Modules\LlmConnector\Api\LlmException;
+use Modules\LlmConnector\Provider\AnthropicProvider;
+use Modules\LlmConnector\Provider\LlmProviderInterface;
+use Modules\LlmConnector\Provider\MistralProvider;
+use Modules\LlmConnector\Provider\ScalewayProvider;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tests\Modules\LlmConnector\StubHttpServer;
+
+/**
+ * Behaviour every driver must share, exercised against a real endpoint —
+ * chiefly that a failed call surfaces as an exception rather than as an
+ * empty-but-successful completion, which is what silently disabled retro
+ * moderation and blanked the news SEO field.
+ */
+class ProviderHttpBehaviourTest extends TestCase
+{
+    private ?StubHttpServer $server = null;
+
+    protected function tearDown(): void
+    {
+        $this->server?->stop();
+        $this->server = null;
+    }
+
+    /**
+     * @return array<string, array{0: class-string<LlmProviderInterface>}>
+     */
+    public static function driverProvider(): array
+    {
+        return [
+            'anthropic' => [AnthropicProvider::class],
+            'mistral' => [MistralProvider::class],
+            'scaleway' => [ScalewayProvider::class],
+        ];
+    }
+
+    /**
+     * @param class-string<LlmProviderInterface> $driverClass
+     */
+    #[DataProvider('driverProvider')]
+    public function testCompleteThrowsRatherThanReturningAnEmptyCompletion(string $driverClass): void
+    {
+        $this->server = StubHttpServer::start([
+            ['status' => 401, 'body' => '{"message":"Unauthorized","request_id":"abc123"}'],
+        ]);
+
+        $driver = new $driverClass($this->server->baseUrl(), 'bad-key');
+
+        $this->expectException(LlmException::class);
+        $driver->complete('some-model', 'Bonjour', ['max_tokens' => 100]);
+    }
+
+    /**
+     * @param class-string<LlmProviderInterface> $driverClass
+     */
+    #[DataProvider('driverProvider')]
+    public function testListModelsThrowsOnAnAuthenticationFailure(string $driverClass): void
+    {
+        $this->server = StubHttpServer::start([
+            ['status' => 403, 'body' => '{"message":"forbidden"}'],
+        ]);
+
+        $driver = new $driverClass($this->server->baseUrl(), 'bad-key');
+
+        $this->expectException(LlmException::class);
+        $driver->listModels();
+    }
+
+    /**
+     * @param class-string<LlmProviderInterface> $driverClass
+     */
+    #[DataProvider('driverProvider')]
+    public function testCompleteReportsAnUnencodablePromptAsAnLlmException(string $driverClass): void
+    {
+        $this->server = StubHttpServer::start([['status' => 200, 'body' => '{}']]);
+
+        $driver = new $driverClass($this->server->baseUrl(), 'k');
+
+        // A transaction label carried over verbatim from a Latin-1 bank export.
+        $this->expectException(LlmException::class);
+        $driver->complete('some-model', "Libellé : Caf\xE9 du coin", []);
+    }
+
+    /**
+     * @param class-string<LlmProviderInterface> $driverClass
+     */
+    #[DataProvider('driverProvider')]
+    public function testListModelsSkipsAModelWithNoIdentifier(string $driverClass): void
+    {
+        $this->server = StubHttpServer::start([[
+            'status' => 200,
+            'body' => json_encode(['data' => [
+                ['id' => 'good-model', 'display_name' => 'Good', 'name' => 'Good'],
+                ['display_name' => 'No id at all', 'name' => 'No id at all'],
+                ['id' => '', 'display_name' => 'Empty id', 'name' => 'Empty id'],
+            ]], JSON_THROW_ON_ERROR),
+        ]]);
+
+        $driver = new $driverClass($this->server->baseUrl(), 'k');
+        $models = $driver->listModels();
+
+        self::assertSame(['good-model'], array_column($models, 'id'));
+    }
+
+    public function testAnthropicFollowsModelPagination(): void
+    {
+        $this->server = StubHttpServer::start([
+            [
+                'status' => 200,
+                'body' => json_encode([
+                    'data' => [['id' => 'claude-a', 'display_name' => 'A']],
+                    'has_more' => true,
+                    'last_id' => 'claude-a',
+                ], JSON_THROW_ON_ERROR),
+            ],
+            [
+                'status' => 200,
+                'body' => json_encode([
+                    'data' => [['id' => 'claude-b', 'display_name' => 'B']],
+                    'has_more' => false,
+                    'last_id' => 'claude-b',
+                ], JSON_THROW_ON_ERROR),
+            ],
+        ]);
+
+        $models = (new AnthropicProvider($this->server->baseUrl(), 'k'))->listModels();
+
+        self::assertSame(['claude-a', 'claude-b'], array_column($models, 'id'));
+
+        $requests = $this->server->requests();
+        self::assertCount(2, $requests);
+        self::assertStringNotContainsString('after_id', $requests[0]['uri']);
+        self::assertStringContainsString('after_id=claude-a', $requests[1]['uri']);
+    }
+
+    public function testAnthropicStopsPaginatingWhenHasMoreIsAbsent(): void
+    {
+        $this->server = StubHttpServer::start([[
+            'status' => 200,
+            'body' => json_encode(['data' => [['id' => 'claude-a', 'display_name' => 'A']]], JSON_THROW_ON_ERROR),
+        ]]);
+
+        $models = (new AnthropicProvider($this->server->baseUrl(), 'k'))->listModels();
+
+        self::assertSame(['claude-a'], array_column($models, 'id'));
+        self::assertCount(1, $this->server->requests());
+    }
+
+    /**
+     * A has_more that never turns false must not spin forever.
+     */
+    public function testAnthropicPaginationIsBounded(): void
+    {
+        $this->server = StubHttpServer::start([[
+            'status' => 200,
+            'body' => json_encode([
+                'data' => [['id' => 'claude-loop', 'display_name' => 'Loop']],
+                'has_more' => true,
+                'last_id' => 'claude-loop',
+            ], JSON_THROW_ON_ERROR),
+        ]]);
+
+        (new AnthropicProvider($this->server->baseUrl(), 'k'))->listModels();
+
+        self::assertLessThanOrEqual(20, count($this->server->requests()));
+    }
+
+    /**
+     * @param class-string<LlmProviderInterface> $driverClass
+     */
+    #[DataProvider('driverProvider')]
+    public function testCompleteStillReturnsContentOnASuccessfulCall(string $driverClass): void
+    {
+        $bodies = [
+            AnthropicProvider::class => ['content' => [['type' => 'text', 'text' => 'Salut']], 'usage' => ['input_tokens' => 7, 'output_tokens' => 2]],
+            MistralProvider::class => ['choices' => [['message' => ['content' => 'Salut'], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 7, 'completion_tokens' => 2]],
+            ScalewayProvider::class => ['choices' => [['message' => ['content' => 'Salut'], 'finish_reason' => 'stop']], 'usage' => ['prompt_tokens' => 7, 'completion_tokens' => 2]],
+        ];
+
+        $this->server = StubHttpServer::start([[
+            'status' => 200,
+            'body' => json_encode($bodies[$driverClass], JSON_THROW_ON_ERROR),
+        ]]);
+
+        $response = (new $driverClass($this->server->baseUrl(), 'k'))->complete('m', 'Bonjour', ['max_tokens' => 50]);
+
+        self::assertSame('Salut', $response->content);
+        self::assertSame(7, $response->inputTokens);
+        self::assertSame(2, $response->outputTokens);
+        self::assertFalse($response->truncated);
+    }
+}

--- a/tests/Modules/LlmConnector/Provider/ScalewayProviderTest.php
+++ b/tests/Modules/LlmConnector/Provider/ScalewayProviderTest.php
@@ -88,15 +88,6 @@ class ScalewayProviderTest extends TestCase
         $this->assertSame('Hello', $content);
     }
 
-    public function testResolveTiersWithEmptyList(): void
-    {
-        $tiers = $this->provider->resolveTiers([]);
-
-        $this->assertNull($tiers['cheap']);
-        $this->assertNull($tiers['capable']);
-        $this->assertNull($tiers['ocr']);
-    }
-
     public function testBuildRequestBodyAlwaysIncludesMaxTokens(): void
     {
         $method = new \ReflectionMethod(ScalewayProvider::class, 'buildRequestBody');

--- a/tests/Modules/LlmConnector/Service/LlmConnectorAvailabilityTest.php
+++ b/tests/Modules/LlmConnector/Service/LlmConnectorAvailabilityTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\LlmConnector\Service;
+
+use Core\Journal\JournalService;
+use Core\Security\DecryptionException;
+use Modules\LlmConnector\Api\LlmException;
+use Modules\LlmConnector\Api\LlmRequest;
+use Modules\LlmConnector\Api\LlmTier;
+use Modules\LlmConnector\Repository\ProviderModelRepository;
+use Modules\LlmConnector\Repository\ProviderRepository;
+use Modules\LlmConnector\Service\LlmConnectorService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Availability semantics, without a database — the repositories are stubbed
+ * so the awkward cases (an undecryptable key, a tier with no model) can be
+ * set up directly.
+ */
+class LlmConnectorAvailabilityTest extends TestCase
+{
+    /**
+     * @return array{id: int, name: string, driver: string, api_endpoint: string, api_key: string}
+     */
+    private function provider(): array
+    {
+        return [
+            'id' => 1,
+            'name' => 'Anthropic',
+            'driver' => 'anthropic',
+            'api_endpoint' => 'https://api.anthropic.com',
+            'api_key' => 'sk-test',
+        ];
+    }
+
+    private function service(
+        ProviderRepository $providerRepo,
+        ProviderModelRepository $modelRepo
+    ): LlmConnectorService {
+        return new LlmConnectorService($providerRepo, $modelRepo, $this->createStub(JournalService::class));
+    }
+
+    /**
+     * @param array<string, bool> $tiers tier value => has a model
+     */
+    private function modelRepoWith(array $tiers): ProviderModelRepository
+    {
+        $modelRepo = $this->createStub(ProviderModelRepository::class);
+        $modelRepo->method('findByProviderAndTier')->willReturnCallback(
+            fn(int $providerId, LlmTier $tier) => ($tiers[$tier->value] ?? false)
+                ? ['id' => 10, 'provider_id' => $providerId, 'model_id' => 'model-' . $tier->value, 'display_name' => 'Model']
+                : null
+        );
+
+        return $modelRepo;
+    }
+
+    private function providerRepoReturning(?array $provider): ProviderRepository
+    {
+        $providerRepo = $this->createStub(ProviderRepository::class);
+        $providerRepo->method('findFirstActive')->willReturn($provider);
+
+        return $providerRepo;
+    }
+
+    /**
+     * The regression: ProviderRepository decrypts eagerly, so a rotated
+     * encryption key made findFirstActive() throw — and isAvailable() is
+     * called while rendering the PUBLIC retrospective board, so an unusable
+     * API key took the whole page down with a 500.
+     */
+    public function testIsAvailableReportsFalseRatherThanThrowingWhenTheKeyCannotBeDecrypted(): void
+    {
+        $providerRepo = $this->createStub(ProviderRepository::class);
+        $providerRepo->method('findFirstActive')
+            ->willThrowException(new DecryptionException('Decryption failed.'));
+
+        $service = $this->service($providerRepo, $this->modelRepoWith(['cheap' => true]));
+
+        self::assertFalse($service->isAvailable());
+        self::assertFalse($service->isTierAvailable(LlmTier::CHEAP));
+    }
+
+    public function testCompleteReportsNoProviderRatherThanThrowingWhenTheKeyCannotBeDecrypted(): void
+    {
+        $providerRepo = $this->createStub(ProviderRepository::class);
+        $providerRepo->method('findFirstActive')
+            ->willThrowException(new DecryptionException('Decryption failed.'));
+
+        $service = $this->service($providerRepo, $this->modelRepoWith(['cheap' => true]));
+
+        $this->expectException(LlmException::class);
+        $this->expectExceptionCode(LlmException::NO_PROVIDER);
+
+        $service->complete(new LlmRequest(tier: LlmTier::CHEAP, prompt: 'Bonjour'));
+    }
+
+    public function testIsAvailableIsFalseWithoutAnActiveProvider(): void
+    {
+        $service = $this->service($this->providerRepoReturning(null), $this->modelRepoWith(['cheap' => true]));
+
+        self::assertFalse($service->isAvailable());
+        self::assertFalse($service->isTierAvailable(LlmTier::CHEAP));
+    }
+
+    public function testIsAvailableIsTrueAsSoonAsAnyTierHasAModel(): void
+    {
+        $service = $this->service(
+            $this->providerRepoReturning($this->provider()),
+            $this->modelRepoWith(['capable' => true])
+        );
+
+        self::assertTrue($service->isAvailable());
+    }
+
+    /**
+     * isAvailable() answering "something is configured" is not the same
+     * question as "the tier I am about to ask for exists" — RGPD generation
+     * only ever uses CAPABLE and used to pass the first check, then fail
+     * inside complete() after the button had already been offered.
+     */
+    public function testIsTierAvailableIsFalseForATierWithNoModelEvenWhenAnotherTierHasOne(): void
+    {
+        $service = $this->service(
+            $this->providerRepoReturning($this->provider()),
+            $this->modelRepoWith(['cheap' => true])
+        );
+
+        self::assertTrue($service->isAvailable());
+        self::assertTrue($service->isTierAvailable(LlmTier::CHEAP));
+        self::assertFalse($service->isTierAvailable(LlmTier::CAPABLE));
+    }
+
+    public function testIsTierAvailableAppliesTheOcrToCheapFallback(): void
+    {
+        $service = $this->service(
+            $this->providerRepoReturning($this->provider()),
+            $this->modelRepoWith(['cheap' => true])
+        );
+
+        self::assertTrue($service->isTierAvailable(LlmTier::OCR));
+    }
+
+    public function testIsTierAvailableIsFalseForOcrWhenNotEvenCheapExists(): void
+    {
+        $service = $this->service(
+            $this->providerRepoReturning($this->provider()),
+            $this->modelRepoWith(['capable' => true])
+        );
+
+        self::assertFalse($service->isTierAvailable(LlmTier::OCR));
+    }
+
+    /**
+     * isTierAvailable() and complete() must never disagree: whenever the
+     * former says yes, the latter must get past model resolution.
+     */
+    public function testIsTierAvailableAgreesWithCompleteAboutMissingModels(): void
+    {
+        $service = $this->service(
+            $this->providerRepoReturning($this->provider()),
+            $this->modelRepoWith(['cheap' => true])
+        );
+
+        self::assertFalse($service->isTierAvailable(LlmTier::CAPABLE));
+
+        $this->expectException(LlmException::class);
+        $this->expectExceptionCode(LlmException::NO_MODEL);
+
+        $service->complete(new LlmRequest(tier: LlmTier::CAPABLE, prompt: 'Bonjour'));
+    }
+}

--- a/tests/Modules/LlmConnector/StubHttpServer.php
+++ b/tests/Modules/LlmConnector/StubHttpServer.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\LlmConnector;
+
+/**
+ * A throwaway HTTP server (php -S) that hands out canned responses and
+ * records what it was sent.
+ *
+ * The provider drivers talk to a real endpoint through file_get_contents(),
+ * and the bugs worth testing here live precisely in how they react to a real
+ * HTTP status line — something no in-process mock of the driver can exercise.
+ * So the tests point a driver at 127.0.0.1 and assert on genuine traffic.
+ */
+final class StubHttpServer
+{
+    /** @var resource|null */
+    private $process = null;
+
+    private string $dir;
+    private int $port;
+
+    private function __construct(string $dir, int $port)
+    {
+        $this->dir = $dir;
+        $this->port = $port;
+    }
+
+    /**
+     * @param array<int, array{status?: int, body: string, headers?: array<int, string>}> $responses
+     *        Served in order; the last one repeats once the list runs out.
+     */
+    public static function start(array $responses): self
+    {
+        $dir = sys_get_temp_dir() . '/scoutmagic-stub-' . bin2hex(random_bytes(6));
+        mkdir($dir, 0o777, true);
+
+        file_put_contents($dir . '/responses.json', json_encode(array_values($responses)));
+        file_put_contents($dir . '/router.php', self::ROUTER);
+
+        $port = self::freePort();
+
+        $descriptors = [1 => ['file', $dir . '/server.log', 'a'], 2 => ['file', $dir . '/server.log', 'a']];
+        $process = proc_open(
+            ['php', '-S', '127.0.0.1:' . $port, '-t', $dir, $dir . '/router.php'],
+            $descriptors,
+            $pipes
+        );
+
+        if (!is_resource($process)) {
+            throw new \RuntimeException('Could not start the stub HTTP server.');
+        }
+
+        $server = new self($dir, $port);
+        $server->process = $process;
+        $server->waitUntilReady();
+
+        return $server;
+    }
+
+    public function baseUrl(): string
+    {
+        return 'http://127.0.0.1:' . $this->port;
+    }
+
+    /**
+     * Every request the server received, oldest first.
+     *
+     * @return array<int, array{method: string, uri: string, body: string, headers: array<string, string>}>
+     */
+    public function requests(): array
+    {
+        $log = $this->dir . '/requests.jsonl';
+        if (!is_file($log)) {
+            return [];
+        }
+
+        $requests = [];
+        foreach (explode("\n", trim((string) file_get_contents($log))) as $line) {
+            if ($line === '') {
+                continue;
+            }
+            $decoded = json_decode($line, true);
+            if (is_array($decoded)) {
+                /** @var array{method: string, uri: string, body: string, headers: array<string, string>} $decoded */
+                $requests[] = $decoded;
+            }
+        }
+
+        return $requests;
+    }
+
+    /**
+     * @return array{method: string, uri: string, body: string, headers: array<string, string>}
+     */
+    public function lastRequest(): array
+    {
+        $requests = $this->requests();
+        if ($requests === []) {
+            throw new \RuntimeException('The stub server received no request.');
+        }
+
+        return $requests[count($requests) - 1];
+    }
+
+    public function stop(): void
+    {
+        if (is_resource($this->process)) {
+            proc_terminate($this->process);
+            proc_close($this->process);
+            $this->process = null;
+        }
+
+        foreach (glob($this->dir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($this->dir);
+    }
+
+    private function waitUntilReady(): void
+    {
+        // php -S needs a moment to bind; 5s is far more than it ever takes
+        // and keeps a slow CI box from failing spuriously.
+        $deadline = microtime(true) + 5.0;
+        while (microtime(true) < $deadline) {
+            $socket = @fsockopen('127.0.0.1', $this->port, $errno, $errstr, 0.1);
+            if (is_resource($socket)) {
+                fclose($socket);
+                return;
+            }
+            usleep(20_000);
+        }
+
+        throw new \RuntimeException('The stub HTTP server did not become ready.');
+    }
+
+    private static function freePort(): int
+    {
+        $socket = stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        if ($socket === false) {
+            throw new \RuntimeException('Could not allocate a port for the stub HTTP server.');
+        }
+
+        $name = stream_socket_get_name($socket, false);
+        fclose($socket);
+
+        $port = (int) substr((string) $name, (int) strrpos((string) $name, ':') + 1);
+        if ($port <= 0) {
+            throw new \RuntimeException('Could not read the allocated port.');
+        }
+
+        return $port;
+    }
+
+    private const ROUTER = <<<'PHP'
+        <?php
+        $dir = __DIR__;
+        $responses = json_decode((string) file_get_contents($dir . '/responses.json'), true) ?: [];
+
+        $headers = [];
+        foreach ($_SERVER as $key => $value) {
+            if (str_starts_with($key, 'HTTP_') || $key === 'CONTENT_LENGTH' || $key === 'CONTENT_TYPE') {
+                $headers[$key] = (string) $value;
+            }
+        }
+
+        file_put_contents(
+            $dir . '/requests.jsonl',
+            json_encode([
+                'method' => $_SERVER['REQUEST_METHOD'] ?? '',
+                'uri' => $_SERVER['REQUEST_URI'] ?? '',
+                'body' => (string) file_get_contents('php://input'),
+                'headers' => $headers,
+            ]) . "\n",
+            FILE_APPEND
+        );
+
+        $countFile = $dir . '/count.txt';
+        $index = is_file($countFile) ? (int) file_get_contents($countFile) : 0;
+        file_put_contents($countFile, (string) ($index + 1));
+
+        // The last entry repeats, so a test only has to describe as many
+        // responses as it actually cares about.
+        $response = $responses[min($index, count($responses) - 1)] ?? ['status' => 200, 'body' => '{}'];
+
+        http_response_code((int) ($response['status'] ?? 200));
+        foreach (($response['headers'] ?? []) as $header) {
+            header($header);
+        }
+        if (!isset($response['headers'])) {
+            header('Content-Type: application/json');
+        }
+        echo (string) ($response['body'] ?? '');
+        PHP;
+}

--- a/tests/Modules/Retro/Controller/RetroBoardControllerTest.php
+++ b/tests/Modules/Retro/Controller/RetroBoardControllerTest.php
@@ -487,4 +487,115 @@ class RetroBoardControllerTest extends TestCase
 
         $this->assertSame(422, $response->getStatusCode());
     }
+
+    /**
+     * POST /r/{token}/shorten is role_min "public", and every call is a paid
+     * LLM round-trip. Service\CommentService::postComment() guards its own
+     * moderation call with a board-open check, a rate limit and a length cap
+     * before reaching the LLM; this route reached it with none of the three.
+     * The tests below pin each guard, and assert the LLM is not called.
+     */
+    private function rebuildControllerWithModeration(ModerationService $moderationService): void
+    {
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $commentService = new CommentService($this->commentRepository, null, $this->rateLimitService);
+        $voteService = new VoteService(new VoteRepository($this->pdo), $this->commentRepository, $encryption);
+
+        $this->controller = new RetroBoardController(
+            $this->twig, $this->boardRepository, $this->commentRepository, $commentService, $voteService, $this->boardService,
+            $this->rateLimitService, $moderationService, new CookieConsentService(), $this->settingService, $this->scoutYearService
+        );
+    }
+
+    private function alwaysAvailableModeration(int $expectedShortenCalls): ModerationService
+    {
+        $moderationService = $this->createMock(ModerationService::class);
+        $moderationService->method('isAvailable')->willReturn(true);
+        $moderationService->expects($this->exactly($expectedShortenCalls))
+            ->method('shorten')
+            ->willReturn('Version raccourcie.');
+
+        return $moderationService;
+    }
+
+    public function testShortenSucceedsOnAnOpenBoardWithAReasonableBody(): void
+    {
+        $this->rebuildControllerWithModeration($this->alwaysAvailableModeration(1));
+        [, $token] = $this->createBoard();
+        $csrf = $this->csrfToken();
+
+        $response = $this->controller->shorten(
+            $this->jsonRequest('/r/' . $token . '/shorten', ['_csrf_token' => $csrf, 'body' => str_repeat('a', 200)]),
+            ['token' => $token]
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertTrue($decoded['success']);
+        $this->assertSame('Version raccourcie.', $decoded['body']);
+    }
+
+    public function testShortenIsRefusedOnAClosedBoardWithoutCallingTheLlm(): void
+    {
+        $this->rebuildControllerWithModeration($this->alwaysAvailableModeration(0));
+        [$boardId, $token] = $this->createBoard();
+        $this->boardRepository->close($boardId);
+        $csrf = $this->csrfToken();
+
+        $response = $this->controller->shorten(
+            $this->jsonRequest('/r/' . $token . '/shorten', ['_csrf_token' => $csrf, 'body' => 'Un commentaire']),
+            ['token' => $token]
+        );
+
+        $this->assertSame(422, $response->getStatusCode());
+        $decoded = json_decode($response->getBody(), true);
+        $this->assertStringContainsString('clôturé', (string) $decoded['error']);
+    }
+
+    public function testShortenRefusesAnOversizedBodyWithoutCallingTheLlm(): void
+    {
+        $this->rebuildControllerWithModeration($this->alwaysAvailableModeration(0));
+        [, $token] = $this->createBoard();
+        $csrf = $this->csrfToken();
+
+        // maxCommentLength is 140 here, so anything past 4x that is refused.
+        $response = $this->controller->shorten(
+            $this->jsonRequest('/r/' . $token . '/shorten', ['_csrf_token' => $csrf, 'body' => str_repeat('a', 600)]),
+            ['token' => $token]
+        );
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testShortenRefusesAnEmptyBodyWithoutCallingTheLlm(): void
+    {
+        $this->rebuildControllerWithModeration($this->alwaysAvailableModeration(0));
+        [, $token] = $this->createBoard();
+        $csrf = $this->csrfToken();
+
+        $response = $this->controller->shorten(
+            $this->jsonRequest('/r/' . $token . '/shorten', ['_csrf_token' => $csrf, 'body' => '   ']),
+            ['token' => $token]
+        );
+
+        $this->assertSame(422, $response->getStatusCode());
+    }
+
+    public function testShortenIsRateLimitedSoAnAnonymousBurstCannotDrainTheAiBudget(): void
+    {
+        // RateLimitService::LIMITS['shorten'] is 5 per window.
+        $this->rebuildControllerWithModeration($this->alwaysAvailableModeration(5));
+        [, $token] = $this->createBoard();
+
+        $statuses = [];
+        for ($i = 0; $i < 8; $i++) {
+            $csrf = $this->csrfToken();
+            $statuses[] = $this->controller->shorten(
+                $this->jsonRequest('/r/' . $token . '/shorten', ['_csrf_token' => $csrf, 'body' => 'Un commentaire à raccourcir']),
+                ['token' => $token]
+            )->getStatusCode();
+        }
+
+        $this->assertSame([200, 200, 200, 200, 200, 422, 422, 422], $statuses);
+    }
 }

--- a/tests/Modules/Retro/Service/ModerationServiceTest.php
+++ b/tests/Modules/Retro/Service/ModerationServiceTest.php
@@ -109,4 +109,64 @@ class ModerationServiceTest extends TestCase
         $this->expectException(RetroException::class);
         $service->shorten('text', 20);
     }
+
+    /**
+     * Structured output is prompt-instructed, not API-enforced, so a model
+     * can answer with the string "false" — truthy in PHP, which used to flag
+     * a perfectly civil comment and block it in "enforced" mode.
+     */
+    public function testModerateTreatsAStringFalseAsNotFlagged(): void
+    {
+        $llmConnector = $this->createMock(LlmConnectorInterface::class);
+        $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('complete')->willReturn(new LlmResponse(
+            content: '{"flagged":"false","reason":null,"suggestion":null}',
+            parsed: ['flagged' => 'false', 'reason' => null, 'suggestion' => null],
+            inputTokens: 5,
+            outputTokens: 5
+        ));
+
+        $result = (new ModerationService($llmConnector))->moderate('Un commentaire tout à fait courtois.', 140);
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result['flagged']);
+    }
+
+    public function testModerateTreatsAStringTrueAsNotFlaggedEither(): void
+    {
+        $llmConnector = $this->createMock(LlmConnectorInterface::class);
+        $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('complete')->willReturn(new LlmResponse(
+            content: '{"flagged":"true","reason":"Attaque","suggestion":"Reformule"}',
+            parsed: ['flagged' => 'true', 'reason' => 'Attaque', 'suggestion' => 'Reformule'],
+            inputTokens: 5,
+            outputTokens: 5
+        ));
+
+        // Only a real boolean counts. Falling back to "not flagged" is the
+        // safe direction: moderation is a courtesy check, and a chief can
+        // still hide a comment afterwards.
+        $result = (new ModerationService($llmConnector))->moderate('Un commentaire.', 140);
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result['flagged']);
+    }
+
+    public function testModerateStillFlagsOnARealBooleanTrue(): void
+    {
+        $llmConnector = $this->createMock(LlmConnectorInterface::class);
+        $llmConnector->method('isAvailable')->willReturn(true);
+        $llmConnector->method('complete')->willReturn(new LlmResponse(
+            content: '{"flagged":true,"reason":"Attaque personnelle","suggestion":"Reformule"}',
+            parsed: ['flagged' => true, 'reason' => 'Attaque personnelle', 'suggestion' => 'Reformule'],
+            inputTokens: 5,
+            outputTokens: 5
+        ));
+
+        $result = (new ModerationService($llmConnector))->moderate('Un commentaire.', 140);
+
+        $this->assertNotNull($result);
+        $this->assertTrue($result['flagged']);
+        $this->assertSame('Attaque personnelle', $result['reason']);
+    }
 }

--- a/tests/Modules/Retro/Service/RateLimitServiceTest.php
+++ b/tests/Modules/Retro/Service/RateLimitServiceTest.php
@@ -100,4 +100,36 @@ class RateLimitServiceTest extends TestCase
         $this->service->checkAndRecord($hash, 'vote');
         $this->assertTrue(true);
     }
+
+    /**
+     * checkAndRecord() falls back to PHP_INT_MAX for an action type that is
+     * not in LIMITS, so adding a call site without adding the entry throttles
+     * nothing at all. "shorten" backs a public, AI-billed route.
+     */
+    public function testShortenIsThrottled(): void
+    {
+        $hash = $this->service->identifierHash(null, 'session-shorten');
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->service->checkAndRecord($hash, 'shorten');
+        }
+
+        $this->expectException(RetroException::class);
+        $this->service->checkAndRecord($hash, 'shorten');
+    }
+
+    public function testShortenLimitIsIndependentFromTheCommentLimit(): void
+    {
+        $hash = $this->service->identifierHash(null, 'session-mixed');
+
+        for ($i = 0; $i < 5; $i++) {
+            $this->service->checkAndRecord($hash, 'shorten');
+        }
+
+        // Exhausting the shorten budget must not consume the comment budget.
+        $this->service->checkAndRecord($hash, 'comment');
+
+        $this->expectException(RetroException::class);
+        $this->service->checkAndRecord($hash, 'shorten');
+    }
 }


### PR DESCRIPTION
## Description

A full review of `llm_connector` and its nine consumers (finance, retro, news, gallery, and core's RGPD generation) turned up 16 defects. All 16 are fixed here, across five commits — one per theme.

Almost every finding traced back to one blind spot: **what happens when a call fails in a way the code did not anticipate**. The drivers never checked HTTP status and only recognised one shape of error body, so failures surfaced as empty successes; symmetrically, malformed input raised a raw `TypeError` that slipped past every consumer's `catch (LlmException)`.

### Commits

| Commit | Fixes |
|---|---|
| `7e44d2d` Fail LLM calls loudly instead of returning an empty success | Non-2xx treated as success · `TypeError` on invalid UTF-8 · Anthropic pagination · empty model ids · dead `resolveTiers()` |
| `832b1f5` Make LLM availability total and tier-aware | `DecryptionException` 500ing a public page · `isAvailable()` not matching the tier actually requested · RGPD page gating on "module installed" |
| `55436dd` Stop a refused provider save from disabling every AI feature | `deactivateAll()` before validation · unknown provider id accepted · unvalidated `api_endpoint` · duplicate provider per driver · unescaped error text · no controller/RBAC tests |
| `802f26e` Guard the public retro shorten route before it reaches the LLM | Unauthenticated, unthrottled, unbounded LLM calls · `"false"` read as flagged |
| `5707ba8` Stop the bulk categorization lock from sticking forever | Lock unrecoverable after a `max_execution_time` kill · one bad row aborting the batch |

### The two worth a careful read

**1. The bulk categorization lock was fixed in parallel on `main`** (`4cd2b53`), with the same self-expiring-timestamp idea — but keeping the `bulk_categorization_running` key. `SettingRepository::upsert()` never re-types an existing row, and `SettingService::setInternal()` validates against the stored type: on a site that already ran the previous version that row is typed `boolean`, so writing a timestamp there throws `SettingException`. `main`'s test does not catch it because it registers the key as `text`.

The resolution keeps `main`'s naming and comments, moves the timestamp to its own numeric key, and still honours a legacy `'1'` marker (while a matching task is actually queued, and clearing it once a run completes). `testWorksOnAnInstallThatStillCarriesTheOldBooleanFlag` pins the upgrade path — reverting to the shared key makes it fail with the exact `SettingException`.

**2. The HTTP fix is shared, not triplicated.** The status check and the `json_encode` guard live in one `HttpTransport` rather than in three copies, which is what stops them drifting apart per driver. It removes roughly 250 lines of duplication, so commit `7e44d2d` is larger than a minimal patch would be.

### Verification

- `vendor/bin/phpunit` — **1611 tests, 0 failures** (1581 on `main`; +30 tests, all new ones passing).
- `vendor/bin/phpunit --group database` — **2984 tests, 0 failures** (2954 on `main`).
- `vendor/bin/phpstan analyse` — **0 errors**, same as `main`. It caught one real defect in the new transport during development, since fixed.
- The two headline defects were reproduced against a real local HTTP server before and after: a 401 with a non-standard body, and a prompt carrying a Latin-1 byte. Both now raise `LlmException`; both previously returned an empty success / a `TypeError`.
- Deprecation count unchanged. The new test files emit no PHPUnit notices; the +3 in the default suite come from tests added to an existing file, following that file's established mock helper.

Data providers use `#[DataProvider]` rather than doc comments, since PHPUnit 13 no longer reads metadata from docblocks.

### Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: no `public/assets/js/` file is touched. The only client-side change is the inline script in `modules/llm_connector/views/config/index.html.twig`, which `tests/js/` does not cover.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CYzqrpAsS52fWFmT9csofv)_