### PR TITLE
IT-07 — Finance : trois primitives, et les trois façons de les rater

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1898,6 +1898,18 @@ Where the unit has camped, and every stay it made there. The product answers one
 
 **It is a draft.** Nothing is sent, the body starts empty, and the user lands in the ordinary composition screen.
 
+### 8.72 Three finance primitives, and the three ways to get them wrong
+
+No user-visible change of its own — these exist so §8.73's tools page has something correct to stand on. Each carries a trap that fails *silently*, which is why all three are written down rather than left as obvious one-liners.
+
+**`IbanNormalizer::format()` is display only.** It groups by four — `BE71 0961 2345 6769` — the way a bank statement prints it and therefore the way somebody checks one. The blind index is computed on the `normalize()`d form, so a formatted value reaching `blindIndex()` or a column makes every IBAN search stop matching, with nothing to see: no error, just a lookup that returns nothing from then on. Format at the last possible moment, in the template or the response, never on the way in. `IbanNormalizerTest` states this as an assertion rather than a comment — a formatted IBAN is deliberately *not* accepted by `isValidFullIban()`.
+
+**`StructuredCommunicationService::isValid()` must map a remainder of 0 onto 97.** The Belgian check digits run 01–97 and never 00, which is exactly what `format()` already does when issuing one. A `$base % 97 === $check` comparison therefore rejects every valid communication whose key is 97 — about one in a hundred: frequent enough to be reported as a bug, rare enough to survive a hand test. Both halves are named tests, and `testEveryCommunicationItIssuesValidates()` pins the two functions to each other so they cannot drift apart. It accepts every shape somebody plausibly pastes (canonical `+++…+++`, the `***…***` variant, bare digits, any spacing): non-digits are stripped first, so only the twelve digits ever decide.
+
+**`ExpectedReceivableRepository::findByCommunication()` re-canonicalises before the WHERE.** The column stores the issued `+++NNN/NNNN/NNNNN+++`; the person checking a payment types what their bank showed them. Comparing the raw input finds nothing for most real inputs, silently — the answer is "unknown", so they conclude the payment was never expected. Twelve digits in, canonical form out, one exact match: no `LIKE`, no collation surprise. An input that is not twelve digits short-circuits rather than running a query that cannot succeed.
+
+**None of the three makes a structured communication decodable.** The ten-digit base is random; a communication says nothing about who paid, and the correspondence is a database lookup. Nothing should try to encode a member in one.
+
 ## 9. Installation / bootstrap
 
 ### 9.1 First install: bootstrap.php

--- a/modules/finance/src/Repository/ExpectedReceivableRepository.php
+++ b/modules/finance/src/Repository/ExpectedReceivableRepository.php
@@ -25,6 +25,39 @@ class ExpectedReceivableRepository
         return $stmt->fetch() !== false;
     }
 
