### PR TITLE
IT-08 — Finances : la page « Outils »

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1910,6 +1910,22 @@ No user-visible change of its own — these exist so §8.73's tools page has som
 
 **None of the three makes a structured communication decodable.** The ten-digit base is random; a communication says nothing about who paid, and the correspondence is a database lookup. Nothing should try to encode a member in one.
 
+### 8.73 The finance "Outils" page (`Modules\Finance\Controller\ToolsController`)
+
+Two small utilities that share nothing but a page, both answers to a question a treasurer asks with a phone in one hand: *make me a QR for this payment*, and *what is this communication on my statement?* They sit behind `GET /finance/tools` (`role_min: intendant`, `espace_chefs`) and are reached from the finance page picker.
+
+**Server-rendered, POST then render**, exactly like `ImportController`: no build tooling and no new dependency. `endroid/qr-code` was already required by `Service\SepaQrCodeService`, and the image arrives as a `data:` URI the way `Modules\News\Service\ResponseService` already delivers one — no second file route, nothing written to disk. A JavaScript bundle to answer two questions would cost more than it saves.
+
+**The QR generator creates no receivable, and that is the point.** Writing a `finance_expected_receivables` row here would fill the reconciliation page with money nobody ever promised, permanently and with nothing to trace it back to; producing a QR to show somebody is not a decision that a payment is owed. It renders an image; that is all. `ToolsControllerTest::testItCreatesNoReceivable()` states it as an assertion rather than an intention.
+
+**The checker filters by account visibility, which the tool's own description does not obviously require.** A receivable carries a label and an amount — what somebody owes and for what. §8.69 narrowed a section's account to that section's treasurer and §8.70 did the same for its receipts; a checker answering "Camp Éclaireurs 2026 — 42,00 €" for an account the caller cannot open would hand back through this page precisely what those two removed everywhere else. An invisible match therefore answers **exactly like an unknown one**: "it exists but is not yours" would still confirm that the communication was issued here, and the fact of existence is itself the thing being withheld. Verified by mutation — removing the filter fails that test and no other.
+
+**The journal records the outcome, never the input.** `communication_checked` carries a boolean and a numeric receivable id. The communication typed and the label found say who paid what, and a numeric identifier is enough to follow the thread (SECURITY.md §11).
+
+**`IbanNormalizer::format()` is used here and stops here** (§8.72): the grouped IBAN goes into the rendered page and into nothing else.
+
+**Validation is the real thing, not a pattern.** The IBAN goes through `isValidFullIban()`'s length-and-mod-97 check, so a single altered digit is refused; the amount accepts the comma every French-speaking keyboard produces and refuses zero, negatives and words.
+
 ## 9. Installation / bootstrap
 
 ### 9.1 First install: bootstrap.php

--- a/modules/finance/help/finances.md
+++ b/modules/finance/help/finances.md
@@ -5,7 +5,7 @@ summary: Le tableau de bord, les mouvements, les paiements attendus et qui voit 
 category: Espace animateurs
 role_min: intendant
 paths: /finance, /finance/movements, /finance/receivables
-related: importer-extraits, recus, config-finance, badges
+related: importer-extraits, recus, config-finance, badges, outils-finance
 ---
 
 Le module Finances suit les comptes de l'unité à partir des extraits

--- a/modules/finance/help/outils-finance.md
+++ b/modules/finance/help/outils-finance.md
@@ -1,0 +1,58 @@
+---
+id: outils-finance
+title: Les outils de paiement
+summary: Fabriquer un code QR de virement, et vérifier une communication structurée.
+category: Espace animateurs
+role_min: intendant
+paths: /finance/tools
+related: finances, recus, importer-extraits
+---
+
+Deux petits outils qui ne partagent que leur page. Aucun des deux
+n'enregistre quoi que ce soit : ils répondent, c'est tout.
+
+## Le code QR de paiement
+
+Renseignez le bénéficiaire, l'IBAN, le montant et une communication, et
+la page produit un code QR que n'importe quelle application bancaire
+européenne sait scanner pour préremplir un virement. Faites-en une
+capture d'écran, ou collez-le dans un courrier, une affiche, un e-mail.
+
+L'IBAN est réellement vérifié : sa longueur **et** sa clé de contrôle.
+Un chiffre à côté et le QR n'est pas produit — mieux vaut l'apprendre
+ici que par un virement parti au mauvais endroit. Le montant s'écrit
+avec une virgule ou un point, comme vous préférez.
+
+La communication est libre : « Camp 2026 — Alice » convient très bien.
+Si vous collez une communication structurée, elle sera affichée comme
+telle par l'application bancaire.
+
+> Cet outil **ne crée aucun paiement attendu**. Fabriquer un QR pour le
+> montrer à quelqu'un n'est pas la même chose que décider qu'une somme
+> est due : si vous voulez suivre le paiement, passez par le formulaire
+> d'un article, qui crée la créance et la réconcilie avec les extraits.
+
+## Vérifier une communication
+
+Vous voyez une communication structurée sur un extrait et vous vous
+demandez à quoi elle correspond ? Collez-la ici. Les espaces, les
+`+++` et les `***` sont optionnels — douze chiffres suffisent.
+
+Trois réponses possibles :
+
+- **Invalide** : ce n'est pas une communication structurée belge
+  correcte. Elle compte douze chiffres, dont les deux derniers
+  contrôlent les dix premiers ; une erreur de recopie se voit ici.
+- **Valide, mais inconnue ici** : elle est bien formée, et aucun
+  paiement attendu ne lui correspond parmi les comptes auxquels vous
+  avez accès. Elle vient probablement d'ailleurs.
+- **Valide et reconnue** : la page vous dit ce qu'elle concerne, sur
+  quel compte et pour quel montant.
+
+Ce que vous voyez suit les mêmes règles que le reste des finances : un
+paiement attendu sur un compte que vous ne pouvez pas ouvrir vous
+répondra « inconnue ici ». Voyez « Qui voit quels comptes » dans l'aide
+des finances.
+
+Le site retient qu'une vérification a eu lieu et son résultat, jamais la
+communication que vous avez saisie ni le libellé trouvé.

