### PR TITLE
finance: the last hand-formatted amount on the reconciliation screen

### DIFF
--- a/modules/finance/views/reconciliation.html.twig
+++ b/modules/finance/views/reconciliation.html.twig
@@ -9,6 +9,14 @@
   Nothing on this page is `danger`: a payment that lands awkwardly has not
   failed, it is waiting for somebody. Amber throughout, and the labels do
   the telling apart.
+
+  Every amount this page DISPLAYS goes through `|money_cents`. The three
+  remaining hand-written `number_format` calls are the `value:` of an
+  editable input and are deliberately not converted: `|money_cents`
+  appends « € » and a thin thousands separator, and a treasurer correcting
+  a split would be typing into a field pre-filled with a currency symbol
+  the form then has to parse back off. An input's value is a number, not
+  a rendered amount.
 #}
 
 {% block title %}Rapprochement — Finances — {{ site_name }}{% endblock %}
@@ -245,7 +253,7 @@
                                             type: 'select', size: 'sm', wrapper_class: 'mb-0',
                                             options: item.siblings|map(sibling => {
                                                 value: sibling.receivable_id,
-                                                label: sibling.name ~ ' — reste ' ~ (sibling.remaining_cents / 100)|number_format(2, ',', ' ') ~ ' €',
+                                                label: sibling.name ~ ' — reste ' ~ (sibling.remaining_cents|money_cents),
                                             }),
                                         } only %}
                                     </div>

--- a/tests/Modules/Finance/Controller/ReconciliationControllerTest.php
+++ b/tests/Modules/Finance/Controller/ReconciliationControllerTest.php
@@ -177,6 +177,25 @@ class ReconciliationControllerTest extends TestCase
         $this->assertStringContainsString('mouvement interne', $body);
     }
 
+    /**
+     * The overpaid tab offers the household's other receivables, and each
+     * option says what is still owed on it — the figure a treasurer picks
+     * on. It is rendered through `|money_cents` like every other displayed
+     * amount, so this pins the rendered string rather than the filter:
+     * the label read "45,00 €" before that conversion and must still.
+     */
+    public function testTheOverpaidTabNamesWhatIsStillOwedOnEachOtherReceivable(): void
+    {
+        $this->receivable('Lucie', 4500, '+++123/4567/89012+++');
+        $this->receivable('Antoine', 4500, '+++123/4567/89025+++');
+        $this->credit('VANDENBRANDE M +++123/4567/89012+++', 60.00);
+
+        $body = $this->controller->index($this->get(['tab' => 'overpaid']), [])->getBody();
+
+        $this->assertStringContainsString('Imputer sur une autre créance du foyer', $body);
+        $this->assertStringContainsString('Vandenbrande Antoine — reste 45,00 €', $body);
+    }
+
     // ── the gestures ────────────────────────────────────────────────────
 
     public function testConfirmingASplitAllocatesEachShare(): void


### PR DESCRIPTION
## Description

Found while re-reading the payment-campaigns work (IT-01 → IT-06, already on `main`) against the roadmap it was written from. The roadmap asks for that re-read explicitly, because visual conformance and French labels are the part the test suite does not defend.

Across the 95 files those six iterations touched, one displayed amount was still formatted by hand:

```twig
label: sibling.name ~ ' — reste ' ~ (sibling.remaining_cents / 100)|number_format(2, ',', ' ') ~ ' €',
```

`|money_cents` is `number_format($cents / 100, 2, ',', ' ') . ' €'`, so the rendered string is identical byte for byte — nothing moves on screen. What changes is that the Belgian money format has one implementation on this page as it does everywhere else.

**The three `number_format` calls that remain are deliberate** and stay: they are the `value:` of an editable input, where `|money_cents` would pre-fill the field with a currency symbol and a thin thousands separator the form then has to parse back off. An input's value is a number, not a rendered amount. The file's header comment now says this, so the next reader converting the page does not convert those too.

**The label had no rendering test.** The overpaid tab was covered for its gestures but never for what it draws, so the conversion was made against nothing. `testTheOverpaidTabNamesWhatIsStillOwedOnEachOtherReceivable` now pins the rendered string — it passed before this change too, which is the point: it is a regression pin, not a bug reproduction.

Everything else in the audit came back conformant: `partials/status_badge.html.twig` used throughout with « Impayée » as `pending` and no `danger` state anywhere on the module; table on desktop and a Bootstrap accordion on mobile; no inline `min-height`; no nested `.container`; no `<script>` block or `on*=` handler in a template; the QR encoding what is still due through `refreshAndSettle()`; the reminder body repeating IBAN, amount and communication in text under each QR.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 11 925 tests, 37 909 assertions, no failures)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — no errors)
- [x] If this PR changes `public/assets/js/` behavior: n/a — no JavaScript touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP7kMK42htkEDzXRzqaEtj

---
_Generated by [Claude Code](https://claude.ai/code/session_01JP7kMK42htkEDzXRzqaEtj)_