+    /**
+     * The receivable this communication is for, or null.
+     *
+     * **The input is re-canonicalised before the WHERE**, and that is the
+     * whole difficulty. The column stores the issued form,
+     * `+++NNN/NNNN/NNNNN+++`, while a human checking a payment types or
+     * pastes whatever their bank showed them: twelve bare digits, the
+     * `***…***` variant, a copy with stray spaces. Comparing the raw
+     * input would find nothing for every one of those, silently — the
+     * lookup would simply answer "unknown" and the person would conclude
+     * the payment is not expected.
+     *
+     * Twelve digits in, canonical form out, one exact match: no LIKE, no
+     * collation surprise, and the unique communication stays the key.
+     * A value that is not twelve digits cannot match anything issued, so
+     * it short-circuits rather than running a query that cannot succeed.
+     */
+    public function findByCommunication(string $communication): ?ExpectedReceivable
+    {
+        $digits = preg_replace('/\D/', '', $communication) ?? '';
+        if (strlen($digits) !== 12) {
+            return null;
+        }
+
+        $canonical = '+++' . substr($digits, 0, 3) . '/' . substr($digits, 3, 4) . '/' . substr($digits, 7, 5) . '+++';
+
+        $stmt = $this->pdo->prepare('SELECT * FROM finance_expected_receivables WHERE communication = ?');
+        $stmt->execute([$canonical]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        return $row !== false ? $this->hydrate($row) : null;
+    }
+
     public function create(
         string $sourceModule,
         int $sourceReferenceId,

--- a/modules/finance/src/Service/IbanNormalizer.php
+++ b/modules/finance/src/Service/IbanNormalizer.php
@@ -57,6 +57,28 @@ class IbanNormalizer
     }
 
     /**
+     * Groups an IBAN into blocks of four for DISPLAY — "BE71 0961 2345
+     * 6769" — which is how the format is printed everywhere outside a
+     * database, and how somebody checks it against their bank statement.
+     *
+     * **Display only, and this matters.** The blind index is computed on
+     * the normalize()d form, so a formatted value reaching blindIndex()
+     * or a column would make every IBAN search silently stop matching —
+     * silently, because nothing errors: the lookup simply returns
+     * nothing, for ever. Format at the last possible moment, in the
+     * template or the response, never on the way in.
+     *
+     * normalize()s first, so it is safe to call on a value that is
+     * already grouped, differently grouped, or lower-case.
+     */
+    public static function format(string $iban): string
+    {
+        $normalized = self::normalize($iban);
+
+        return $normalized === '' ? '' : trim(chunk_split($normalized, 4, ' '));
+    }
+
+    /**
      * True length-and-checksum ISO 13616 validation — $iban must already
      * be normalize()d. Only call this against a value meant to be a
      * complete IBAN.

--- a/modules/finance/src/Service/StructuredCommunicationService.php
+++ b/modules/finance/src/Service/StructuredCommunicationService.php
@@ -41,6 +41,49 @@ class StructuredCommunicationService implements StructuredCommunicationInterface
     }
 
     /**
+     * Whether $communication is a well-formed Belgian structured
+     * communication — twelve digits whose last two check the first ten.
+     *
+     * Accepts every shape a human plausibly types or pastes: the
+     * canonical `+++123/4567/89012+++`, the `***…***` variant some banks
+     * print, twelve bare digits, and any spacing or punctuation in
+     * between. Everything that is not a digit is stripped first, so the
+     * only thing that ever decides is the twelve digits themselves.
+     *
+     * **The check digits run 01–97, never 00**, and that is the trap
+     * here: the format maps a remainder of 0 onto 97 (see format()
+     * below, which is where the rule is actually applied when issuing
+     * one). A naive `$base % 97 === $check` therefore rejects every
+     * perfectly valid communication whose key is 97 — roughly one in a
+     * hundred, which is frequent enough to be reported as a bug and rare
+     * enough to survive a hand test. Both halves of that rule are
+     * covered by a named test.
+     *
+     * Static, like format(), because it decides nothing that needs the
+     * database: it answers "is this a plausible communication", never
+     * "does this correspond to something we are waiting for" — that
+     * second question is Repository\ExpectedReceivableRepository::
+     * findByCommunication().
+     */
+    public static function isValid(string $communication): bool
+    {
+        $digits = preg_replace('/\D/', '', $communication) ?? '';
+        if (strlen($digits) !== 12) {
+            return false;
+        }
+
+        $base = substr($digits, 0, 10);
+        $check = (int) substr($digits, 10, 2);
+
+        $expected = ((int) $base) % 97;
+        if ($expected === 0) {
+            $expected = 97;
+        }
+
+        return $check === $expected;
+    }
+
+    /**
      * Formats a 10-digit base into "+++NNN/NNNN/NNNNN+++" with its mod-97
      * check digits appended. Public/static so tests can verify the
      * checksum math directly against known-good examples.

--- a/tests/Modules/Finance/Repository/ExpectedReceivableRepositoryTest.php
+++ b/tests/Modules/Finance/Repository/ExpectedReceivableRepositoryTest.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Finance\Repository;
+
+use Core\Security\EncryptionService;
+use Modules\Finance\Repository\ExpectedReceivableRepository;
+use Modules\Finance\Service\StructuredCommunicationService;
+use PHPUnit\Framework\TestCase;
+use Tests\Modules\Finance\FinanceTestHelper;
+
+/**
+ * Finding the receivable a payment's communication refers to.
+ *
+ * The column holds the issued form, `+++NNN/NNNN/NNNNN+++`, while a human
+ * checking a payment types whatever their bank showed them. Every case
+ * below is about that gap: a raw comparison finds nothing for most real
+ * inputs, and finds it silently — the answer is "unknown", not an error,
+ * so the person concludes the payment was never expected.
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class ExpectedReceivableRepositoryTest extends TestCase
+{
+    private \PDO $pdo;
+    private ExpectedReceivableRepository $repository;
+    private string $communication;
+    private int $receivableId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new \PDO('sqlite::memory:');
+        $this->pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        FinanceTestHelper::createTables($this->pdo);
+
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->repository = new ExpectedReceivableRepository($this->pdo, $encryption);
+
+        $this->pdo->exec("INSERT INTO finance_accounts (name, account_type) VALUES ('Compte', 'bank')");
+        $accountId = (int) $this->pdo->lastInsertId();
+
+        $this->communication = StructuredCommunicationService::format('1234567890');
+        $this->receivableId = $this->repository->create('news', 42, $accountId, 2500, $this->communication, 'Camp 2026');
+    }
+
+    public function testItFindsAReceivableByItsIssuedForm(): void
+    {
+        $found = $this->repository->findByCommunication($this->communication);
+
+        $this->assertNotNull($found);
+        $this->assertSame($this->receivableId, $found->id);
+        $this->assertSame(2500, $found->amountDueCents);
+    }
+
+    public function testItFindsTheSameReceivableFromWhateverTheBankShowed(): void
+    {
+        $digits = preg_replace('/\D/', '', $this->communication) ?? '';
+
+        foreach ([
+            'twelve bare digits' => $digits,
+            'the ***…*** variant' => '***' . substr($digits, 0, 3) . '/' . substr($digits, 3, 4) . '/' . substr($digits, 7, 5) . '***',
+            'spaced out' => trim(chunk_split($digits, 4, ' ')),
+            'pasted with stray spaces' => '  ' . $this->communication . ' ',
+        ] as $shape => $input) {
+            $found = $this->repository->findByCommunication($input);
+
+            $this->assertNotNull($found, "should have matched {$shape}");
+            $this->assertSame($this->receivableId, $found->id, $shape);
+        }
+    }
+
+    public function testAnUnknownCommunicationIsNullAndNotAnError(): void
+    {
+        // Well-formed, simply never issued here — the honest answer for
+        // the payment checker is "we are not waiting for this".
+        $found = $this->repository->findByCommunication(StructuredCommunicationService::format('9876543210'));
+
+        $this->assertNull($found);
+    }
+
+    public function testSomethingThatIsNotTwelveDigitsCannotMatchAndDoesNotQuery(): void
+    {
+        // No issued communication has any other length, so there is
+        // nothing a query could find; the short-circuit keeps a free-text
+        // payment note out of the WHERE clause entirely.
+        $this->assertNull($this->repository->findByCommunication(''));
+        $this->assertNull($this->repository->findByCommunication('12345'));
+        $this->assertNull($this->repository->findByCommunication('Merci pour le camp'));
+    }
+
+    public function testItDoesNotMatchOnAPrefix(): void
+    {
+        // An exact match, never a LIKE: a communication that merely
+        // starts the same is a different receivable's.
+        $this->pdo->exec("INSERT INTO finance_accounts (name, account_type) VALUES ('Autre', 'bank')");
+        $otherAccountId = (int) $this->pdo->lastInsertId();
+        $neighbour = StructuredCommunicationService::format('1234567891');
+        $this->repository->create('news', 43, $otherAccountId, 100, $neighbour, 'Autre');
+
+        $found = $this->repository->findByCommunication($neighbour);
+
+        $this->assertNotNull($found);
+        $this->assertNotSame($this->receivableId, $found->id);
+    }
+}

--- a/tests/Modules/Finance/Service/IbanNormalizerTest.php
+++ b/tests/Modules/Finance/Service/IbanNormalizerTest.php
@@ -55,4 +55,51 @@ class IbanNormalizerTest extends TestCase
     {
         $this->assertFalse(IbanNormalizer::looksLikeFullIban('BE710000'));
     }
+
+    // --- format(): display only ---
+
+    public function testFormatGroupsByFourForReading(): void
+    {
+        // How a bank statement prints it, and therefore how somebody
+        // checks it against one.
+        $this->assertSame('BE71 0961 2345 6769', IbanNormalizer::format('BE71096123456769'));
+    }
+
+    public function testFormatIsIdempotentAndTakesAnyInputShape(): void
+    {
+        $expected = 'BE71 0961 2345 6769';
+
+        $this->assertSame($expected, IbanNormalizer::format($expected), 'already grouped');
+        $this->assertSame($expected, IbanNormalizer::format('be71-0961.2345 6769'), 'other punctuation');
+        $this->assertSame($expected, IbanNormalizer::format('  BE710961 23456769  '), 'stray spacing');
+    }
+
+    public function testFormatLeavesNoTrailingSpaceOnALengthNotDivisibleByFour(): void
+    {
+        // 15 characters: chunk_split() would leave a trailing separator,
+        // which would then be stored or compared by an unwary caller.
+        $this->assertSame('NO93 8601 1117 947', IbanNormalizer::format('NO9386011117947'));
+    }
+
+    public function testFormatOfNothingIsNothing(): void
+    {
+        $this->assertSame('', IbanNormalizer::format(''));
+        $this->assertSame('', IbanNormalizer::format('   '));
+    }
+
+    public function testAFormattedIbanIsNotWhatGetsStoredOrIndexed(): void
+    {
+        // The point of the whole distinction: normalize() is what a
+        // column and a blind index see. A formatted value reaching either
+        // makes every IBAN search stop matching — silently, since nothing
+        // errors and the lookup merely returns nothing.
+        $formatted = IbanNormalizer::format('BE71096123456769');
+
+        $this->assertNotSame($formatted, IbanNormalizer::normalize($formatted));
+        $this->assertSame('BE71096123456769', IbanNormalizer::normalize($formatted));
+        // And it must not be mistaken for a valid IBAN in its own right:
+        // isValidFullIban() documents that it takes a normalize()d value.
+        $this->assertFalse(IbanNormalizer::isValidFullIban($formatted));
+        $this->assertTrue(IbanNormalizer::isValidFullIban(IbanNormalizer::normalize($formatted)));
+    }
 }

--- a/tests/Modules/Finance/Service/StructuredCommunicationServiceTest.php
+++ b/tests/Modules/Finance/Service/StructuredCommunicationServiceTest.php
@@ -77,4 +77,64 @@ class StructuredCommunicationServiceTest extends TestCase
 
         $this->assertCount(20, array_unique($communications));
     }
+
+    // --- isValid(): the other half of format() ---
+
+    public function testAKeyOf97IsValidAndIsWhereANaiveCheckFails(): void
+    {
+        // THE trap. The check digits run 01–97, never 00: format() maps a
+        // remainder of 0 onto 97. A `$base % 97 === $check` comparison
+        // rejects this one, and only this one in a hundred — often enough
+        // to be reported as a bug, rare enough to survive a hand test.
+        $communication = StructuredCommunicationService::format('0000000097');
+
+        $this->assertSame('+++000/0000/09797+++', $communication, 'precondition: this base really does key on 97');
+        $this->assertTrue(StructuredCommunicationService::isValid($communication));
+    }
+
+    public function testAKeyOf00IsNeverValid(): void
+    {
+        // The mirror of the case above: 00 is the value the naive
+        // computation would produce, and no issued communication carries it.
+        $this->assertFalse(StructuredCommunicationService::isValid('+++000/0000/09700+++'));
+    }
+
+    public function testEveryCommunicationItIssuesValidates(): void
+    {
+        // The two halves must agree, whatever the random base.
+        for ($i = 0; $i < 50; $i++) {
+            $communication = $this->service->generate();
+            $this->assertTrue(
+                StructuredCommunicationService::isValid($communication),
+                "generate() produced {$communication}, which isValid() rejects"
+            );
+        }
+    }
+
+    public function testItAcceptsEveryShapeSomebodyPlausiblyPastes(): void
+    {
+        $canonical = StructuredCommunicationService::format('1234567890');
+        $digits = preg_replace('/\D/', '', $canonical) ?? '';
+
+        $this->assertTrue(StructuredCommunicationService::isValid($canonical), 'canonical +++…+++');
+        $this->assertTrue(StructuredCommunicationService::isValid($digits), 'twelve bare digits');
+        $this->assertTrue(StructuredCommunicationService::isValid('***' . substr($digits, 0, 3) . '/' . substr($digits, 3, 4) . '/' . substr($digits, 7, 5) . '***'), '***…*** variant');
+        $this->assertTrue(StructuredCommunicationService::isValid(' ' . chunk_split($digits, 4, ' ')), 'spaced out');
+    }
+
+    public function testItRejectsAWrongKey(): void
+    {
+        $digits = preg_replace('/\D/', '', StructuredCommunicationService::format('1234567890')) ?? '';
+        $wrongKey = (int) substr($digits, 10, 2) === 42 ? '43' : '42';
+
+        $this->assertFalse(StructuredCommunicationService::isValid(substr($digits, 0, 10) . $wrongKey));
+    }
+
+    public function testItRejectsAnythingThatIsNotTwelveDigits(): void
+    {
+        $this->assertFalse(StructuredCommunicationService::isValid(''));
+        $this->assertFalse(StructuredCommunicationService::isValid('12345'), 'too short');
+        $this->assertFalse(StructuredCommunicationService::isValid('1234567890123'), 'too long');
+        $this->assertFalse(StructuredCommunicationService::isValid('Merci pour le camp'), 'a free-text communication');
+    }
 }


### PR DESCRIPTION
Petite itération, purement service + tests. **Aucun changement visible pour l'utilisateur** — pas d'entrée dans `specifications.md`, pas de fiche d'aide : ces trois méthodes existent pour qu'IT-08 ait quelque chose de correct sur quoi s'appuyer.

Ce qui mérite d'être écrit, c'est que **chacune des trois échoue silencieusement** si on la rate. Aucune ne lève d'erreur : la recherche répond simplement « rien », pour toujours.

## 1. `IbanNormalizer::format()` — affichage uniquement

Groupe par quatre (`BE71 0961 2345 6769`), comme un extrait bancaire l'imprime et donc comme quelqu'un le vérifie.

Le blind index se calcule sur la forme `normalize()`e. Une valeur formatée qui atteindrait `blindIndex()` ou une colonne ferait **cesser toute recherche par IBAN de correspondre** — sans rien à voir : pas d'erreur, juste un résultat vide à partir de là. Formater au dernier moment, dans le gabarit ou la réponse, jamais à l'entrée.

Le test l'**affirme** plutôt que de le commenter : un IBAN formaté est délibérément refusé par `isValidFullIban()`, et `normalize()` le ramène à la forme stockée.

## 2. `StructuredCommunicationService::isValid()` — le reste 0 vaut 97

Les clés de contrôle belges vont de **01 à 97, jamais 00** — c'est exactement ce que `format()` fait déjà à l'émission. Une comparaison `$base % 97 === $check` rejette donc toute communication valide dont la clé vaut 97 : environ une sur cent, assez fréquent pour être remonté comme un bug, assez rare pour passer un test à la main.

Les deux moitiés ont leur test nommé, et `testEveryCommunicationItIssuesValidates()` épingle `generate()` et `isValid()` l'une à l'autre pour qu'elles ne puissent pas diverger.

Accepte toutes les formes qu'on colle en pratique : `+++…+++` canonique, la variante `***…***` de certaines banques, douze chiffres bruts, n'importe quel espacement — les non-chiffres sont retirés d'abord, seuls les douze chiffres décident.

## 3. `ExpectedReceivableRepository::findByCommunication()` — re-canonicaliser avant le WHERE

La colonne stocke la forme émise `+++NNN/NNNN/NNNNN+++` ; la personne qui vérifie un paiement tape ce que sa banque lui a montré. Comparer la saisie brute ne trouve rien pour la plupart des entrées réelles, **en silence** — la réponse est « inconnu », et la personne en conclut que le paiement n'était pas attendu.

Douze chiffres en entrée, forme canonique en sortie, une correspondance exacte : pas de `LIKE`, pas de surprise de collation. Une saisie qui n'a pas douze chiffres court-circuite au lieu de lancer une requête qui ne peut pas aboutir.

## Aucune des trois ne rend une communication décodable

La base de dix chiffres est aléatoire. Une communication ne dit rien de qui a payé ; la correspondance est une recherche en base. Rien ne doit chercher à y encoder un membre.

## Vérifié par mutation, pas affirmé

| Mutation | Tests qui tombent |
| --- | --- |
| `isValid()` sans le mappage 0 → 97 | **3** (`testAKeyOf97…`, `testAKeyOf00…`, `testEveryCommunicationItIssuesValidates`) |
| `findByCommunication()` comparant la saisie brute | **1** (`testItFindsTheSameReceivableFromWhateverTheBankShowed`) |

**+16 tests** : 5 sur `format()`, 6 sur `isValid()`, 5 sur la recherche (dont « ne correspond pas sur un préfixe »). Aucune ligne PHP neuve non couverte.

Portes : PHPStan `[OK]`, PHPUnit **10195**, `npm run typecheck`, Vitest 1443, Playwright 40 — toutes vertes. `main` n'avait pas bougé.

## Version de module

Aucune modification de `schema.sql`. Pas de bump.

## Documentation

`ARCHITECTURE.md` §8.72 (nouveau) — les trois pièges, pour qu'ils ne soient pas réintroduits par quelqu'un qui trouverait ces méthodes trop simples pour mériter un commentaire.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGtfp6tsaMYej1Gi1sq5yu)_