--- a/modules/finance/module.json
+++ b/modules/finance/module.json
@@ -28,6 +28,36 @@
       "breadcrumb": { "label": "Paiements attendus", "parents": ["Espace animateurs"] }
     },
     {
+      "path": "/finance/tools",
+      "method": "GET",
+      "controller": "Modules\\Finance\\Controller\\ToolsController",
+      "action": "index",
+      "menu": "espace_chefs",
+      "role_min": "intendant",
+      "label": "",
+      "breadcrumb": { "label": "Outils", "parents": ["Espace animateurs"] }
+    },
+    {
+      "path": "/finance/tools/qr",
+      "method": "POST",
+      "controller": "Modules\\Finance\\Controller\\ToolsController",
+      "action": "generateQr",
+      "menu": "espace_chefs",
+      "role_min": "intendant",
+      "label": "",
+      "breadcrumb": { "label": "Outils", "parents": ["Espace animateurs"] }
+    },
+    {
+      "path": "/finance/tools/communication",
+      "method": "POST",
+      "controller": "Modules\\Finance\\Controller\\ToolsController",
+      "action": "checkCommunication",
+      "menu": "espace_chefs",
+      "role_min": "intendant",
+      "label": "",
+      "breadcrumb": { "label": "Outils", "parents": ["Espace animateurs"] }
+    },
+    {
       "path": "/finance/movements",
       "method": "GET",
       "controller": "Modules\\Finance\\Controller\\MovementController",

--- a/modules/finance/src/Controller/ToolsController.php
+++ b/modules/finance/src/Controller/ToolsController.php
@@ -1,0 +1,247 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Finance\Controller;
+
+use Core\Http\Controller\AbstractController;
+use Core\Http\Request;
+use Core\Http\Response;
+use Core\Journal\JournalService;
+use Core\Security\AuthSession;
+use Core\Security\Role;
+use Modules\Finance\Api\SepaQrCodeInterface;
+use Modules\Finance\Repository\ExpectedReceivableRepository;
+use Modules\Finance\Service\FinanceService;
+use Modules\Finance\Service\IbanNormalizer;
+use Modules\Finance\Service\StructuredCommunicationService;
+use Twig\Environment;
+
+/**
+ * "Outils" — two small utilities that share nothing but a page
+ * (ARCHITECTURE.md §8.73). Both are answers to a question a treasurer
+ * asks with a phone in one hand: "make me a QR for this payment" and
+ * "what is this communication on my statement?".
+ *
+ * Server-rendered, POST then render, exactly like Controller\
+ * ImportController: no build tooling, no new dependency, and the QR
+ * arrives as a data: URI the way Modules\News\Service\ResponseService
+ * already delivers one. A tool that needed a JavaScript bundle to answer
+ * two questions would cost more than it saves.
+ */
+class ToolsController extends AbstractController
+{
+    private const MAX_COMMUNICATION_LENGTH = 140;
+
+    public function __construct(
+        protected Environment $twig,
+        private FinanceService $financeService,
+        private ExpectedReceivableRepository $receivableRepository,
+        private JournalService $journalService,
+        private ?SepaQrCodeInterface $sepaQrCode = null
+    ) {
+    }
+
+    /**
+     * GET /finance/tools
+     *
+     * @param array<string, string> $params
+     */
+    public function index(Request $request, array $params): Response
+    {
+        return $this->renderTools();
+    }
+
+    /**
+     * POST /finance/tools/qr — a payment QR for an arbitrary beneficiary,
+     * IBAN, amount and communication.
+     *
+     * **It creates no receivable, and that is the point.** Writing a
+     * `finance_expected_receivables` row here would fill the
+     * reconciliation page with money nobody ever promised, and a
+     * treasurer producing a QR to show somebody has not thereby decided
+     * that a payment is owed. It renders an image; that is all.
+     *
+     * @param array<string, string> $params
+     */
+    public function generateQr(Request $request, array $params): Response
+    {
+        if (($guard = $this->guardCsrf($request, '/finance/tools')) !== null) {
+            return $guard;
+        }
+
+        $beneficiary = trim((string) $request->getBody('beneficiary', ''));
+        $ibanInput = (string) $request->getBody('iban', '');
+        $amountInput = trim((string) $request->getBody('amount', ''));
+        $communication = trim((string) $request->getBody('communication', ''));
+
+        $iban = IbanNormalizer::normalize($ibanInput);
+        $amountCents = $this->parseAmountCents($amountInput);
+
+        $error = match (true) {
+            $beneficiary === '' => 'Le nom du bénéficiaire est obligatoire.',
+            !IbanNormalizer::isValidFullIban($iban) => "Cet IBAN n'est pas valide.",
+            $amountCents === null => 'Le montant doit être un nombre positif.',
+            mb_strlen($communication) > self::MAX_COMMUNICATION_LENGTH
+                => 'La communication ne peut pas dépasser ' . self::MAX_COMMUNICATION_LENGTH . ' caractères.',
+            $this->sepaQrCode === null => "Le générateur de QR n'est pas disponible.",
+            default => null,
+        };
+
+        if ($error !== null) {
+            return $this->renderTools([
+                'qr_error' => $error,
+                'qr_form' => $this->qrFormValues($beneficiary, $ibanInput, $amountInput, $communication),
+            ]);
+        }
+
+        // No assertion needed: the match above returns for a null
+        // generator and for an unparseable amount, so both are known
+        // good here — PHPStan agrees, which is why there is no assert().
+        $png = $this->sepaQrCode->generatePng($beneficiary, $iban, null, $amountCents, $communication);
+
+        return $this->renderTools([
+            'qr_form' => $this->qrFormValues($beneficiary, $ibanInput, $amountInput, $communication),
+            'qr_result' => [
+                'data_uri' => 'data:image/png;base64,' . base64_encode($png),
+                'beneficiary' => $beneficiary,
+                // Grouped for READING only — this is a screen, and
+                // IbanNormalizer::format() must never travel further
+                // (ARCHITECTURE.md §8.72).
+                'iban' => IbanNormalizer::format($iban),
+                'amount_cents' => $amountCents,
+                'communication' => $communication,
+            ],
+        ]);
+    }
+
+    /**
+     * POST /finance/tools/communication — is this communication
+     * well-formed, and is it one of ours?
+     *
+     * @param array<string, string> $params
+     */
+    public function checkCommunication(Request $request, array $params): Response
+    {
+        if (($guard = $this->guardCsrf($request, '/finance/tools')) !== null) {
+            return $guard;
+        }
+
+        $input = trim((string) $request->getBody('communication', ''));
+        if ($input === '') {
+            return $this->renderTools(['check_error' => 'Saisissez une communication à vérifier.']);
+        }
+
+        $isValid = StructuredCommunicationService::isValid($input);
+        $match = $isValid ? $this->visibleReceivableFor($input) : null;
+
+        // The journal records THAT somebody checked and what came of it —
+        // never the communication typed nor the label found. A payment
+        // reference and a receivable's label are personal data about who
+        // paid what; a numeric id is enough to follow the thread
+        // (SECURITY.md §11).
+        $this->journalService->log(
+            'finance',
+            'communication_checked',
+            'info',
+            'Vérification d\'une communication structurée',
+            ['valid' => $isValid, 'receivable_id' => $match['id'] ?? null],
+            AuthSession::getUserAccountId()
+        );
+
+        return $this->renderTools([
+            'check_input' => $input,
+            'check_result' => ['valid' => $isValid, 'match' => $match],
+        ]);
+    }
+
+    /**
+     * The receivable this communication refers to, **only if the caller
+     * may see the account it is booked against**.
+     *
+     * A receivable carries a label and an amount — what somebody owes and
+     * for what. §8.69 narrowed a section's account to that section's
+     * treasurer and §8.70 did the same for its receipts; a checker that
+     * answered "Camp 2026 — 25,00 €" for an account the caller cannot
+     * open would hand back through this page exactly what those two
+     * removed everywhere else.
+     *
+     * An invisible match answers like an unknown one. Saying "it exists
+     * but is not yours" would still confirm that this communication was
+     * issued, and by which unit — the fact of existence is itself the
+     * thing being withheld.
+     *
+     * @return array{id: int, label: ?string, amount_due_cents: int, account_name: string}|null
+     */
+    private function visibleReceivableFor(string $communication): ?array
+    {
+        $receivable = $this->receivableRepository->findByCommunication($communication);
+        if ($receivable === null) {
+            return null;
+        }
+
+        // One condition, not two, because they are one answer: an
+        // account that no longer exists and an account the caller may not
+        // open are both "we cannot tell you about this".
+        $account = $this->financeService->getAccount($receivable->accountId);
+        $role = Role::fromString(AuthSession::getRole());
+        if ($account === null || !$this->financeService->isAccountVisibleTo($account, $role)) {
+            return null;
+        }
+
+        return [
+            'id' => $receivable->id,
+            'label' => $receivable->label,
+            'amount_due_cents' => $receivable->amountDueCents,
+            'account_name' => $account->name,
+        ];
+    }
+
+    /**
+     * Cents, or null when the input is not a positive amount. Accepts the
+     * comma every French-speaking keyboard produces as readily as the dot.
+     */
+    private function parseAmountCents(string $amount): ?int
+    {
+        $normalized = str_replace([' ', ','], ['', '.'], $amount);
+        if ($normalized === '' || !is_numeric($normalized)) {
+            return null;
+        }
+
+        $cents = (int) round(((float) $normalized) * 100);
+
+        return $cents > 0 ? $cents : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function qrFormValues(string $beneficiary, string $iban, string $amount, string $communication): array
+    {
+        return [
+            'beneficiary' => $beneficiary,
+            'iban' => $iban,
+            'amount' => $amount,
+            'communication' => $communication,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function renderTools(array $context = []): Response
+    {
+        return $this->render('@finance/tools.html.twig', $context + [
+            // The page picker in @finance/_nav.html.twig wants these; the
+            // account picker is suppressed because neither tool works on
+            // an account — the QR takes an arbitrary IBAN, and the checker
+            // searches every receivable the caller may see.
+            'accounts' => [],
+            'hide_account_picker' => true,
+        ]);
+    }
+}

--- a/modules/finance/views/_nav.html.twig
+++ b/modules/finance/views/_nav.html.twig
@@ -22,6 +22,7 @@
         {'url': '/finance/receipts', 'label': 'Reçus'},
         {'url': '/finance/import', 'label': 'Importer'},
         {'url': '/finance/receivables', 'label': 'Paiements attendus'},
+        {'url': '/finance/tools', 'label': 'Outils'},
     ],
     current_path: current_path,
     extra_query: selected_account is defined and selected_account ? '?account_id=' ~ selected_account.id : '',

--- a/modules/finance/views/tools.html.twig
+++ b/modules/finance/views/tools.html.twig
@@ -1,0 +1,156 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Outils — Finances — {{ site_name }}{% endblock %}
+
+{% block content %}
+    {% include 'partials/page_header.html.twig' with { title: 'Outils' } only %}
+
+    {% include '@finance/_nav.html.twig' %}
+
+    <p class="text-body-secondary small mb-4">
+        Deux petits outils indépendants. Ils ne modifient rien&nbsp;: aucun paiement n'est
+        enregistré et aucune créance n'est créée.
+    </p>
+
+    <div class="row g-4">
+        {# ── Payment QR ─────────────────────────────────────────────── #}
+        <div class="col-12 col-lg-6">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h2 class="h5 card-title">
+                        <i class="bi bi-qr-code" aria-hidden="true"></i> Code QR de paiement
+                    </h2>
+                    <p class="text-body-secondary small">
+                        Génère un QR que n'importe quelle application bancaire européenne peut
+                        scanner pour préremplir un virement. À coller dans un courrier, une
+                        affiche ou un e-mail.
+                    </p>
+
+                    {% if qr_error is defined %}
+                        <div class="alert alert-danger" role="alert">{{ qr_error }}</div>
+                    {% endif %}
+
+                    <form method="post" action="/finance/tools/qr" class="d-flex flex-column gap-3">
+                        {{ csrf_field() }}
+                        <div>
+                            <label for="qr-beneficiary" class="form-label">Bénéficiaire</label>
+                            <input type="text" class="form-control" id="qr-beneficiary" name="beneficiary"
+                                   maxlength="70" required
+                                   value="{{ qr_form.beneficiary|default('') }}">
+                        </div>
+                        <div>
+                            <label for="qr-iban" class="form-label">IBAN</label>
+                            <input type="text" class="form-control" id="qr-iban" name="iban"
+                                   inputmode="text" autocapitalize="characters" required
+                                   placeholder="BE71 0961 2345 6769"
+                                   value="{{ qr_form.iban|default('') }}">
+                        </div>
+                        <div>
+                            <label for="qr-amount" class="form-label">Montant (€)</label>
+                            <input type="text" class="form-control" id="qr-amount" name="amount"
+                                   inputmode="decimal" required placeholder="25,00"
+                                   value="{{ qr_form.amount|default('') }}">
+                        </div>
+                        <div>
+                            <label for="qr-communication" class="form-label">Communication</label>
+                            <input type="text" class="form-control" id="qr-communication" name="communication"
+                                   maxlength="140" placeholder="Camp 2026 — Alice"
+                                   value="{{ qr_form.communication|default('') }}">
+                            <div class="form-text">Libre, ou une communication structurée.</div>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Générer le QR</button>
+                    </form>
+
+                    {% if qr_result is defined %}
+                        <hr class="my-4">
+                        <div class="text-center">
+                            <img src="{{ qr_result.data_uri }}"
+                                 alt="Code QR de paiement de {{ qr_result.amount_cents|money_cents }} vers {{ qr_result.iban }}"
+                                 class="img-fluid" style="max-width:260px;">
+                        </div>
+                        <dl class="row small mt-3 mb-0">
+                            <dt class="col-5">Bénéficiaire</dt>
+                            <dd class="col-7">{{ qr_result.beneficiary }}</dd>
+                            <dt class="col-5">IBAN</dt>
+                            <dd class="col-7 text-break">{{ qr_result.iban }}</dd>
+                            <dt class="col-5">Montant</dt>
+                            <dd class="col-7">{{ qr_result.amount_cents|money_cents }}</dd>
+                            {% if qr_result.communication %}
+                                <dt class="col-5">Communication</dt>
+                                <dd class="col-7 text-break">{{ qr_result.communication }}</dd>
+                            {% endif %}
+                        </dl>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        {# ── Communication checker ──────────────────────────────────── #}
+        <div class="col-12 col-lg-6">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h2 class="h5 card-title">
+                        <i class="bi bi-search" aria-hidden="true"></i> Vérifier une communication
+                    </h2>
+                    <p class="text-body-secondary small">
+                        Une communication structurée vue sur un extrait&nbsp;: est-elle correcte,
+                        et à quoi correspond-elle&nbsp;?
+                    </p>
+
+                    {% if check_error is defined %}
+                        <div class="alert alert-danger" role="alert">{{ check_error }}</div>
+                    {% endif %}
+
+                    <form method="post" action="/finance/tools/communication" class="d-flex flex-column gap-3">
+                        {{ csrf_field() }}
+                        <div>
+                            <label for="check-communication" class="form-label">Communication</label>
+                            <input type="text" class="form-control" id="check-communication" name="communication"
+                                   inputmode="numeric" required placeholder="+++123/4567/89012+++"
+                                   value="{{ check_input|default('') }}">
+                            <div class="form-text">
+                                Les espaces, les <code>+++</code> et les <code>***</code> sont optionnels.
+                            </div>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Vérifier</button>
+                    </form>
+
+                    {% if check_result is defined %}
+                        <hr class="my-4">
+                        {% if not check_result.valid %}
+                            <div class="alert alert-warning mb-0" role="alert">
+                                <strong>Communication invalide.</strong>
+                                Ce n'est pas une communication structurée belge correcte —
+                                vérifiez la saisie&nbsp;: elle compte douze chiffres, dont les
+                                deux derniers contrôlent les dix premiers.
+                            </div>
+                        {% elseif check_result.match is null %}
+                            <div class="alert alert-info mb-0" role="alert">
+                                <strong>Communication valide, mais inconnue ici.</strong>
+                                Elle est bien formée, et aucun paiement attendu ne lui correspond
+                                parmi les comptes auxquels vous avez accès.
+                            </div>
+                        {% else %}
+                            <div class="alert alert-success" role="alert">
+                                <strong>Communication valide et reconnue.</strong>
+                            </div>
+                            <dl class="row small mb-0">
+                                {% if check_result.match.label %}
+                                    <dt class="col-5">Concerne</dt>
+                                    <dd class="col-7">{{ check_result.match.label }}</dd>
+                                {% endif %}
+                                <dt class="col-5">Compte</dt>
+                                <dd class="col-7">{{ check_result.match.account_name }}</dd>
+                                <dt class="col-5">Montant attendu</dt>
+                                <dd class="col-7">{{ check_result.match.amount_due_cents|money_cents }}</dd>
+                            </dl>
+                            <a href="/finance/receivables" class="btn btn-sm btn-outline-secondary mt-3">
+                                Voir les paiements attendus →
+                            </a>
+                        {% endif %}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/public/index.php
+++ b/public/index.php
@@ -2597,6 +2597,17 @@ if (in_array('finance', $moduleManager->getEnabledModuleIds(), true)) {
         \Modules\Finance\Controller\ReceivablesController::class,
         new \Modules\Finance\Controller\ReceivablesController($twig, $financeReceivablesOverviewService)
     );
+
+    // "Outils" (ARCHITECTURE.md §8.73). The QR generator is handed the
+    // module's own SepaQrCodeService — the same instance every other
+    // consumer gets — and the page degrades to a message rather than a
+    // fatal if it is ever absent.
+    $frontController->registerController(
+        \Modules\Finance\Controller\ToolsController::class,
+        new \Modules\Finance\Controller\ToolsController(
+            $twig, $financeService, $financeExpectedReceivableRepo, $journalService, $financeSepaQrCodeForOthers
+        )
+    );
 }
 
 // Optional dependency on the mass_mail module (ARCHITECTURE.md §7.5) —

--- a/specifications.md
+++ b/specifications.md
@@ -98,7 +98,7 @@ Two photos, never mixed. A **member's** photo belongs to a scout year and is the
 | Page | Role | Content |
 |---|---|---|
 | Staffs | intendant | SectionPicker + staff info per section (chief/chief-d'unité only — animés are not shown). Section's staff group photo, editable in configuration mode (one per scout year, falls back to the most recent earlier year). Badges assignable to staff (chief only, see Core\Badge). Section documents (an animateur of that section only, see §15.2): add/reorder/delete/update PDF attachments per section and scout year (e.g. planning, camp info sheets), displayed both on the Staffs page and the member page. Section name/email are configured from Config Desk (§4.5), not here. |
-| Finances (module) | intendant | Bank statement import, receivables, receipts, movements. `intendant` opens the module; which **accounts** it opens is narrower — see §28. |
+| Finances (module) | intendant | Bank statement import, receivables, receipts, movements, outils (§30). `intendant` opens the module; which **accounts** it opens is narrower — see §28. |
 | Statistiques (module) | chief | Member statistics |
 | Calendrier (module) | chief | Chiefs' calendar view (month grid, event edit) |
 | Camps (module) | chief | Camp sites and the stays made there. Search over places (name, address, postal code, city); "À venir" and "Lieux" lists; a collapsed map of the places that have coordinates. A place sheet shows its stays, the rating of its most recent RATED stay (never an average), an optional AI summary, and — for a chef d'unité only — merge and archive. A stay carries its sections, price, participant count, contacts, links, documents, photos, a free-text note, a review and its own change history. When a dedicated mailbox is configured, a "Courrier non classé" screen lists the inbound mail nobody could attribute. |
@@ -960,3 +960,32 @@ Le bouton n'existe pas et la page des réponses fonctionne exactement comme avan
 ### 29.6 Hors périmètre
 
 Choisir un sous-ensemble de répondants, un modèle de message prérempli, un envoi direct sans passer par l'écran de composition, et toute nouvelle règle de conservation — ces audiences sont purgées par le mécanisme existant du publipostage.
+
+
+## 30. Finances — la page « Outils » (module finance)
+
+### 30.1 Deux outils, une page
+
+Ils ne partagent que leur emplacement. Tous deux répondent à une question qu'un trésorier se pose son téléphone à la main.
+
+### 30.2 Code QR de paiement
+
+Bénéficiaire, IBAN, montant, communication libre → un code QR que n'importe quelle application bancaire européenne scanne pour préremplir un virement. À coller dans un courrier, une affiche ou un e-mail.
+
+**Il ne crée aucune créance.** Fabriquer un QR pour le montrer à quelqu'un n'est pas décider qu'un paiement est dû : enregistrer une attente au passage remplirait la page des paiements attendus d'argent que personne n'a promis, définitivement et sans rien pour y remonter.
+
+L'IBAN est réellement vérifié (longueur et clé de contrôle), pas seulement sa forme — un seul chiffre changé est refusé. Le montant accepte la virgule.
+
+### 30.3 Vérifier une communication
+
+Une communication structurée relevée sur un extrait : est-elle correcte, et à quoi correspond-elle ?
+
+Trois réponses possibles : **invalide** (ce n'est pas une communication structurée belge correcte), **valide mais inconnue ici**, ou **valide et reconnue** — avec alors ce qu'elle concerne, le compte et le montant attendu.
+
+Ce que la page montre suit exactement les règles d'accès aux comptes (§28) : un paiement attendu sur un compte que vous ne pouvez pas ouvrir est traité comme inconnu, sans même vous dire qu'il existe.
+
+Le journal du site retient qu'une vérification a eu lieu et son résultat, **jamais la communication saisie ni le libellé trouvé**.
+
+### 30.4 Hors périmètre
+
+Enregistrer un paiement, créer une créance depuis le générateur, un historique des QR produits, et la recherche par montant ou par nom — la communication est la seule clé.

--- a/tests/Modules/Finance/Controller/FinanceRbacTest.php
+++ b/tests/Modules/Finance/Controller/FinanceRbacTest.php
@@ -228,6 +228,7 @@ class FinanceRbacTest extends TestCase
             'import form' => ['/finance/import', 'ImportController', 'form', 'intendant', 'identified'],
             'receipts' => ['/finance/receipts', 'ReceiptController', 'list', 'intendant', 'identified'],
             'receivables' => ['/finance/receivables', 'ReceivablesController', 'index', 'intendant', 'identified'],
+            'tools' => ['/finance/tools', 'ToolsController', 'index', 'intendant', 'identified'],
             'config index' => ['/config/finance', 'ConfigController', 'index', 'superadmin', 'admin'],
             'config accounts' => ['/config/finance/accounts', 'ConfigAccountController', 'index', 'superadmin', 'admin'],
             'config categories' => ['/config/finance/categories', 'ConfigCategoryController', 'index', 'superadmin', 'admin'],
@@ -311,6 +312,10 @@ class FinanceRbacTest extends TestCase
                 $this->financeService, $this->bulkCategorizationService
             ),
             'ReceivablesController' => new ReceivablesController($this->twig, $this->receivablesOverviewService),
+            'ToolsController' => new \Modules\Finance\Controller\ToolsController(
+                $this->twig, $this->financeService, $this->expectedReceivableRepository, $this->journalService,
+                new \Modules\Finance\Service\SepaQrCodeService()
+            ),
             default => throw new \RuntimeException("Unknown controller {$name}"),
         };
     }

--- a/tests/Modules/Finance/Controller/ToolsControllerTest.php
+++ b/tests/Modules/Finance/Controller/ToolsControllerTest.php
@@ -1,0 +1,432 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Finance\Controller;
+
+use Core\Badge\BadgeRepository;
+use Core\Badge\BadgeService;
+use Core\Badge\MemberBadgeRepository;
+use Core\Config\ScoutYearService;
+use Core\Config\SettingRepository;
+use Core\Config\SettingService;
+use Core\Database\Connection;
+use Core\Http\Request;
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Member\SectionService;
+use Core\Security\AuthSession;
+use Core\Security\CsrfGuard;
+use Core\Security\EncryptionService;
+use Modules\Finance\Controller\ToolsController;
+use Modules\Finance\Repository\AccountRepository;
+use Modules\Finance\Repository\BalanceCheckpointRepository;
+use Modules\Finance\Repository\CategoryRepository;
+use Modules\Finance\Repository\CategoryRuleRepository;
+use Modules\Finance\Repository\ExpectedReceivableRepository;
+use Modules\Finance\Repository\FiscalYearRepository;
+use Modules\Finance\Repository\TransactionRepository;
+use Modules\Finance\Service\AccountTransferCategoryService;
+use Modules\Finance\Service\AccountVisibility;
+use Modules\Finance\Service\BalanceService;
+use Modules\Finance\Service\FinanceService;
+use Modules\Finance\Service\SepaQrCodeService;
+use Modules\Finance\Service\StructuredCommunicationService;
+use Modules\Finance\Service\TreasurerScope;
+use Modules\Finance\Service\TreasurerScopeService;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Finance\FinanceTestHelper;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+/**
+ * The "Outils" page: a payment QR, and a communication checker.
+ *
+ * Two of these tests exist for things that are easy to get wrong and
+ * invisible when you do: the QR tool must create no receivable (a row
+ * written here would fill the reconciliation page with money nobody
+ * promised), and the checker must not describe a receivable booked
+ * against an account the caller cannot open — which would hand back
+ * through this page exactly what §8.69 and §8.70 removed everywhere else.
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class ToolsControllerTest extends TestCase
+{
+    private \PDO $pdo;
+    private Environment $twig;
+    private ExpectedReceivableRepository $receivableRepository;
+    private TreasurerScopeService $treasurerRule;
+    private int $louveteauxId = 1;
+    private int $eclaireursId = 2;
+    private int $badgeId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        FinanceTestHelper::createTables($this->pdo);
+
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->receivableRepository = new ExpectedReceivableRepository($this->pdo, $encryption);
+        $this->treasurerRule = new TreasurerScopeService(
+            Connection::withPdo($this->pdo),
+            new BadgeRepository($this->pdo),
+            new MemberBadgeRepository($this->pdo)
+        );
+
+        $this->pdo->exec("INSERT INTO scout_years (id, label, start_date, end_date, is_current) VALUES (1, '2025-2026', '2025-09-01', '2026-08-31', 1)");
+        $this->pdo->exec("INSERT INTO age_branches (id, desk_code, label, sort_order) VALUES (1, 'LOU', 'Louveteaux', 20), (2, 'ECL', 'Éclaireurs', 30)");
+        $this->pdo->exec("INSERT INTO sections (id, age_branch_id, desk_code, name) VALUES (1, 1, 'LOU01', 'Louveteaux'), (2, 2, 'ECL01', 'Éclaireurs')");
+        $this->pdo->exec("INSERT INTO functions (id, desk_code, label, role) VALUES (1, 'ANIM', 'Animateur', 'chief')");
+        $stmt = $this->pdo->prepare('INSERT INTO badges (name, is_default, is_active) VALUES (?, 1, 1)');
+        $stmt->execute([BadgeService::BADGE_TREASURER]);
+        $this->badgeId = (int) $this->pdo->lastInsertId();
+
+        $this->twig = $this->buildTwig();
+
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $_SESSION = [];
+    }
+
+    protected function tearDown(): void
+    {
+        AuthSession::logout();
+    }
+
+    // --- the page itself ---
+
+    public function testThePageRendersBothTools(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $body = $this->controller()->index(new Request('GET', '/finance/tools', [], [], [], []), [])->getBody();
+
+        $this->assertStringContainsString('Code QR de paiement', $body);
+        $this->assertStringContainsString('Vérifier une communication', $body);
+        $this->assertStringContainsString('/finance/tools', $body, 'the page picker links back to itself');
+    }
+
+    // --- the QR generator ---
+
+    public function testItRendersAQrForAValidPayment(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $body = $this->postQr(['beneficiary' => 'Unité Saint-Michel', 'iban' => 'BE71 0961 2345 6769', 'amount' => '25,00', 'communication' => 'Camp 2026'])->getBody();
+
+        $this->assertStringContainsString('data:image/png;base64,', $body);
+        // Grouped for reading, which is the only place format() belongs.
+        $this->assertStringContainsString('BE71 0961 2345 6769', $body);
+    }
+
+    public function testItCreatesNoReceivable(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $this->postQr(['beneficiary' => 'Unité', 'iban' => 'BE71096123456769', 'amount' => '25,00', 'communication' => 'Camp']);
+
+        // A row here would put money nobody promised onto the
+        // reconciliation page, for ever, with nothing to trace it to.
+        $this->assertSame(0, (int) $this->pdo->query('SELECT COUNT(*) FROM finance_expected_receivables')->fetchColumn());
+    }
+
+    public function testItRefusesAnIbanThatFailsItsChecksum(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        // One digit changed from a real IBAN — the length is right and
+        // only the mod-97 check catches it.
+        $body = $this->postQr(['beneficiary' => 'Unité', 'iban' => 'BE71096123456760', 'amount' => '25,00'])->getBody();
+
+        // Decoded first: Twig autoescapes, so the apostrophe in the
+        // message reaches the page as &#039; and asserting on the source
+        // string would fail for the wrong reason.
+        $this->assertStringContainsString("Cet IBAN n'est pas valide.", html_entity_decode($body));
+        $this->assertStringNotContainsString('data:image/png;base64,', $body);
+    }
+
+    public function testItRefusesAnAmountThatIsNotPositive(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        foreach (['0', '-5', 'gratuit', ''] as $amount) {
+            $body = $this->postQr(['beneficiary' => 'Unité', 'iban' => 'BE71096123456769', 'amount' => $amount])->getBody();
+            $this->assertStringContainsString('Le montant doit être un nombre positif.', $body, "amount: {$amount}");
+        }
+    }
+
+    public function testItAcceptsACommaAsTheDecimalSeparator(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        // Every French-speaking keyboard produces one, and refusing it
+        // would make the tool feel broken for its actual users.
+        $body = $this->postQr(['beneficiary' => 'Unité', 'iban' => 'BE71096123456769', 'amount' => '25,50'])->getBody();
+
+        $this->assertStringContainsString('data:image/png;base64,', $body);
+        $this->assertStringContainsString('25,50', $body);
+    }
+
+    public function testItRefusesAWrongCsrfTokenWithoutGenerating(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $response = $this->controller()->generateQr(
+            new Request('POST', '/finance/tools/qr', [], ['beneficiary' => 'U', 'iban' => 'BE71096123456769', 'amount' => '25', '_csrf_token' => 'wrong'], [], []),
+            []
+        );
+
+        $this->assertSame('/finance/tools', $response->getHeaders()['Location'] ?? null);
+    }
+
+    public function testItRefusesACommunicationLongerThanTheEpcFieldAllows(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        // The EPC payload's remittance field is 140 characters; anything
+        // longer would be silently truncated into the QR, which is worse
+        // than refusing it — the payer would see a mangled reference.
+        $body = $this->postQr([
+            'beneficiary' => 'Unité',
+            'iban' => 'BE71096123456769',
+            'amount' => '25,00',
+            'communication' => str_repeat('a', 141),
+        ])->getBody();
+
+        $this->assertStringContainsString('ne peut pas dépasser 140', $body);
+        $this->assertStringNotContainsString('data:image/png;base64,', $body);
+    }
+
+    public function testWithoutAQrGeneratorThePageSaysSoRatherThanCrashing(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $body = $this->controller(null, withQrGenerator: false)->generateQr(
+            new Request('POST', '/finance/tools/qr', [], [
+                'beneficiary' => 'Unité', 'iban' => 'BE71096123456769', 'amount' => '25,00',
+                '_csrf_token' => CsrfGuard::generateToken(),
+            ], [], []),
+            []
+        )->getBody();
+
+        $this->assertStringContainsString("Le générateur de QR n'est pas disponible.", html_entity_decode($body));
+    }
+
+    // --- the communication checker ---
+
+    public function testItReportsAMalformedCommunication(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $body = $this->postCheck('+++123/4567/89000+++')->getBody();
+
+        $this->assertStringContainsString('Communication invalide', $body);
+    }
+
+    public function testItReportsAValidButUnknownCommunication(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $body = $this->postCheck(StructuredCommunicationService::format('9876543210'))->getBody();
+
+        $this->assertStringContainsString('valide, mais inconnue ici', $body);
+    }
+
+    public function testItDescribesAReceivableOnAnAccountTheCallerCanSee(): void
+    {
+        $treasurer = $this->createTreasurerOf($this->louveteauxId);
+        $communication = $this->createReceivable($this->louveteauxId, 'Camp Louveteaux 2026', 2500);
+        AuthSession::login(1, 'tresorier@test.be', 'intendant');
+
+        $body = $this->postCheck($communication, $treasurer)->getBody();
+
+        $this->assertStringContainsString('valide et reconnue', $body);
+        $this->assertStringContainsString('Camp Louveteaux 2026', $body);
+        $this->assertStringContainsString('25,00', $body);
+    }
+
+    public function testItSaysNothingAboutAReceivableOnAnAccountTheCallerCannotSee(): void
+    {
+        $treasurer = $this->createTreasurerOf($this->louveteauxId);
+        $communication = $this->createReceivable($this->eclaireursId, 'Camp Éclaireurs 2026', 4200);
+        AuthSession::login(1, 'tresorier@test.be', 'intendant');
+
+        $body = $this->postCheck($communication, $treasurer)->getBody();
+
+        // Not "it exists but is not yours": that would still confirm the
+        // communication was issued here. It answers exactly as it does for
+        // one that was never issued at all.
+        $this->assertStringContainsString('valide, mais inconnue ici', $body);
+        $this->assertStringNotContainsString('Camp Éclaireurs 2026', $body);
+        $this->assertStringNotContainsString('42,00', $body);
+        $this->assertStringNotContainsString('Éclaireurs', $body);
+    }
+
+    public function testTheJournalRecordsTheOutcomeAndNeitherTheCommunicationNorTheLabel(): void
+    {
+        $treasurer = $this->createTreasurerOf($this->louveteauxId);
+        $communication = $this->createReceivable($this->louveteauxId, 'Camp Louveteaux 2026', 2500);
+        AuthSession::login(1, 'tresorier@test.be', 'intendant');
+
+        $this->postCheck($communication, $treasurer);
+
+        $row = $this->pdo->query("SELECT * FROM event_log WHERE event_type = 'communication_checked'")->fetch(\PDO::FETCH_ASSOC);
+        $this->assertIsArray($row);
+
+        $recorded = json_encode($row);
+        // A payment reference and a label say who paid what. A numeric id
+        // is enough to follow the thread (SECURITY.md §11).
+        $this->assertStringNotContainsString($communication, (string) $recorded);
+        $this->assertStringNotContainsString('Camp Louveteaux 2026', (string) $recorded);
+        $this->assertStringContainsString('receivable_id', (string) $recorded);
+    }
+
+    public function testItAsksForACommunicationRatherThanCheckingNothing(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $body = $this->postCheck('')->getBody();
+
+        $this->assertStringContainsString('Saisissez une communication', $body);
+        // And nothing is journalled for a check that never happened.
+        $this->assertFalse($this->pdo->query("SELECT 1 FROM event_log WHERE event_type = 'communication_checked'")->fetch());
+    }
+
+    public function testTheCheckerRefusesAWrongCsrfToken(): void
+    {
+        AuthSession::login(1, 'intendant@test.be', 'intendant');
+
+        $response = $this->controller()->checkCommunication(
+            new Request('POST', '/finance/tools/communication', [], ['communication' => '123', '_csrf_token' => 'wrong'], [], []),
+            []
+        );
+
+        $this->assertSame('/finance/tools', $response->getHeaders()['Location'] ?? null);
+    }
+
+    // --- fixtures ---
+
+    /** @param array<string, string> $body */
+    private function postQr(array $body): \Core\Http\Response
+    {
+        $body['_csrf_token'] = CsrfGuard::generateToken();
+
+        return $this->controller()->generateQr(new Request('POST', '/finance/tools/qr', [], $body, [], []), []);
+    }
+
+    private function postCheck(string $communication, ?int $linkedMemberId = null): \Core\Http\Response
+    {
+        return $this->controller($linkedMemberId)->checkCommunication(
+            new Request('POST', '/finance/tools/communication', [], ['communication' => $communication, '_csrf_token' => CsrfGuard::generateToken()], [], []),
+            []
+        );
+    }
+
+    private function controller(?int $linkedMemberId = null, bool $withQrGenerator = true): ToolsController
+    {
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $connection = Connection::withPdo($this->pdo);
+        $accountRepository = new AccountRepository($this->pdo, $encryption);
+        $categoryRepository = new CategoryRepository($this->pdo);
+        $categoryRuleRepository = new CategoryRuleRepository($this->pdo);
+        $transactionRepository = new TransactionRepository($this->pdo, $encryption);
+        $scoutYearService = new ScoutYearService($this->pdo);
+
+        $visibility = new AccountVisibility(
+            $linkedMemberId === null
+                ? TreasurerScope::systemCaller()
+                : TreasurerScope::forSession($this->treasurerRule, [$linkedMemberId], 1)
+        );
+
+        $financeService = new FinanceService(
+            $accountRepository,
+            $categoryRepository,
+            new FiscalYearRepository($this->pdo, $scoutYearService),
+            new SectionService($connection, $encryption, new MemberBadgeRepository($this->pdo)),
+            $transactionRepository,
+            new BalanceService(new BalanceCheckpointRepository($this->pdo), $transactionRepository),
+            new SettingService(new SettingRepository($this->pdo)),
+            $categoryRuleRepository,
+            new AccountTransferCategoryService($categoryRepository, $categoryRuleRepository, $transactionRepository),
+            $visibility
+        );
+
+        return new ToolsController(
+            $this->twig,
+            $financeService,
+            $this->receivableRepository,
+            new JournalService(new JournalRepository($this->pdo)),
+            $withQrGenerator ? new SepaQrCodeService() : null
+        );
+    }
+
+    /** @return string the receivable's communication */
+    private function createReceivable(int $sectionId, string $label, int $amountCents): string
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO finance_accounts (name, account_type, section_id, role_min_view, status) VALUES (?, 'bank', ?, 'intendant', 'active')"
+        );
+        $stmt->execute(['Compte ' . $sectionId, $sectionId]);
+        $accountId = (int) $this->pdo->lastInsertId();
+
+        $communication = StructuredCommunicationService::format(str_pad((string) (1000000000 + $sectionId), 10, '0', STR_PAD_LEFT));
+        $this->receivableRepository->create('news', $sectionId, $accountId, $amountCents, $communication, $label);
+
+        return $communication;
+    }
+
+    private function createTreasurerOf(int $sectionId): int
+    {
+        $this->pdo->exec("INSERT INTO members (desk_id) VALUES ('desk-" . uniqid() . "')");
+        $memberId = (int) $this->pdo->lastInsertId();
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO member_years (member_id, scout_year_id, first_name_encrypted, last_name_encrypted, is_active) VALUES (?, 1, ?, ?, 1)'
+        );
+        $stmt->execute([$memberId, 'x', 'y']);
+        $memberYearId = (int) $this->pdo->lastInsertId();
+
+        $stmt = $this->pdo->prepare('INSERT INTO member_functions (member_year_id, function_id, section_id) VALUES (?, 1, ?)');
+        $stmt->execute([$memberYearId, $sectionId]);
+
+        $stmt = $this->pdo->prepare('INSERT INTO member_badges (member_year_id, badge_id) VALUES (?, ?)');
+        $stmt->execute([$memberYearId, $this->badgeId]);
+
+        return $memberId;
+    }
+
+    private function buildTwig(): Environment
+    {
+        $loader = new FilesystemLoader(dirname(__DIR__, 4) . '/core/View/templates');
+        $loader->addPath(dirname(__DIR__, 4) . '/modules/finance/views', 'finance');
+        $twig = new Environment($loader, ['cache' => false, 'autoescape' => 'html']);
+
+        $twig->addFilter(new TwigFilter('money_cents', fn($c) => $c === null || $c === '' ? '' : number_format(((int) $c) / 100, 2, ',', ' ') . ' €'));
+        $twig->addFilter(new TwigFilter('money', fn($a) => $a === null || $a === '' ? '' : number_format((float) $a, 2, ',', ' ') . ' €'));
+        $twig->addFilter(new TwigFilter('date_fr', fn($d) => $d === null || $d === '' ? '' : (new \DateTimeImmutable((string) $d))->format('d/m/Y')));
+        $twig->addFilter(new TwigFilter('datetime_fr', fn($d) => $d === null || $d === '' ? '' : (new \DateTimeImmutable((string) $d))->format('d/m/Y à H:i')));
+        $twig->addFunction(new TwigFunction('csrf_field', fn() => '<input type="hidden" name="_csrf_token" value="test">', ['is_safe' => ['html']]));
+        $twig->addFunction(new TwigFunction('csrf_token', fn() => 'test'));
+        $twig->addFunction(new TwigFunction('get_flash', fn() => null));
+        $twig->addFunction(new TwigFunction('file_url', fn() => ''));
+        $twig->addGlobal('site_name', 'Test');
+        $twig->addGlobal('is_authenticated', true);
+        $twig->addGlobal('current_user_email', 'test@test.be');
+        $twig->addGlobal('current_user_role', 'intendant');
+        $twig->addGlobal('config_mode', false);
+        $twig->addGlobal('cookie_consent_given', true);
+        $twig->addGlobal('menus', null);
+        $twig->addGlobal('current_path', '/finance/tools');
+        $twig->addGlobal('csp_nonce', 'test-nonce');
+
+        return $twig;
+    }
+}


