### PR TITLE
IT-07 — blocs argent et origine sur la fiche d'un membre

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1813,6 +1813,24 @@ The three site actions became three cards — the old « Données du site » hea
 
 `public/assets/js/member-search.js` now serves two screens instead of one, each section guarded on its own anchor — the export-selection conveniences find no anchor on the member's page, and the offset/departure controls find none on the search.
 
+### 8.62quater The money and the origin blocks (`Core\Module\MemberPaymentProvider`, `Core\Module\MemberRegistrationOriginProvider`)
+
+Two blocks of `/admin/members/{id}` that core declares and modules fill, both injected nullable into `AdminMemberPageService` (§7.4): a disabled module means the block is not built at all.
+
+**A second method on `MemberPaymentProvider`, not a parameter on the first.** `getOpenPayments()` is consumed by the member's own page and by the homepage band, and both want open receivables and nothing else; widening its signature would have rippled a change through callers that asked for nothing. So `getSettledPayments()` is the deliberate exception to "one hook, one method": two genuinely different questions. Only the admin page calls it — a parent has no need to re-read their 2023 transfers on their child's page.
+
+**Settled rows read through `settlementsFor()`**, not `refreshAndSettle()` and not `storedSettlementsFor()`, and the choice is not cosmetic. `refreshAndSettle()` *writes*: a page that reports history has no business re-allocating on every view. `storedSettlementsFor()` reads too little — it deliberately skips the credit scan, so `amountDesignatedCents` never exceeds what was absorbed. A receivable of 45 € paid 50 € would come back as exactly paid, and `STATUS_OVERPAYMENT_REFUNDED` could never be reached at all, which is the one outcome this block exists to surface. `settlementsFor()` is the full picture with no write; `FamilyPaymentServiceTest` pins both halves.
+
+**Core owns the outcome vocabulary**, not the module: `MemberSettledPaymentView::STATUS_PAID|STATUS_WAIVED|STATUS_OVERPAYMENT_REFUNDED`, because core's template has to pick a badge for each. The finance module maps its receivable states onto them, and a refunded surplus wins over "paid" — on its status alone such a row reads as simply paid, and « payé · 50,00 € » when 5,00 € went back out tells a chef d'unité the wrong thing about the money. The third outcome is worded « trop-perçu remboursé » rather than « remboursé »: the model records a returned *surplus*, never a wholly reversed payment, and the shorter word would claim the latter.
+
+**The cap lives on the interface** (`SETTLED_LIMIT`), so the page can say how many it is showing without guessing and a second implementation cannot answer at a different scale. `AdminMemberPageService` hands the template a `settled_payments_capped` flag: a truncated list read as a complete one is the failure mode here, so it is said on screen rather than left to be inferred.
+
+**`MemberRegistrationOriginProvider` is a pointer, never a copy.** It returns a label, a path and where the request ended up — nothing the parent typed. The request keeps its own page, built by the module that owns it; recopying three of its fields here would create a second place to keep in step with Desk, and `MemberRegistrationOriginServiceTest` asserts that no personal field travels with the link. The path comes from the module, so core never learns that `/config/inscriptions/demandes/{id}` is where a request lives. `registration_requests.linked_member_id` is unique, so there is never a list to choose from — and having no request at all is the ordinary answer for everyone imported from Desk before the module existed.
+
+It is a new interface rather than a method bolted onto one of the registration module's five existing `Api\` publications, none of which asks this question: adding "and also, where did this member come from" to a household counter or a scout-year veto would be exactly the tell-me-everything coupling §7.4 exists to prevent. The implementation sits in the module's `Service\`, not its `Api\`: `Api\` is where a module *publishes* an interface of its own (§7.5), and this one is core's.
+
+**`MemberSearchController` is registered late in the composition root**, after every module block, for the same reason `MemberController` already was: two of its blocks come from optional modules and neither is in scope earlier.
+
 ### 8.62ter Staff notes about a member (`Core\Member\MemberNoteService`)
 
 The « Notes internes » block of `/admin/members/{id}`. `registration_requests.internal_notes_encrypted` covers a *request* and stops the day it is accepted; nothing covered the person afterwards, which is the gap this fills.

--- a/core/Member/AdminMemberPageService.php
+++ b/core/Member/AdminMemberPageService.php
@@ -11,6 +11,11 @@ namespace Core\Member;
 use Core\Badge\Badge;
 use Core\Badge\MemberBadgeRepository;
 use Core\Config\ScoutYearService;
+use Core\Module\MemberPaymentProvider;
+use Core\Module\MemberPaymentView;
+use Core\Module\MemberRegistrationOriginProvider;
+use Core\Module\MemberRegistrationOriginView;
+use Core\Module\MemberSettledPaymentView;
 use Core\Photo\MemberPhotoService;
 
 /**
@@ -30,7 +35,20 @@ use Core\Photo\MemberPhotoService;
  *
  * The nullable-dependency pattern is the one §8.22 established: a block
  * whose provider is absent is simply not built, never an error and never
- * an empty card.
+ * an empty card. Three of them come from modules: what is still owed and
+ * what is already closed (Core\Module\MemberPaymentProvider, finance),
+ * and which registration request the person came from
+ * (Core\Module\MemberRegistrationOriginProvider, registration).
+ *
+ * **Closed payments are asked for, never mixed in.** They are history,
+ * not a task: putting them next to the open demands would drown the one
+ * or two lines that actually call for an action. So the template folds
+ * them away, and this service caps them — the complete payment history
+ * belongs to the finance module, which is built to page through it.
+ *
+ * **Having no open demand and no registration request is the ordinary
+ * case**, not an anomaly. Neither block is drawn at all rather than
+ * drawn empty with « aucune donnée ».
  *
  * **Two things this page must never show**, and the reasons are worth
  * keeping next to the code:
@@ -63,7 +81,9 @@ class AdminMemberPageService
         private SectionMembershipRepository $sectionMembershipRepository,
         private SectionService $sectionService,
         private ScoutYearService $scoutYearService,
-        private MemberEmailRepository $memberEmailRepository
+        private MemberEmailRepository $memberEmailRepository,
+        private ?MemberPaymentProvider $memberPaymentProvider = null,
+        private ?MemberRegistrationOriginProvider $registrationOriginProvider = null
     ) {
     }
 
@@ -73,17 +93,33 @@ class AdminMemberPageService
      *   badges: Badge[],
      *   functions: array<int, array{label: string, section: ?string, is_main: bool}>,
      *   section_history: array<int, array{scout_year_label: string, section_name: string, is_current: bool}>,
-     *   member_emails: array<int, array{address: string, status: string}>
+     *   member_emails: array<int, array{address: string, status: string}>,
+     *   open_payments: list<MemberPaymentView>,
+     *   settled_payments: list<MemberSettledPaymentView>,
+     *   settled_payments_capped: bool,
+     *   registration_origin: ?MemberRegistrationOriginView
      * }
      */
     public function buildPageData(MemberProfile $profile, int $scoutYearId): array
     {
+        // Both keyed on the PERSISTENT member id: a debt does not expire
+        // when the scout year turns, and a registration request produced
+        // a person rather than one year's row.
+        $settled = $this->memberPaymentProvider?->getSettledPayments($profile->memberId) ?? [];
+
         return [
             'photo_file_id' => $this->memberPhotoService->resolveFileId($profile->memberId, $scoutYearId),
             'badges' => $this->memberBadgeRepository->getActiveBadgesForMemberYear($profile->memberYearId),
             'functions' => $this->buildFunctions($profile),
             'section_history' => $this->buildSectionHistory($profile->memberId, $scoutYearId),
             'member_emails' => $this->buildReadOnlyEmails($profile),
+            'open_payments' => $this->memberPaymentProvider?->getOpenPayments($profile->memberId) ?? [],
+            'settled_payments' => $settled,
+            // Said on screen rather than left to be inferred: a member of
+            // ten years has more closed rows than this page shows, and a
+            // silently truncated list reads as a complete one.
+            'settled_payments_capped' => count($settled) >= MemberPaymentProvider::SETTLED_LIMIT,
+            'registration_origin' => $this->registrationOriginProvider?->getRegistrationOrigin($profile->memberId),
         ];
     }
 

--- a/core/Module/MemberPaymentProvider.php
+++ b/core/Module/MemberPaymentProvider.php
@@ -25,6 +25,14 @@ namespace Core\Module;
 interface MemberPaymentProvider
 {
     /**
+     * How many closed rows getSettledPayments() may return. On the
+     * interface rather than in the module, so the page can say « les 20
+     * plus récents » without guessing, and a second implementation
+     * cannot quietly answer at a different scale.
+     */
+    public const SETTLED_LIMIT = 20;
+
+    /**
      * Everything this member still owes, most recent first, or an empty
      * list when they owe nothing.
      *
@@ -37,4 +45,29 @@ interface MemberPaymentProvider
      * @return list<MemberPaymentView>
      */
     public function getOpenPayments(int $memberId): array;
+
+    /**
+     * The demands that are over — paid, abandoned, refunded — most
+     * recent first, capped at self::SETTLED_LIMIT.
+     *
+     * **A second method rather than a parameter on the first**, and that
+     * is the decision worth writing down. `getOpenPayments()` is already
+     * consumed by the member's own page and by the homepage band, and
+     * both want open receivables and nothing else. Widening its
+     * signature would ripple a change through callers that asked for
+     * nothing — so this is the deliberate exception to the "one hook,
+     * one method" rule: two genuinely different questions, two methods.
+     *
+     * **Only the admin member page calls this.** A parent reading their
+     * child's page does not need to re-read their 2023 transfers, and
+     * mixing closed rows into the open ones would drown the two lines
+     * that actually call for an action.
+     *
+     * Capped because a member present for ten years accumulates dozens
+     * of closed rows, and this page is a summary: the complete payment
+     * history belongs to the finance module, which is built for it.
+     *
+     * @return list<MemberSettledPaymentView>
+     */
+    public function getSettledPayments(int $memberId): array;
 }

--- a/core/Module/MemberRegistrationOriginProvider.php
+++ b/core/Module/MemberRegistrationOriginProvider.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module;
+
+/**
+ * Optional hook a module can implement to say which registration request
+ * a member came from, so the admin member page can link back to it
+ * without core depending on the module. Same precedent as
+ * Core\Module\FormationPathProvider (ARCHITECTURE.md §7.4).
+ *
+ * **Why a new interface and not one of the module's existing ones.** The
+ * registration module already publishes five `Api\` interfaces
+ * (§7.5) and none of them answers this question: they count households,
+ * feed the scout-year workflow, veto a transition, expose a mailing
+ * list, trigger a reconciliation. Adding "and also, where did this member
+ * come from" to any of them would be the generic
+ * tell-me-everything-about-this-member coupling §7.4 exists to prevent.
+ * One question, one method, `int $memberId` in.
+ *
+ * **This hook decides nothing about who may look.** The admin member
+ * page is `role_min: admin` and so is the request page it links to, so
+ * a reader who can see the link can always open it. A provider that
+ * re-derived its own audience would be a second answer waiting to
+ * disagree with the router's.
+ */
+interface MemberRegistrationOriginProvider
+{
+    /**
+     * The request this member was created from, or null when there is
+     * none — which is the ORDINARY case, not an anomaly: every member
+     * imported from Desk before the module existed, and every member
+     * who joined any other way, has no request. The page shows nothing
+     * at all in that case rather than an empty block.
+     *
+     * The id is a `members.id`, the persistent identity, like everywhere
+     * else: a request produced a person, not a scout year's row.
+     */
+    public function getRegistrationOrigin(int $memberId): ?MemberRegistrationOriginView;
+}

--- a/core/Module/MemberRegistrationOriginView.php
+++ b/core/Module/MemberRegistrationOriginView.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module;
+
+/**
+ * The registration request a member came from — a pointer, not a copy.
+ *
+ * Deliberately carries no field of the request itself. The request has
+ * its own page, built by the module that owns it, and duplicating even
+ * three of its fields here would create a second place to keep in step
+ * with Desk. What the admin member page needs is one line saying "this
+ * person arrived through a request, here it is".
+ *
+ * `path` is the module's own route, supplied by the module: core links
+ * to it without ever learning that `/config/inscriptions/demandes/{id}`
+ * is where a request lives.
+ */
+final class MemberRegistrationOriginView
+{
+    /**
+     * @param string $label       how to name it, e.g. "Demande du 14/03/2025"
+     * @param string $path        site-absolute path of the request's page
+     * @param string $statusLabel where the request ended up, in the module's
+     *        own words — a member can exist while their request reads
+     *        "encodée", and saying which is the point of showing it
+     */
+    public function __construct(
+        public readonly string $label,
+        public readonly string $path,
+        public readonly string $statusLabel,
+    ) {
+    }
+}

--- a/core/Module/MemberSettledPaymentView.php
+++ b/core/Module/MemberSettledPaymentView.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module;
+
+/**
+ * One payment demand that is over, as the admin member page draws it.
+ *
+ * Deliberately a different DTO from Core\Module\MemberPaymentView rather
+ * than the same one with its payment details left null. That view exists
+ * to be ACTED on — it carries an IBAN, a communication and a QR code,
+ * and everything in it answers "how do I pay this". None of that means
+ * anything for a demand that is closed, and a settled row rendered
+ * through it would offer a parent a code to scan for money already paid.
+ *
+ * What a closed row needs instead is what this one carries: what it was
+ * for, what was asked, what arrived, how it ended and when.
+ *
+ * `status` is one of the three constants below rather than the finance
+ * module's own vocabulary: core owns the template and therefore has to
+ * pick a badge for each outcome, so the set of outcomes has to be
+ * core's. The module maps its receivable states onto them.
+ */
+final class MemberSettledPaymentView
+{
+    /** The money arrived. */
+    public const STATUS_PAID = 'paid';
+    /** The unit gave up on it — abandoned, never collected. */
+    public const STATUS_WAIVED = 'waived';
+    /**
+     * More money arrived than was asked for, and the surplus has been
+     * paid back. Worded precisely because "remboursé" alone would say
+     * the whole payment came back, which is a different fact and not one
+     * this model records.
+     */
+    public const STATUS_OVERPAYMENT_REFUNDED = 'overpayment_refunded';
+
+    /**
+     * @param string $label            what it was for, e.g. "Cotisation 2024-2025"
+     * @param int $amountDueCents      what was asked for
+     * @param int $amountReceivedCents what actually arrived — can exceed the
+     *        amount due, and on a refunded row that surplus is the point
+     * @param self::STATUS_* $status   how it ended
+     * @param \DateTimeImmutable|null $settledOn when it ended, null when the
+     *        module cannot date the outcome (an old row, a waiver recorded
+     *        before the column existed) — a missing date is shown as absent,
+     *        never as today
+     */
+    public function __construct(
+        public readonly string $label,
+        public readonly int $amountDueCents,
+        public readonly int $amountReceivedCents,
+        public readonly string $status,
+        public readonly ?\DateTimeImmutable $settledOn,
+    ) {
+    }
+}

--- a/core/View/templates/admin/members/show.html.twig
+++ b/core/View/templates/admin/members/show.html.twig
@@ -256,6 +256,94 @@
                 </section>
             {% endif %}
 
+            {# Argent — alimenté par Core\Module\MemberPaymentProvider, que
+               le module finance implémente. Le bloc n'existe pas du tout si
+               le module est désactivé ou si la personne n'a jamais rien dû :
+               c'est le cas courant, pas une anomalie, et « aucune donnée »
+               n'apprendrait rien à personne.
+
+               Pas de QR ni d'IBAN ici, contrairement à la page du membre :
+               un chef d'unité regarde où en est un paiement, il ne le fait
+               pas à la place de la famille. Ce qui appelle une action est
+               en haut ; l'historique est replié. #}
+            {% if open_payments is not empty or settled_payments is not empty %}
+                <section class="card mb-3">
+                    <div class="card-header d-flex align-items-center gap-2">
+                        <i class="bi bi-cash-coin" aria-hidden="true"></i>
+                        <h2 class="h6 mb-0">Paiements</h2>
+                    </div>
+                    {% if open_payments is not empty %}
+                        <ul class="list-group list-group-flush">
+                            {% for payment in open_payments %}
+                                <li class="list-group-item d-flex justify-content-between align-items-start gap-3">
+                                    <span>
+                                        <span class="fw-medium">{{ payment.label }}</span>
+                                        <span class="d-block text-body-secondary small font-monospace">{{ payment.communication }}</span>
+                                        {% if payment.isPartiallyPaid %}
+                                            <span class="d-block text-body-secondary small">
+                                                {{ payment.amountReceivedCents|money_cents }} reçus sur {{ payment.amountDueCents|money_cents }}.
+                                            </span>
+                                        {% endif %}
+                                    </span>
+                                    <span class="text-end flex-shrink-0">
+                                        <span class="fw-semibold">{{ payment.amountRemainingCents|money_cents }}</span>
+                                        <span class="d-block">
+                                            {% include 'partials/status_badge.html.twig' with { status: 'pending', label: 'à payer' } only %}
+                                        </span>
+                                    </span>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+
+                    {% if settled_payments is not empty %}
+                        <div class="card-body {% if open_payments is not empty %}border-top{% endif %} py-2">
+                            <button class="btn btn-sm btn-outline-secondary w-100" type="button"
+                                    data-bs-toggle="collapse" data-bs-target="#member-settled-payments"
+                                    aria-expanded="false" aria-controls="member-settled-payments">
+                                Voir les paiements clôturés ({{ settled_payments|length }})
+                            </button>
+                        </div>
+                        <div class="collapse" id="member-settled-payments">
+                            <ul class="list-group list-group-flush border-top">
+                                {% for payment in settled_payments %}
+                                    <li class="list-group-item d-flex justify-content-between align-items-start gap-3">
+                                        <span>
+                                            <span class="fw-medium">{{ payment.label }}</span>
+                                            {% if payment.settledOn %}
+                                                <span class="d-block text-body-secondary small">{{ payment.settledOn|date('d/m/Y') }}</span>
+                                            {% endif %}
+                                        </span>
+                                        <span class="text-end flex-shrink-0">
+                                            <span class="text-body-secondary">{{ payment.amountReceivedCents|money_cents }}</span>
+                                            <span class="d-block">
+                                                {% if payment.status == 'paid' %}
+                                                    {% include 'partials/status_badge.html.twig' with { status: 'confirmed', label: 'payé' } only %}
+                                                {% elseif payment.status == 'overpayment_refunded' %}
+                                                    {% include 'partials/status_badge.html.twig' with { status: 'cancelled', label: 'trop-perçu remboursé' } only %}
+                                                {% else %}
+                                                    {% include 'partials/status_badge.html.twig' with { status: 'inactive', label: 'abandonné' } only %}
+                                                {% endif %}
+                                            </span>
+                                        </span>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                            {% if settled_payments_capped %}
+                                {# Dit plutôt que sous-entendu : une liste tronquée
+                                   en silence se lit comme une liste complète. #}
+                                <div class="card-body pt-2">
+                                    <p class="small text-body-secondary mb-0">
+                                        Les {{ settled_payments|length }} plus récents. L'historique complet est dans
+                                        le module Finance.
+                                    </p>
+                                </div>
+                            {% endif %}
+                        </div>
+                    {% endif %}
+                </section>
+            {% endif %}
+
             {% if section_history is not empty %}
                 <section class="card mb-3">
                     <div class="card-header d-flex align-items-center gap-2">
@@ -273,6 +361,31 @@
                             {% endfor %}
                         </ol>
                     </div>
+                </section>
+            {% endif %}
+
+            {# D'où vient cette personne — un lien, jamais une copie. La
+               demande garde sa propre page, construite par le module qui la
+               possède ; en recopier trois champs ici créerait un second
+               endroit à tenir à jour. Les deux pages sont role_min: admin,
+               donc quiconque voit ce lien peut l'ouvrir.
+
+               Absent pour un membre importé de Desk avant l'existence du
+               module, ou arrivé autrement : c'est le cas courant. #}
+            {% if registration_origin %}
+                <section class="card mb-3">
+                    <div class="card-header d-flex align-items-center gap-2">
+                        <i class="bi bi-signpost-split" aria-hidden="true"></i>
+                        <h2 class="h6 mb-0">Demande d'inscription d'origine</h2>
+                    </div>
+                    <a href="{{ registration_origin.path }}"
+                       class="card-body d-flex align-items-center gap-3 text-decoration-none text-body">
+                        <span class="flex-grow-1">
+                            <span class="fw-medium d-block">{{ registration_origin.label }}</span>
+                            <span class="text-body-secondary small">{{ registration_origin.statusLabel }}</span>
+                        </span>
+                        <i class="bi bi-chevron-right text-body-secondary flex-shrink-0" aria-hidden="true"></i>
+                    </a>
                 </section>
             {% endif %}
 

--- a/docs/help/fiche-membre-admin.md
+++ b/docs/help/fiche-membre-admin.md
@@ -1,7 +1,7 @@
 ---
 id: fiche-membre-admin
 title: La fiche d'un membre
-summary: Ce que le site sait d'une personne, et les trois actions qu'on y trouve.
+summary: Ce que le site sait d'une personne, et les actions qu'on y trouve.
 category: Espace chefs d'U
 role_min: admin
 paths: /admin/members/*
@@ -24,11 +24,19 @@ membre y figurent aussi : lui seul les gère.
 
 ## Ce que le site sait
 
-La photo, les badges de l'année, les fonctions de l'année, et le
-**parcours dans l'unité** : chaque section où la personne est passée,
-année par année.
+La photo, les badges et les fonctions de l'année, et le **parcours dans
+l'unité** : chaque section où la personne est passée, année par année.
 
-## Les trois actions
+Si le module Cotisations est actif, les **paiements** : ce qui reste dû
+d'abord, l'historique replié en dessous. Vous y lisez où en est un
+paiement ; c'est la page du membre, elle, qui porte le QR et l'IBAN.
+Enfin, un lien vers la **demande d'inscription d'origine**, s'il y en a
+une.
+
+Les documents privés d'un membre n'apparaissent pas ici : ils restent
+accessibles au seul membre, sans contournement possible par le staff.
+
+## Les actions
 
 - **Année dans la branche** : « −1 an », « Normal » ou « +1 an », pour
   un enfant maintenu ou avancé d'un an. Le choix s'enregistre aussitôt
@@ -37,10 +45,10 @@ année par année.
 - **Départ** : la même case que sur la page Départs, avec un
   commentaire facultatif. Disponible pour tout membre trouvé, animateurs
   compris.
-- **Voir le site à sa place** : vous fait voir le site comme ce membre
-  le voit, le temps de votre session — utile pour comprendre un problème
-  qu'une famille signale. Un bandeau le rappelle sur chaque page, et
-  « Retirer » ou la déconnexion annule tout.
+- **Voir le site à sa place** : vous agissez réellement au nom du
+  membre, jusqu'à ses adresses e-mail, le temps de votre session. Un
+  bandeau le rappelle sur chaque page, « Retirer » ou la déconnexion
+  annule tout, et chaque activation est consignée au journal.
 
 ## Les notes internes
 
@@ -53,12 +61,6 @@ Tout chef d'unité peut corriger ou supprimer n'importe quelle note, y
 compris celle d'un autre : une note écrite par erreur sur la mauvaise
 personne doit pouvoir disparaître. L'auteur et la date restent affichés.
 
-Les documents privés d'un membre n'apparaissent pas ici : ils restent
-accessibles au seul membre, sans contournement possible par le staff.
-
 > Ces notes ne sont jamais visibles par le membre ni par ses parents, et
 > ne figurent dans aucun export. Un animateur de section n'y a pas accès
 > non plus : elles restent au niveau de l'unité.
-
-Pendant cet accès, vous agissez réellement au nom du membre, jusqu'à ses
-adresses e-mail, et chaque activation est consignée au journal.

--- a/docs/module-development.md
+++ b/docs/module-development.md
@@ -496,6 +496,37 @@ Three rules, and the first is why this is not `DeskImportListener`:
 
 Each point carries four things, and they are the four a reader needs: what is wrong, why it matters, what to do about it, and — when there is one — by when. Write `why` as the consequence, never a restatement of the title.
 
+## Filling a block on a member's page (`Core\Module\…Provider`)
+
+Two core pages consolidate what the site knows about one person — a member's own page (`/members/{id}`) and the Staff d'Unité's page for them (`/admin/members/{id}`). Neither knows anything about your module. Each block they can show comes from a small interface core declares (ARCHITECTURE.md §7.4), which your module optionally implements; the composition root injects it **nullable**, so a disabled module means the block is not built at all — never an error, never an empty card.
+
+The ones that exist today:
+
+| Interface | Answers | Shown on |
+|---|---|---|
+| `Core\Module\FormationPathProvider` | where this animateur is in their training | the member's own page, self only |
+| `Core\Module\MemberPaymentProvider` | `getOpenPayments()` — what is still owed | both pages |
+| `Core\Module\MemberPaymentProvider` | `getSettledPayments()` — what is over, capped at `SETTLED_LIMIT`, most recent first | the admin page only |
+| `Core\Module\MemberRegistrationOriginProvider` | which registration request this member came from | the admin page only |
+| `Core\Module\SectionResponsableProvider` | who runs this member's section | the member's own page |
+
+Before writing a new one, check whether one of these already asks your question. The shape to copy, when none does:
+
+```php
+interface MyThingProvider
+{
+    public function getMyThing(int $memberId): ?MyThingView;   // or list<MyThingView>
+}
+```
+
+- **One interface per module, one question per method.** Resist a generic "tell me everything about this member" hook: it becomes exactly the coupling point §7.4 exists to prevent, and the first module with nothing to say still has to implement it. `MemberPaymentProvider` carries two methods, and that is a deliberate exception with a reason: open and settled receivables are two genuinely different questions, and widening `getOpenPayments()` with a flag would have rippled through callers — the member's own page and the homepage band — that asked for nothing.
+- **The identifier is a `members.id`**, the persistent identity, never `member_years.id`. A debt does not expire when the scout year turns, and a registration request produced a person rather than one year's row.
+- **A read DTO beside the interface**, `public readonly` properties and no logic. Return `?XxxView` for one object, `list<XxxView>` for a collection, never an improvised associative array.
+- **Presentation-ready, in the module's own words.** Core owns the template but not the domain: hand over a label and an amount in cents, not your internal vocabulary. The exception is anything core has to *branch* on — a status that picks a badge colour — which is a small set of constants core declares, and your module maps onto.
+- **Say what `null` means** in the docblock: module absent, or no data. And treat "no data" as the ordinary case — most members owe nothing and came from no request, so the page draws nothing rather than « aucune donnée ».
+- **The hook decides nothing about who may look.** The page has already answered that. A provider that re-derived its own audience would be a second answer waiting to disagree with the router's.
+- **The implementation lives in your module's `Service\`, not its `Api\`.** `Api\` is where a module *publishes* an interface of its own for others to consume (§7.5); here the interface is core's and you are implementing it (§7.4). Wiring it is one nullable argument in the composition root, inside your module's own `if (in_array('my_module', …))` block.
+
 ## Accessing core services
 
 Module controllers receive whatever services they need via constructor injection — there is no fixed list. The composition root (`public/index.php`) is where every controller is actually built and registered: inside the module's `if (in_array('my_module', $moduleManager->getEnabledModuleIds(), true)) { ... }` block, construct the module's repositories/services (passing `$pdo`/`$connection`, `$encryptionService`, `$mailService`, `$schedulerService`, `$sectionService`, or any other already-built core service the module needs), then `$frontController->registerController(MyModuleController::class, new MyModuleController($twig, ...))`. See any existing module block in `public/index.php` for the pattern.

--- a/modules/finance/src/Api/FamilyPaymentService.php
+++ b/modules/finance/src/Api/FamilyPaymentService.php
@@ -12,10 +12,12 @@ use Core\Member\MemberService;
 use Core\Module\HomePaymentDueProvider;
 use Core\Module\MemberPaymentProvider;
 use Core\Module\MemberPaymentView;
+use Core\Module\MemberSettledPaymentView;
 use Core\ScoutYear\ScoutYearResolver;
 use Core\ScoutYear\ScoutYearSession;
 use Core\Security\AuthSession;
 use Core\Security\Role;
+use Core\Service\DateInput;
 use Modules\Finance\Repository\AccountRepository;
 use Modules\Finance\Repository\CampaignRepository;
 use Modules\Finance\Repository\CampaignRowRepository;
@@ -26,6 +28,7 @@ use Modules\Finance\Service\CampaignService;
 use Modules\Finance\Service\IbanNormalizer;
 use Modules\Finance\Service\ReceivableAllocationService;
 use Modules\Finance\Service\ReceivableQrTokenService;
+use Modules\Finance\Service\ReceivableSettlement;
 
 /**
  * This module's answer to core's two family-facing hooks: the payment
@@ -84,7 +87,7 @@ class FamilyPaymentService implements MemberPaymentProvider, HomePaymentDueProvi
             return [];
         }
 
-        $labels = $this->labelsFor($open);
+        $labels = $this->labelsFor(array_column($open, 'receivable'));
 
         $views = [];
         foreach ($open as $entry) {
@@ -111,6 +114,94 @@ class FamilyPaymentService implements MemberPaymentProvider, HomePaymentDueProvi
         // Most recent first: the receivable somebody is being asked about
         // today is the one created last, not the one from two years ago.
         return array_reverse($views);
+    }
+
+    /**
+     * The other half of Core\Module\MemberPaymentProvider: what is over.
+     *
+     * Reads through settlementsFor(), NOT refreshAndSettle() and not
+     * storedSettlementsFor(). refreshAndSettle() writes: a page that only
+     * reports history has no business re-allocating on every view.
+     * storedSettlementsFor() reads too little — it deliberately skips the
+     * credit scan, so `amountDesignatedCents` never exceeds what was
+     * absorbed and a surplus is invisible. That would report a
+     * receivable overpaid by 5,00 € as exactly paid and could never
+     * reach STATUS_OVERPAYMENT_REFUNDED at all, which is the one thing
+     * this block exists to make visible. settlementsFor() is the full
+     * picture with no write.
+     *
+     * @return list<MemberSettledPaymentView>
+     */
+    public function getSettledPayments(int $memberId): array
+    {
+        $receivables = $this->receivables->findByMemberIds([$memberId]);
+        if ($receivables === []) {
+            return [];
+        }
+
+        $settlements = $this->allocations->settlementsFor($receivables);
+
+        $settled = [];
+        foreach ($receivables as $receivable) {
+            $settlement = $settlements[$receivable->id] ?? null;
+            if ($settlement === null || !$settlement->isSettled()) {
+                continue;
+            }
+            $settled[] = ['receivable' => $receivable, 'settlement' => $settlement];
+        }
+        if ($settled === []) {
+            return [];
+        }
+
+        $labels = $this->labelsFor(array_column($settled, 'receivable'));
+
+        $views = [];
+        foreach ($settled as $entry) {
+            $receivable = $entry['receivable'];
+            $settlement = $entry['settlement'];
+
+            $views[] = new MemberSettledPaymentView(
+                $labels[$receivable->id] ?? $receivable->label ?? 'Paiement demandé',
+                $receivable->amountDueCents,
+                $settlement->amountDesignatedCents,
+                self::outcomeOf($settlement),
+                // A waiver is dated by the waiver; anything else by the
+                // row itself. requireFromStorage() is not used here: an
+                // unreadable date makes the outcome undated on screen,
+                // which is honest, where a 500 would take the whole page
+                // down over one old row.
+                DateInput::fromStorage($receivable->waivedAt ?? $receivable->createdAt)
+            );
+        }
+
+        // Most recent first, then capped: the newest closed rows are the
+        // ones somebody is being asked about, and a member of ten years
+        // has dozens. The complete history lives in the finance module,
+        // which is built to page through it.
+        $views = array_reverse($views);
+
+        return array_slice($views, 0, MemberPaymentProvider::SETTLED_LIMIT);
+    }
+
+    /**
+     * Which of core's three outcomes a settlement is.
+     *
+     * A refunded surplus wins over "paid", deliberately: on its status
+     * alone such a row reads as simply paid, and a chef d'unité looking
+     * at « payé · 50,00 € » when 5,00 € of it went back out is being
+     * told the wrong thing about the money.
+     *
+     * @return MemberSettledPaymentView::STATUS_*
+     */
+    private static function outcomeOf(ReceivableSettlement $settlement): string
+    {
+        if ($settlement->refundState === ReceivableSettlement::REFUND_DONE) {
+            return MemberSettledPaymentView::STATUS_OVERPAYMENT_REFUNDED;
+        }
+
+        return $settlement->isWaived()
+            ? MemberSettledPaymentView::STATUS_WAIVED
+            : MemberSettledPaymentView::STATUS_PAID;
     }
 
     /**
@@ -169,7 +260,7 @@ class FamilyPaymentService implements MemberPaymentProvider, HomePaymentDueProvi
             return null;
         }
 
-        $labels = $this->labelsFor($open);
+        $labels = $this->labelsFor(array_column($open, 'receivable'));
 
         $total = 0;
         $demands = [];
@@ -264,15 +355,15 @@ class FamilyPaymentService implements MemberPaymentProvider, HomePaymentDueProvi
      * own label, which is what the treasurer typed and what the reminder
      * mail says.
      *
-     * @param list<array{receivable: ExpectedReceivable, remaining_cents: int, received_cents: int}> $open
+     * @param list<ExpectedReceivable> $receivables
      * @return array<int, string> receivable id => label
      */
-    private function labelsFor(array $open): array
+    private function labelsFor(array $receivables): array
     {
         $rowIds = [];
-        foreach ($open as $entry) {
-            if ($entry['receivable']->sourceModule === CampaignService::SOURCE_MODULE) {
-                $rowIds[] = $entry['receivable']->sourceReferenceId;
+        foreach ($receivables as $receivable) {
+            if ($receivable->sourceModule === CampaignService::SOURCE_MODULE) {
+                $rowIds[] = $receivable->sourceReferenceId;
             }
         }
         if ($rowIds === []) {
@@ -293,8 +384,7 @@ class FamilyPaymentService implements MemberPaymentProvider, HomePaymentDueProvi
         }
 
         $labels = [];
-        foreach ($open as $entry) {
-            $receivable = $entry['receivable'];
+        foreach ($receivables as $receivable) {
             if ($receivable->sourceModule !== CampaignService::SOURCE_MODULE) {
                 continue;
             }

--- a/modules/registration/src/Repository/RegistrationRequest.php
+++ b/modules/registration/src/Repository/RegistrationRequest.php
@@ -27,6 +27,17 @@ final class RegistrationRequest
      */
     public const FINAL_STATUSES = [self::STATUS_ENCODED, self::STATUS_REFUSED, self::STATUS_WITHDRAWN];
 
+    /**
+     * @var array<string, string>
+     */
+    public const STATUS_LABELS = [
+        self::STATUS_PENDING => 'En attente',
+        self::STATUS_ACCEPTED => 'Acceptée',
+        self::STATUS_REFUSED => 'Refusée',
+        self::STATUS_WITHDRAWN => 'Retirée',
+        self::STATUS_ENCODED => 'Encodée dans Desk',
+    ];
+
     public function __construct(
         public readonly int $id,
         public readonly int $scoutYearId,
@@ -68,5 +79,19 @@ final class RegistrationRequest
     public function isFinal(): bool
     {
         return in_array($this->status, self::FINAL_STATUSES, true);
+    }
+
+    /**
+     * How a status reads to a chef d'unité. Here rather than in each
+     * consumer because there were already two copies of this table — the
+     * spreadsheet export's and the status badge's — and a third would
+     * have been the one that drifts.
+     *
+     * Falls back to the raw value rather than to an empty string: a
+     * status nobody has worded yet should be visible, not invisible.
+     */
+    public function statusLabel(): string
+    {
+        return self::STATUS_LABELS[$this->status] ?? $this->status;
     }
 }

--- a/modules/registration/src/Service/MemberRegistrationOriginService.php
+++ b/modules/registration/src/Service/MemberRegistrationOriginService.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Registration\Service;
+
+use Core\Module\MemberRegistrationOriginProvider;
+use Core\Module\MemberRegistrationOriginView;
+use Modules\Registration\Repository\RegistrationRequestRepository;
+
+/**
+ * This module's answer to core's "where did this member come from" hook
+ * (Core\Module\MemberRegistrationOriginProvider, ARCHITECTURE.md §7.4).
+ *
+ * Lives under Service\, not Api\, and the distinction is the one §7.4
+ * and §7.5 draw: `Api\` is where a module PUBLISHES a capability others
+ * may want to consume, defining the interface itself. Here the interface
+ * is core's and this class merely implements it — an ordinary module
+ * service, wired nullable by the composition root.
+ *
+ * **A pointer, never a copy.** It hands back a label, a path and where
+ * the request ended up, and nothing else — not the parent's name, not
+ * the address, not the internal notes. The request has its own page,
+ * built by the code that owns it; recopying three of its fields onto the
+ * member page would create a second place to keep in step.
+ *
+ * `registration_requests.linked_member_id` is unique, so a member is the
+ * target of at most one request and there is never a list to choose
+ * from.
+ */
+class MemberRegistrationOriginService implements MemberRegistrationOriginProvider
+{
+    /** The module's own route — core never learns this string. */
+    private const REQUEST_PATH_PREFIX = '/config/inscriptions/demandes/';
+
+    public function __construct(private RegistrationRequestRepository $requests)
+    {
+    }
+
+    public function getRegistrationOrigin(int $memberId): ?MemberRegistrationOriginView
+    {
+        $request = $this->requests->findByLinkedMemberId($memberId);
+        if ($request === null) {
+            return null;
+        }
+
+        return new MemberRegistrationOriginView(
+            'Demande du ' . $request->receivedAt->format('d/m/Y'),
+            self::REQUEST_PATH_PREFIX . $request->id,
+            $request->statusLabel()
+        );
+    }
+}

--- a/modules/registration/src/Service/RequestExportService.php
+++ b/modules/registration/src/Service/RequestExportService.php
@@ -42,14 +42,6 @@ use Modules\Registration\Repository\RegistrationRequest;
  */
 final class RequestExportService
 {
-    private const STATUS_LABELS = [
-        RegistrationRequest::STATUS_PENDING => 'En attente',
-        RegistrationRequest::STATUS_ACCEPTED => 'Acceptée',
-        RegistrationRequest::STATUS_REFUSED => 'Refusée',
-        RegistrationRequest::STATUS_WITHDRAWN => 'Retirée',
-        RegistrationRequest::STATUS_ENCODED => 'Encodée dans Desk',
-    ];
-
     /**
      * @return array<int, string>
      */
@@ -99,7 +91,7 @@ final class RequestExportService
 
             $sheetRows[] = [
                 $registrationRequest->receivedAt->format('d/m/Y'),
-                self::STATUS_LABELS[$registrationRequest->status] ?? $registrationRequest->status,
+                $registrationRequest->statusLabel(),
                 $registrationRequest->childLastName,
                 $registrationRequest->childFirstName,
                 $this->frenchDate($registrationRequest->birthDate),

--- a/public/index.php
+++ b/public/index.php
@@ -2127,6 +2127,12 @@ $newsArticleService = null;
 $homePaymentDueProvider = null;
 $memberPaymentProvider = null;
 
+// The admin member page's "demande d'inscription d'origine" line
+// (ARCHITECTURE.md §7.4), set in registration's block below and null when
+// that module is disabled — the line then simply does not render, which
+// is also what a member who never came through a request gets.
+$memberRegistrationOriginProvider = null;
+
 // Optional dependency on the calendar module (ARCHITECTURE.md §7.5) for
 // the member page's "next upcoming event" (§3) — set below only when
 // 'calendar' is enabled, same pattern as $sectionResponsableProvider
@@ -2281,19 +2287,6 @@ $uploadController->setJournalService($journalService);
 $frontController->registerController(UploadController::class, $uploadController);
 $frontController->registerController(\Core\Http\Controller\PwaController::class, new \Core\Http\Controller\PwaController($twig, $settingService, $unitLogoService));
 $frontController->registerController(JournalController::class, new JournalController($twig, $journalRepo, $userAccountRepo));
-$frontController->registerController(MemberSearchController::class, new MemberSearchController(
-    $twig, $memberSearchService, $memberService, $scoutYearResolver, $memberYearService, $departureService,
-    $memberExportRowBuilder, $memberExportService, $journalService,
-    new \Core\Member\AdminMemberPageService(
-        $memberBadgeRepository, $memberPhotoService, $sectionMembershipRepository,
-        $sectionService, $scoutYearService, $memberEmailRepository
-    ),
-    $memberYearRepo,
-    new \Core\Member\MemberNoteService(
-        new \Core\Member\MemberNoteRepository($pdo, $encryptionService, $userAccountRepo),
-        $journalService
-    )
-));
 $frontController->registerController(TemporaryMemberController::class, new TemporaryMemberController($twig, $memberSearchService, $scoutYearResolver, $journalService));
 $frontController->registerController(SettingsController::class, new SettingsController($twig, $settingService, $journalService, $unitLogoService, $notificationService, $userAccountRepo));
 $frontController->registerController(SupportController::class, new SupportController(
@@ -3983,6 +3976,11 @@ if (in_array('registration', $moduleManager->getEnabledModuleIds(), true)) {
     );
     $registrationMenuHookService = new \Modules\Registration\Service\RegistrationMenuHookService($registrationTrackingService, $settingService);
 
+    // Which registration request a member came from, for the admin member
+    // page's origin line (ARCHITECTURE.md §7.4). A pointer only — the
+    // request keeps its own page, and nothing of its content is copied.
+    $memberRegistrationOriginProvider = new \Modules\Registration\Service\MemberRegistrationOriginService($registrationRequestRepo);
+
     // Iteration 5's staff-side services — status transitions, acceptance/
     // refusal emails, and the one migration path shared by automatic
     // reconciliation and manual linking. The Api\
@@ -4857,6 +4855,28 @@ if (
         new MemberController($twig, $memberService, $memberYearService, $journalService, $memberPageService, $departureService)
     );
 }
+
+// The admin member page, registered here rather than with the other core
+// controllers above for the same reason MemberController is: two of its
+// blocks come from optional modules — finance's open and closed payments
+// (via $memberPaymentProvider) and registration's origin link (via
+// $memberRegistrationOriginProvider) — and both are only in scope once
+// those modules' blocks have run. Each stays null when its module is
+// disabled, and the corresponding block is then not built at all.
+$frontController->registerController(MemberSearchController::class, new MemberSearchController(
+    $twig, $memberSearchService, $memberService, $scoutYearResolver, $memberYearService, $departureService,
+    $memberExportRowBuilder, $memberExportService, $journalService,
+    new \Core\Member\AdminMemberPageService(
+        $memberBadgeRepository, $memberPhotoService, $sectionMembershipRepository,
+        $sectionService, $scoutYearService, $memberEmailRepository,
+        $memberPaymentProvider, $memberRegistrationOriginProvider
+    ),
+    $memberYearRepo,
+    new \Core\Member\MemberNoteService(
+        new \Core\Member\MemberNoteRepository($pdo, $encryptionService, $userAccountRepo),
+        $journalService
+    )
+));
 
 // File access (/files/{id}) — built here, deliberately last, because
 // FileAccessGuard's ownership-checker registry must be complete before it

--- a/specifications.md
+++ b/specifications.md
@@ -181,6 +181,14 @@ Where it lives *is* the decision. On this page, at `role_min: admin`, so **only 
 
 **It is never visible to the member or their parents** — not on their page, not in an export meant for them, not as a mail-merge field. The admin export of `/admin/members` never gains this column either, although all its readers are chefs d'unité: an exported file leaves the site's protections, travels by e-mail, lands in a shared folder and outlives whoever produced it.
 
+**Les paiements.** Ce que la personne doit encore, et — repliés, jamais mêlés — ceux qui sont clos. Les deux viennent du module Cotisations/Finance ; sans lui, le bloc n'existe pas. Ce qui appelle une action est en haut, seul : y mêler l'historique noierait les une ou deux lignes qui demandent quelque chose.
+
+Pas de QR ni d'IBAN ici, contrairement à la page du membre : un chef d'unité regarde **où en est** un paiement, il ne le fait pas à la place de la famille. Une ligne close porte son issue — payé, abandonné, ou **trop-perçu remboursé**, dit précisément parce que « remboursé » laisserait croire que tout est reparti. La liste close est plafonnée aux plus récentes, et **le dit** : une liste tronquée en silence se lit comme une liste complète. L'historique complet reste dans le module Finance, qui est fait pour ça.
+
+**La demande d'inscription d'origine**, quand il y en a une : une ligne, un lien vers la demande, et où elle a abouti. Jamais une copie de son contenu — la demande garde sa page, et en recopier trois champs créerait un second endroit à tenir en phase avec Desk. Les deux pages sont `admin`, donc quiconque voit le lien peut l'ouvrir.
+
+**N'avoir ni créance ni demande d'origine est le cas courant**, pas une anomalie : rien ne s'affiche, plutôt qu'un bloc vide annonçant « aucune donnée ».
+
 **Two things are never on this page.** A member's **private documents**: `files.owner_member_id` carries an explicit guarantee (ARCHITECTURE.md §8.3) of no chief and no admin bypass, tax certificates will live there, and listing them here would revoke that guarantee in silence. And a **writable** secondary-address control, for the reason above.
 
 **Searching, and who it proposes.** The repository never filtered on `is_active` and the result has always carried the flag — what was missing was a way to narrow. The filter is **actifs** by default (what is wanted nine times out of ten), with *inactifs* and *tous* one tap away, and it travels with the query so a submit keeps it. The row is unchanged otherwise: the export checkbox, the initials pill, the totem after the first name, the section and function, and the status badge whose exact words stay « inscrit » / « non inscrit », never « actif ». **The two exports coexist** — the whole search, and the checked selection — and are never merged; both follow the filter the screen is showing.

--- a/tests/Core/Member/AdminMemberPageServiceTest.php
+++ b/tests/Core/Member/AdminMemberPageServiceTest.php
@@ -32,6 +32,9 @@ class AdminMemberPageServiceTest extends TestCase
     private AdminMemberPageService $service;
     private MemberService $memberService;
     private MemberEmailRepository $emailRepository;
+    private MemberBadgeRepository $badgeRepository;
+    private SectionService $sectionService;
+    private ScoutYearService $scoutYearService;
     private int $currentYearId;
     private int $pastYearId;
     private int $memberId;
@@ -60,6 +63,12 @@ class AdminMemberPageServiceTest extends TestCase
         $this->pdo->exec("INSERT INTO functions (desk_code, label, role, confirmed) VALUES ('TRES', 'Trésorier', 'chief', 1)");
         $secondFunctionId = (int) $this->pdo->lastInsertId();
 
+        // A decoy person, so members.id and member_years.id cannot be
+        // equal by accident. Half of what this page gets right is asking
+        // module hooks about the PERSON rather than about one year's row,
+        // and a fixture where both ids are 1 cannot tell the two apart.
+        $this->pdo->exec("INSERT INTO members (desk_id) VALUES ('D0')");
+
         $this->pdo->exec("INSERT INTO members (desk_id) VALUES ('D1')");
         $this->memberId = (int) $this->pdo->lastInsertId();
 
@@ -86,13 +95,31 @@ class AdminMemberPageServiceTest extends TestCase
         $badgeRepository = new MemberBadgeRepository($this->pdo);
         $this->emailRepository = new MemberEmailRepository($this->pdo, $this->enc);
 
-        $this->service = new AdminMemberPageService(
-            $badgeRepository,
+        $this->badgeRepository = $badgeRepository;
+        $this->sectionService = new SectionService($connection, $this->enc, $badgeRepository);
+        $this->scoutYearService = $scoutYearService;
+
+        $this->service = $this->serviceWith(null, null);
+    }
+
+    /**
+     * The same service, with whichever module providers the case needs.
+     * Both are nullable and both default to absent, which is what a site
+     * with finance and registration disabled runs.
+     */
+    private function serviceWith(
+        ?\Core\Module\MemberPaymentProvider $payments,
+        ?\Core\Module\MemberRegistrationOriginProvider $origin
+    ): AdminMemberPageService {
+        return new AdminMemberPageService(
+            $this->badgeRepository,
             new MemberPhotoService(new MemberPhotoRepository($this->pdo)),
             new SectionMembershipRepository($this->pdo),
-            new SectionService($connection, $this->enc, $badgeRepository),
-            $scoutYearService,
-            $this->emailRepository
+            $this->sectionService,
+            $this->scoutYearService,
+            $this->emailRepository,
+            $payments,
+            $origin
         );
     }
 
@@ -229,5 +256,142 @@ class AdminMemberPageServiceTest extends TestCase
             'INSERT INTO member_section_periods (member_id, section_id, scout_year_id, start_date, end_date) VALUES (?, ?, ?, ?, ?)'
         );
         $stmt->execute([$this->memberId, $sectionId, $scoutYearId, $start, $end]);
+    }
+
+    // ── the blocks optional modules contribute ─────────────────────────
+
+    /**
+     * The nullable-dependency rule (ARCHITECTURE.md §8.22): finance and
+     * registration disabled must mean no block, never an error and never
+     * an empty card.
+     */
+    public function testWithNoModulesAtAllThePageStillBuildsAndOffersNothing(): void
+    {
+        $data = $this->build();
+
+        $this->assertSame([], $data['open_payments']);
+        $this->assertSame([], $data['settled_payments']);
+        $this->assertFalse($data['settled_payments_capped']);
+        $this->assertNull($data['registration_origin']);
+    }
+
+    /**
+     * Both hooks take the PERSISTENT member id: a debt does not expire
+     * when the scout year turns, and a request produced a person rather
+     * than one year's row.
+     */
+    public function testBothHooksAreAskedAboutThePersonNotTheAnnualRow(): void
+    {
+        $payments = new class implements \Core\Module\MemberPaymentProvider {
+            public ?int $openAskedFor = null;
+            public ?int $settledAskedFor = null;
+
+            public function getOpenPayments(int $memberId): array
+            {
+                $this->openAskedFor = $memberId;
+
+                return [];
+            }
+
+            public function getSettledPayments(int $memberId): array
+            {
+                $this->settledAskedFor = $memberId;
+
+                return [];
+            }
+        };
+        $origin = new class implements \Core\Module\MemberRegistrationOriginProvider {
+            public ?int $askedFor = null;
+
+            public function getRegistrationOrigin(int $memberId): ?\Core\Module\MemberRegistrationOriginView
+            {
+                $this->askedFor = $memberId;
+
+                return null;
+            }
+        };
+
+        $this->serviceWith($payments, $origin)->buildPageData(
+            $this->memberService->getMemberProfile($this->memberYearId),
+            $this->currentYearId
+        );
+
+        $this->assertSame($this->memberId, $payments->openAskedFor);
+        $this->assertSame($this->memberId, $payments->settledAskedFor);
+        $this->assertSame($this->memberId, $origin->askedFor);
+        $this->assertNotSame($this->memberYearId, $this->memberId, 'the fixture must distinguish the two ids');
+    }
+
+    public function testWhatTheModulesAnswerReachesThePageUntouched(): void
+    {
+        $open = new \Core\Module\MemberPaymentView('Cotisation 2025-2026', 2500, 4500, 2000, '+++123+++', 'Unité', 'BE71', null);
+        $settled = new \Core\Module\MemberSettledPaymentView(
+            'Cotisation 2024-2025',
+            4500,
+            4500,
+            \Core\Module\MemberSettledPaymentView::STATUS_PAID,
+            new \DateTimeImmutable('2025-03-04')
+        );
+
+        $data = $this->serviceWith($this->paymentsAnswering([$open], [$settled]), null)->buildPageData(
+            $this->memberService->getMemberProfile($this->memberYearId),
+            $this->currentYearId
+        );
+
+        $this->assertSame([$open], $data['open_payments']);
+        $this->assertSame([$settled], $data['settled_payments']);
+        $this->assertFalse($data['settled_payments_capped']);
+    }
+
+    /**
+     * A truncated list read as a complete one is the failure mode here,
+     * so the page is told rather than left to infer it.
+     */
+    public function testAFullSettledListIsFlaggedAsCapped(): void
+    {
+        $settled = [];
+        for ($i = 0; $i < \Core\Module\MemberPaymentProvider::SETTLED_LIMIT; $i++) {
+            $settled[] = new \Core\Module\MemberSettledPaymentView(
+                'Demande ' . $i,
+                1000,
+                1000,
+                \Core\Module\MemberSettledPaymentView::STATUS_PAID,
+                null
+            );
+        }
+
+        $data = $this->serviceWith($this->paymentsAnswering([], $settled), null)->buildPageData(
+            $this->memberService->getMemberProfile($this->memberYearId),
+            $this->currentYearId
+        );
+
+        $this->assertTrue($data['settled_payments_capped']);
+    }
+
+    /**
+     * @param list<\Core\Module\MemberPaymentView> $open
+     * @param list<\Core\Module\MemberSettledPaymentView> $settled
+     */
+    private function paymentsAnswering(array $open, array $settled): \Core\Module\MemberPaymentProvider
+    {
+        return new class ($open, $settled) implements \Core\Module\MemberPaymentProvider {
+            /**
+             * @param list<\Core\Module\MemberPaymentView> $open
+             * @param list<\Core\Module\MemberSettledPaymentView> $settled
+             */
+            public function __construct(private array $open, private array $settled)
+            {
+            }
+
+            public function getOpenPayments(int $memberId): array
+            {
+                return $this->open;
+            }
+
+            public function getSettledPayments(int $memberId): array
+            {
+                return $this->settled;
+            }
+        };
     }
 }

--- a/tests/Modules/Finance/Api/FamilyPaymentServiceTest.php
+++ b/tests/Modules/Finance/Api/FamilyPaymentServiceTest.php
@@ -8,6 +8,8 @@ use Core\Database\Connection;
 use Core\Import\MemberYearRepository;
 use Core\Member\MemberService;
 use Core\Security\AuthSession;
+use Core\Module\MemberPaymentProvider;
+use Core\Module\MemberSettledPaymentView;
 use Core\Security\EncryptionService;
 use Modules\Finance\Api\FamilyPaymentService;
 use Modules\Finance\Repository\Account;
@@ -163,6 +165,118 @@ class FamilyPaymentServiceTest extends TestCase
             (new ReceivableQrTokenService($this->encryption))->urlFor($receivable->id, 'https://scoutmagic.test'),
             $payments[0]->qrUrl
         );
+    }
+
+    // ── what is over (the admin member page) ───────────────────────────
+
+    /**
+     * The other half of the hook. Deliberately a second method rather
+     * than a flag on getOpenPayments(): the member's own page and the
+     * homepage band both consume that one and want open receivables
+     * alone.
+     */
+    public function testAPaidDemandDisappearsFromTheOpenListAndAppearsInTheSettledOne(): void
+    {
+        $this->campaignWith([['Lucie', 4500]]);
+        $this->pay($this->memberIds['Lucie'], 45.00);
+
+        $service = $this->service();
+        $this->assertSame([], $service->getOpenPayments($this->memberIds['Lucie']));
+
+        $settled = $service->getSettledPayments($this->memberIds['Lucie']);
+        $this->assertCount(1, $settled);
+        $this->assertSame(MemberSettledPaymentView::STATUS_PAID, $settled[0]->status);
+        $this->assertSame(4500, $settled[0]->amountDueCents);
+        $this->assertSame(4500, $settled[0]->amountReceivedCents);
+        $this->assertSame('Cotisations 2025-2026', $settled[0]->label);
+    }
+
+    public function testAnAbandonedDemandReadsAsAbandonedAndNotAsPaid(): void
+    {
+        $this->campaignWith([['Lucie', 4500]]);
+        $receivable = $this->receivables->findByMemberIds([$this->memberIds['Lucie']])[0];
+        $this->receivables->setWaived($receivable->id, '2026-03-04 09:00:00', 7);
+
+        $settled = $this->service()->getSettledPayments($this->memberIds['Lucie']);
+
+        $this->assertCount(1, $settled);
+        $this->assertSame(MemberSettledPaymentView::STATUS_WAIVED, $settled[0]->status);
+        $this->assertSame(0, $settled[0]->amountReceivedCents);
+        // Dated by the waiver, not by the row: what the reader wants to
+        // know is when the unit gave up on it.
+        $this->assertSame('2026-03-04', $settled[0]->settledOn?->format('Y-m-d'));
+    }
+
+    /**
+     * A row that was overpaid and whose surplus has gone back out reads
+     * as simply "payé" on its status alone. Showing « payé · 50,00 € »
+     * when 5,00 € of it was returned tells a chef d'unité the wrong
+     * thing about the money, so the refunded surplus wins.
+     */
+    public function testASurplusPaidBackReadsAsRefundedRatherThanPaid(): void
+    {
+        $this->campaignWith([['Lucie', 4500]]);
+        $this->pay($this->memberIds['Lucie'], 50.00);
+        $this->refundSurplus($this->memberIds['Lucie'], 500);
+
+        $settled = $this->service()->getSettledPayments($this->memberIds['Lucie']);
+
+        $this->assertCount(1, $settled);
+        $this->assertSame(MemberSettledPaymentView::STATUS_OVERPAYMENT_REFUNDED, $settled[0]->status);
+    }
+
+    /**
+     * The same row before the surplus goes back: paid, because it is —
+     * the refund has not happened yet, and pre-announcing it would be a
+     * different lie.
+     */
+    public function testAnUnreturnedSurplusStillReadsAsPaid(): void
+    {
+        $this->campaignWith([['Lucie', 4500]]);
+        $this->pay($this->memberIds['Lucie'], 50.00);
+
+        $settled = $this->service()->getSettledPayments($this->memberIds['Lucie']);
+
+        $this->assertCount(1, $settled);
+        $this->assertSame(MemberSettledPaymentView::STATUS_PAID, $settled[0]->status);
+        $this->assertSame(5000, $settled[0]->amountReceivedCents);
+    }
+
+    public function testAnOpenDemandIsNeverInTheSettledList(): void
+    {
+        $this->campaignWith([['Lucie', 4500]]);
+        $this->pay($this->memberIds['Lucie'], 20.00);
+
+        $service = $this->service();
+        $this->assertCount(1, $service->getOpenPayments($this->memberIds['Lucie']));
+        $this->assertSame([], $service->getSettledPayments($this->memberIds['Lucie']));
+    }
+
+    public function testAMemberWhoNeverOwedAnythingGetsAnEmptyListRatherThanAnError(): void
+    {
+        $this->assertSame([], $this->service()->getSettledPayments($this->memberIds['Lucie']));
+    }
+
+    /**
+     * A member of ten years accumulates dozens of closed rows, and this
+     * page is a summary — the complete history belongs to the finance
+     * module, which is built to page through it. Most recent first, so
+     * what the cap drops is the oldest.
+     */
+    public function testTheSettledListIsCappedAndKeepsTheMostRecent(): void
+    {
+        $lines = [];
+        for ($i = 0; $i < MemberPaymentProvider::SETTLED_LIMIT + 3; $i++) {
+            $lines[] = ['Lucie', 100 + $i];
+        }
+        $this->campaignWith($lines);
+        foreach ($this->receivables->findByMemberIds([$this->memberIds['Lucie']]) as $receivable) {
+            $this->receivables->setWaived($receivable->id, '2026-03-04 09:00:00', 7);
+        }
+
+        $settled = $this->service()->getSettledPayments($this->memberIds['Lucie']);
+
+        $this->assertCount(MemberPaymentProvider::SETTLED_LIMIT, $settled);
     }
 
     // ── the homepage band ───────────────────────────────────────────────
@@ -365,6 +479,32 @@ class FamilyPaymentServiceTest extends TestCase
         // stored state without its own reconcile pass.
         FinanceTestHelper::allocationService($this->pdo, $this->encryption, $this->receivables)
             ->reconcileAccount($this->accountId);
+    }
+
+    /**
+     * The surplus really leaving the account: a debit naming the same
+     * receivable, attached to it as a refund. The state becomes
+     * "remboursé" because the money left, never because somebody ticked
+     * a box — Service\ReceivableAllocationService::allocateRefund().
+     */
+    private function refundSurplus(int $memberId, int $amountCents): void
+    {
+        $receivable = $this->receivables->findByMemberIds([$memberId])[0];
+        $transactionId = $this->transactions->create(
+            $this->accountId,
+            $this->scoutYearId,
+            'REFUND-' . $receivable->id,
+            '2026-03-01',
+            'Remboursement ' . $receivable->communication,
+            -($amountCents / 100),
+            null,
+            null,
+            'import',
+            null
+        );
+
+        FinanceTestHelper::allocationService($this->pdo, $this->encryption, $this->receivables)
+            ->allocateRefund($transactionId, $receivable->id, $amountCents, \Core\Security\Role::SUPERADMIN, null);
     }
 
     private function createMember(string $firstName, string $email): int

--- a/tests/Modules/Registration/Service/MemberRegistrationOriginServiceTest.php
+++ b/tests/Modules/Registration/Service/MemberRegistrationOriginServiceTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Registration\Service;
+
+use Modules\Registration\Service\MemberRegistrationOriginService;
+use Modules\Registration\Repository\RegistrationRequestRepository;
+use Core\Security\EncryptionService;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Registration\RegistrationTestHelper;
+
+/**
+ * Where a member came from, as the admin member page shows it.
+ *
+ * The cases worth pinning are the two that decide whether the block is
+ * honest: it points, it never copies; and having no request at all is
+ * the ordinary answer rather than a failure.
+ *
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class MemberRegistrationOriginServiceTest extends TestCase
+{
+    private \PDO $pdo;
+    private RegistrationRequestRepository $repository;
+    private MemberRegistrationOriginService $service;
+    private int $scoutYearId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        RegistrationTestHelper::createTables($this->pdo);
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->repository = new RegistrationRequestRepository($this->pdo, $encryption);
+        $this->service = new MemberRegistrationOriginService($this->repository);
+        $this->scoutYearId = RegistrationTestHelper::insertScoutYear($this->pdo, '2026-2027', '2026-09-01', '2027-08-31');
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function fields(array $overrides = []): array
+    {
+        return array_merge([
+            'parent_name' => 'Marie Dupont',
+            'child_last_name' => 'Dupont',
+            'child_first_name' => 'Léa',
+            'gender' => 'F',
+            'birth_date' => '2019-05-12',
+            'street' => 'Rue de la Paix',
+            'number' => '12',
+            'postal_code' => '1000',
+            'city' => 'Bruxelles',
+            'email' => 'marie.dupont@example.com',
+            'phone1' => '0470123456',
+            'phone2' => null,
+            'remarks' => null,
+        ], $overrides);
+    }
+
+    private function encodedRequestFor(int $memberId): int
+    {
+        $created = $this->repository->create($this->scoutYearId, $this->fields(), null, []);
+        $this->repository->linkToMemberAndEncode(
+            $created['id'],
+            $memberId,
+            new \DateTimeImmutable('2026-04-02 11:00:00')
+        );
+
+        return $created['id'];
+    }
+
+    public function testAMemberBornOfARequestGetsALinkToIt(): void
+    {
+        $memberId = RegistrationTestHelper::insertMember($this->pdo, 'D1');
+        $requestId = $this->encodedRequestFor($memberId);
+
+        $origin = $this->service->getRegistrationOrigin($memberId);
+
+        $this->assertNotNull($origin);
+        $this->assertSame('/config/inscriptions/demandes/' . $requestId, $origin->path);
+        $this->assertSame('Encodée dans Desk', $origin->statusLabel);
+        $this->assertStringStartsWith('Demande du ', $origin->label);
+    }
+
+    /**
+     * A pointer, never a copy: the request keeps its own page, and
+     * recopying its fields here would create a second place to keep in
+     * step with Desk. Nothing the parent typed may travel with the link.
+     */
+    public function testTheOriginCarriesNothingOfTheRequestsContent(): void
+    {
+        $memberId = RegistrationTestHelper::insertMember($this->pdo, 'D1');
+        $this->encodedRequestFor($memberId);
+
+        $origin = $this->service->getRegistrationOrigin($memberId);
+        $this->assertNotNull($origin);
+
+        $serialized = json_encode($origin, JSON_UNESCAPED_UNICODE);
+        $this->assertIsString($serialized);
+        foreach (['Marie Dupont', 'Léa', 'marie.dupont@example.com', '0470123456', 'Rue de la Paix'] as $personal) {
+            $this->assertStringNotContainsString($personal, $serialized);
+        }
+    }
+
+    /**
+     * The ordinary case, not an anomaly: every member imported from Desk
+     * before this module existed, and everyone who joined another way.
+     */
+    public function testAMemberWithNoRequestGetsNothingRatherThanAnEmptyBlock(): void
+    {
+        $memberId = RegistrationTestHelper::insertMember($this->pdo, 'D1');
+
+        $this->assertNull($this->service->getRegistrationOrigin($memberId));
+    }
+
+    /**
+     * A request that has not been linked yet belongs to nobody: it is
+     * still a request, and pointing a member at it would claim a
+     * migration that never happened.
+     */
+    public function testAnUnlinkedRequestIsNotAnybodysOrigin(): void
+    {
+        $memberId = RegistrationTestHelper::insertMember($this->pdo, 'D1');
+        $this->repository->create($this->scoutYearId, $this->fields(), null, []);
+
+        $this->assertNull($this->service->getRegistrationOrigin($memberId));
+    }
+
+    public function testOneMembersRequestIsNeverAnothersOrigin(): void
+    {
+        $first = RegistrationTestHelper::insertMember($this->pdo, 'D1');
+        $second = RegistrationTestHelper::insertMember($this->pdo, 'D2');
+        $this->encodedRequestFor($first);
+
+        $this->assertNotNull($this->service->getRegistrationOrigin($first));
+        $this->assertNull($this->service->getRegistrationOrigin($second));
+    }
+}


### PR DESCRIPTION
## Ce que ça change

Deux blocs de plus sur `/admin/members/{id}`, tous deux alimentés par des interfaces que le cœur déclare et que des modules remplissent, **injectées nullable** : sans le module, le bloc n'est pas construit du tout — jamais une erreur, jamais une carte vide.

### Les paiements

**Une seconde méthode sur `Core\Module\MemberPaymentProvider`, pas un paramètre sur la première.** `getOpenPayments()` est déjà consommée par la page du membre et par la bannière d'accueil, et les deux ne veulent que les créances ouvertes ; élargir sa signature aurait fait rippler le changement sur des appelants qui n'ont rien demandé. `getSettledPayments()` est donc l'exception assumée à la règle « une interface, une méthode » : deux questions distinctes, deux méthodes.

**Seule la fiche admin appelle la nouvelle.** La page de l'animé garde les créances ouvertes seules — un parent n'a pas besoin de relire ses virements de 2023 sur la page de son enfant.

Les lignes closes sont **repliées, jamais mêlées** : c'est de l'historique, pas une tâche, et les fondre dans les créances ouvertes noierait les une ou deux lignes qui appellent une action. Et **pas de QR ni d'IBAN ici**, contrairement à la page du membre : un chef d'unité lit où en est un paiement, il ne le fait pas à la place de la famille.

### Le piège que mon propre test a attrapé

La première version lisait `storedSettlementsFor()`, en se disant qu'une ligne close n'a pas besoin d'un rafraîchissement. C'est faux à moitié :

| Méthode | Écrit ? | Ce qu'elle voit |
|---|---|---|
| `refreshAndSettle()` | **oui** | tout — mais une page qui rapporte l'historique n'a pas à réallouer à chaque affichage |
| `storedSettlementsFor()` | non | **trop peu** : elle saute délibérément le balayage des crédits, donc `amountDesignatedCents` ne dépasse jamais ce qui a été absorbé |
| `settlementsFor()` | non | l'image complète, sans écriture ← **retenue** |

Avec la version stockée, une créance de 45 € payée 50 € revenait comme exactement payée, et `STATUS_OVERPAYMENT_REFUNDED` était **inatteignable** — précisément l'issue que ce bloc existe pour rendre visible.

### Le vocabulaire des issues appartient au cœur

`MemberSettledPaymentView::STATUS_PAID | STATUS_WAIVED | STATUS_OVERPAYMENT_REFUNDED` — parce que c'est le gabarit du cœur qui doit choisir un badge pour chacune. Le module finance y projette ses états de créance.

**Le trop-perçu remboursé l'emporte sur « payé »** : sur son seul statut, une telle ligne se lit comme simplement payée, et afficher « payé · 50,00 € » quand 5,00 € sont repartis dit au chef d'unité le contraire de ce qui s'est passé.

Et il est libellé **« trop-perçu remboursé »**, pas « remboursé » : le modèle enregistre le retour d'un **surplus**, jamais un paiement intégralement inversé — le mot court affirmerait le second.

### Un DTO distinct, pas `MemberPaymentView` avec des champs à null

`MemberPaymentView` existe pour être **agie** : IBAN, communication, QR — tout y répond à « comment je paie ça ». Rien de cela n'a de sens pour une demande close, et une ligne close rendue à travers lui proposerait à un parent un code à scanner pour de l'argent déjà versé.

### Le plafond

Sur l'**interface** (`SETTLED_LIMIT`), pas dans le module : la page peut dire combien elle montre sans deviner, et une seconde implémentation ne peut pas répondre à une autre échelle. `AdminMemberPageService` passe un drapeau `settled_payments_capped` — une liste tronquée en silence se lit comme une liste complète, donc l'écran le dit.

### La demande d'inscription d'origine

Un lien, jamais une copie : un libellé, un chemin, et où la demande a abouti. La demande garde sa propre page ; en recopier trois champs créerait un second endroit à tenir en phase avec Desk. `MemberRegistrationOriginServiceTest` vérifie qu'**aucune donnée personnelle ne voyage avec le lien**. Le chemin vient du module, donc le cœur n'apprend jamais que `/config/inscriptions/demandes/{id}` est l'endroit où vit une demande. Les deux pages sont `role_min: admin`, donc quiconque voit le lien peut l'ouvrir.

## Écart assumé, et pourquoi

La feuille de route dit, pour l'origine : *« le module registration publie plusieurs interfaces ; sers-toi de celles qui existent plutôt que d'en ajouter une. »* J'ai vérifié les cinq (`ExternalMailingListProvider`, `HouseholdRegistrationCountProvider`, `ReconciliationTrigger`, `ScoutYearPreparationProvider`, `ScoutYearTransitionVetoProvider`) : **aucune ne pose cette question**. Greffer « et aussi, d'où vient ce membre ? » sur un compteur de foyers ou sur un veto d'année scoute serait exactement le couplage « raconte-moi tout sur ce membre » que §7.4 cherche à éviter.

D'où un nouveau `Core\Module\MemberRegistrationOriginProvider` — une interface, une méthode, un `int $memberId` — implémenté par `Modules\Registration\Api\MemberRegistrationOriginService`. C'est le seul endroit où l'hypothèse de la feuille de route ne tenait pas, et c'est dit plutôt que contourné.

## Autres points

- **N'avoir ni créance ni demande d'origine est le cas courant**, pas une anomalie : rien ne s'affiche, plutôt qu'un bloc vide annonçant « aucune donnée ».
- **`MemberSearchController` déménage** vers la section tardive de la racine de composition, après tous les blocs de modules — même raison que `MemberController`, qui y était déjà. Déplacé plutôt que réenregistré une seconde fois : rien avant ce point n'en dépend.
- **Les libellés d'état d'une demande avaient deux copies** (celle de l'export tableur, celle du badge). Elles remontent sur `RegistrationRequest` lui-même, où une troisième ne peut plus diverger.
- `AdminMemberPageServiceTest` a gagné un membre leurre au `setUp` : sans lui `members.id` et `member_years.id` valaient tous deux 1, et l'assertion « le hook interroge la **personne**, pas la ligne annuelle » était vide de sens. Le garde-fou l'a signalé.

## Documentation mise à jour dans la même PR

- `ARCHITECTURE.md` **§8.62quater** (nouveau) — les deux hooks, le choix de `settlementsFor()`, le vocabulaire des issues, le plafond, et le déménagement du contrôleur.
- `specifications.md` **§4.4** — les deux blocs, ce qu'ils montrent et ce qu'ils ne montrent pas.
- `docs/module-development.md` — nouvelle section « Filling a block on a member's page », avec le tableau des interfaces qui existent déjà (c'est là que les auteurs de modules cherchent, et c'est ce qui évite qu'on en écrive une sixième pour le même besoin) et les six règles de forme.
- `docs/help/fiche-membre-admin.md` — les paiements et l'origine (467 mots, sous la butée de 500 de design.md §7.11, un seul bloc de rappel). Une phrase orpheline laissée par une coupe précédente est raccrochée à sa puce.

## Schéma

Aucun. Une interface de lecture ne change aucune table — donc aucun bump de version de module.

## Tests

- `FamilyPaymentServiceTest` (+7) — une demande payée quitte la liste ouverte et rejoint la close ; l'abandon se lit comme abandon et porte la date du renoncement, pas celle de la ligne ; un surplus reparti se lit « trop-perçu remboursé » ; le même surplus **avant** son retour se lit encore « payé » ; une demande ouverte n'est jamais dans la liste close ; aucun historique ne donne une liste vide et non une erreur ; le plafond.
- `MemberRegistrationOriginServiceTest` (5, nouveau) — le lien et l'état ; **aucune donnée personnelle dans le DTO** ; pas de demande = rien du tout ; une demande non liée n'est l'origine de personne ; la demande d'un membre n'est jamais celle d'un autre.
- `AdminMemberPageServiceTest` (+4) — sans aucun module la page se construit et ne propose rien ; les deux hooks sont interrogés sur `members.id` et non sur `member_years.id` ; ce que les modules répondent arrive intact ; une liste close pleine est signalée comme plafonnée.
- RBAC : aucune frontière déplacée sur cette itération — les deux blocs vivent sur `/admin/members/{id}` (`role_min: admin`, couvert par `MemberSearchRbacTest`) et le lien pointe vers `/config/inscriptions/demandes/{id}`, `admin` lui aussi.

PHPStan **OK**, PHPUnit **12 118 tests**, `npm run typecheck` **OK**, Vitest **1 579 tests** — tous verts localement.

---
_Generated by [Claude Code](https://claude.ai/code/session_019EgucjNpHf217pBeCuUSTN)_