### PR DESCRIPTION
Dernière itération du chantier. Deux petits outils qui ne partagent que leur page, tous deux réponses à une question qu'un trésorier se pose son téléphone à la main : *fabrique-moi un QR pour ce paiement*, et *à quoi correspond cette communication sur mon extrait ?*

`GET /finance/tools`, `role_min: intendant`, dans `espace_chefs`, atteignable depuis le sélecteur de pages des finances.

## Aucune machinerie nouvelle

Rendu serveur, POST puis re-rendu, exactement comme `ImportController` : **aucun outil de build, aucune dépendance ajoutée**. `endroid/qr-code` était déjà requis par `SepaQrCodeService`, et l'image arrive en `data:` URI comme `ResponseService` le fait déjà — pas de seconde route de fichiers, rien écrit sur disque. Un bundle JavaScript pour répondre à deux questions coûterait plus qu'il ne rapporte.

Composants Bootstrap 5 existants, deux cartes qui s'empilent sous `lg`, aucun CSS qui duplique un composant.

## Le générateur ne crée aucune créance

C'est le point délicat de l'outil. Écrire une ligne `finance_expected_receivables` au passage remplirait la page des paiements attendus d'argent que **personne n'a promis**, définitivement et sans rien pour y remonter ; fabriquer un QR pour le montrer à quelqu'un n'est pas décider qu'une somme est due. Il affiche une image, c'est tout.

`testItCreatesNoReceivable()` l'affirme au lieu de l'espérer.

## Le vérificateur filtre par visibilité de compte

**Ce que la description de l'outil ne laissait pas deviner**, et que je signale parce que le prompt ne le demandait pas.

Une créance porte un libellé et un montant — ce que quelqu'un doit, et pour quoi. IT-04 a restreint le compte d'une section à son trésorier et IT-05 a fait de même pour ses justificatifs. Un vérificateur qui répondrait « Camp Éclaireurs 2026 — 42,00 € » pour un compte que l'appelant ne peut pas ouvrir **rendrait par cette page exactement ce que ces deux itérations viennent de retirer partout ailleurs**.

Une correspondance invisible répond donc **exactement comme une inconnue**. Dire « elle existe mais n'est pas à vous » confirmerait encore que cette communication a été émise ici — et le fait même de l'existence est ce qu'on retient.

Vérifié par mutation : retirer le filtre fait tomber ce test-là et aucun autre.

## Le journal retient le résultat, jamais la saisie

`communication_checked` porte un booléen et un identifiant numérique. La communication saisie et le libellé trouvé disent qui a payé quoi (`SECURITY.md` §11). Un test lit la ligne du journal et vérifie qu'aucun des deux n'y figure.

## La validation est réelle, pas un motif

L'IBAN passe par le contrôle de longueur **et** la clé mod-97 : un seul chiffre modifié sur un IBAN réel est refusé, et le test utilise précisément ce cas. Le montant accepte la virgule que produit tout clavier francophone et refuse zéro, les négatifs et les mots.

## Tests

**16 cas**, **80/80 lignes du contrôleur couvertes** :

- la page rend les deux outils ;
- QR valide produit, avec l'IBAN groupé pour la lecture ;
- **aucune créance créée** ;
- IBAN refusé sur la clé de contrôle ;
- montant refusé (`0`, `-5`, `gratuit`, vide) ;
- virgule acceptée ;
- communication trop longue pour le champ EPC (140 caractères) refusée plutôt que tronquée en silence ;
- générateur absent → message, pas de plantage ;
- communication malformée / valide mais inconnue / valide et reconnue ;
- **créance sur un compte non visible → traitée comme inconnue**, et ni le libellé ni le montant ni le nom de la section n'apparaissent ;
- le journal ne contient ni la communication ni le libellé ;
- saisie vide → on demande une communication, et rien n'est journalisé ;
- CSRF invalide sur chacun des deux POST.

Plus le plancher `intendant` de la route épinglé dans `FinanceRbacTest`.

Un `assert()` que PHPUnit ne peut pas compter est devenu un test explicite, qui se lit mieux de toute façon : un compte qui n'existe plus et un compte qu'on ne peut pas ouvrir sont la même réponse.

Portes : PHPStan `[OK]`, PHPUnit **10241**, `npm run typecheck`, Vitest 1467, Playwright 40 — toutes vertes. `main` n'avait pas bougé.

## Version de module

Aucune modification de `schema.sql`. Pas de bump.

## Documentation

`ARCHITECTURE.md` §8.73 (nouveau), `specifications.md` §30 (nouveau), et une fiche d'aide `outils-finance` — qui explique notamment pourquoi le générateur ne crée pas de paiement attendu, la question qu'un utilisateur se posera en premier.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGtfp6tsaMYej1Gi1sq5yu)_