### PR TITLE
IT-08 — blocs parcours : formations, camps, groupes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1831,6 +1831,26 @@ It is a new interface rather than a method bolted onto one of the registration m
 
 **`MemberSearchController` is registered late in the composition root**, after every module block, for the same reason `MemberController` already was: two of its blocks come from optional modules and neither is in scope earlier.
 
+### 8.62quinquies The « parcours » blocks (`Core\Module\MemberCampStayProvider`, `Core\Module\MemberDiscussionGroupProvider`)
+
+Three blocks of `/admin/members/{id}` answering "where has this person been": the training path, the stays their sections went on, and the discussion groups they belong to. All three are §7.4 hooks injected nullable into `AdminMemberPageService`; each implementation sits in its module's `Service\`, not its `Api\`, because `Api\` is where a module *publishes* an interface of its own (§7.5) and these are core's.
+
+**The training path creates nothing.** `Core\Module\FormationPathProvider` already existed and `Modules\Leadership\Service\MemberFormationPathService` already implemented it; the admin page simply becomes a second consumer, and it is the only block here scoped to a scout year — where somebody stood is a statement about a season, not a fact that accumulates.
+
+That interface's docblock used to read "self only" flatly. It is reworded in the same change rather than quietly contradicted: what "self only" forbade is a chief reading a member's training state off a page built *for the member*; it was never a rule that the unit may not know where its own staff stand. `/admin/leadership/training` carries the same `admin` floor as this page, so nothing reaches a reader here who could not already open it one menu away.
+
+**The camps block is an inference, and says so.** Nothing records a stay's participants one by one — `camp_camps` links to *sections*. A stay counts as this member's when their section went on it during a scout year in which they belonged to that section: core's `member_section_periods` crossed with the module's `camp_camp_sections`. A block claiming a real roster would be inventing one, so the interface's docblock states the inference where an implementer will read it.
+
+A stay carries no `scout_year_id`, only dates — or, for half of what a unit remembers about its own past, a bare year. Placing it is `ScoutYearService::labelForDate()` on the END date, the site's own rule. A `year_only` stay is read as the scout year **ending** in that year: a grand camp happens in July or August, so "2012" means 2011-2012. That is a convention, not a fact, and it is the least wrong one available — dropping those stays instead would silently empty the block for exactly the old camps the feature exists to remember. A stay with neither a readable date nor a year is attached to nobody: the site does not know when it happened.
+
+One line per stay even when two of the member's sections both went — the reader wants where they went, not how many rows the join produced. Capped at `MemberCampStayProvider::LIMIT`, on the interface for the same reason as `MemberPaymentProvider::SETTLED_LIMIT`, and the page says so when the cap bites.
+
+**The groups block is membership, and nothing else** — no post, no reply, no count of either. A chef d'unité fielding "elle ne reçoit rien" needs to know which groups reach this person; what people write to each other is not a fact about a member to be summarised on a staff page. `MemberDiscussionGroupServiceTest` pins the DTO's property list so a later "just add the post count" cannot pass unnoticed.
+
+Explicit `discussion_group_members` rows only. The module also derives membership from a section group's composition (`GroupAccessService::isDerivedMember()`), and that deliberately does not appear: a derived member is in the group *because* of the section they are in this year, which the page already states one card above under « Parcours dans l'unité ». Repeating it as a group membership would say a chef d'unité did something they did not. Open groups first, each side most recently active first — a closed group is still part of the journey, but it is not where somebody is reachable today.
+
+Both link out, and both links are always openable by whoever can see them: a stay page is `chief` and this page is `admin`, and a site admin reads every group by the groups module's own rule (`GroupAccessService::canRead()`).
+
 ### 8.62ter Staff notes about a member (`Core\Member\MemberNoteService`)
 
 The « Notes internes » block of `/admin/members/{id}`. `registration_requests.internal_notes_encrypted` covers a *request* and stops the day it is accepted; nothing covered the person afterwards, which is the gap this fills.

--- a/core/Member/AdminMemberPageService.php
+++ b/core/Member/AdminMemberPageService.php
@@ -11,6 +11,12 @@ namespace Core\Member;
 use Core\Badge\Badge;
 use Core\Badge\MemberBadgeRepository;
 use Core\Config\ScoutYearService;
+use Core\Module\FormationPathProvider;
+use Core\Module\FormationPathView;
+use Core\Module\MemberCampStayProvider;
+use Core\Module\MemberCampStayView;
+use Core\Module\MemberDiscussionGroupProvider;
+use Core\Module\MemberDiscussionGroupView;
 use Core\Module\MemberPaymentProvider;
 use Core\Module\MemberPaymentView;
 use Core\Module\MemberRegistrationOriginProvider;
@@ -50,6 +56,20 @@ use Core\Photo\MemberPhotoService;
  * case**, not an anomaly. Neither block is drawn at all rather than
  * drawn empty with « aucune donnée ».
  *
+ * **The « parcours » blocks** come from three more: the training path
+ * (`FormationPathProvider`, leadership), the stays the member's sections
+ * went on (`MemberCampStayProvider`, camps) and the discussion groups
+ * they belong to (`MemberDiscussionGroupProvider`, groups).
+ *
+ * The training path is the one block here the member's OWN page shows
+ * only to themselves, and showing it to the Staff d'Unité is a deliberate
+ * decision rather than an oversight: `FormationPathProvider`'s docblock
+ * already says the answer for the unit belongs on that module's own
+ * role-gated pages, and `/admin/leadership/training` carries the same
+ * `admin` floor as this page. Nothing is revealed here that a reader
+ * could not already open one menu away, and the interface's docblock is
+ * updated in the same change so the two do not disagree.
+ *
  * **Two things this page must never show**, and the reasons are worth
  * keeping next to the code:
  *
@@ -83,7 +103,10 @@ class AdminMemberPageService
         private ScoutYearService $scoutYearService,
         private MemberEmailRepository $memberEmailRepository,
         private ?MemberPaymentProvider $memberPaymentProvider = null,
-        private ?MemberRegistrationOriginProvider $registrationOriginProvider = null
+        private ?MemberRegistrationOriginProvider $registrationOriginProvider = null,
+        private ?FormationPathProvider $formationPathProvider = null,
+        private ?MemberCampStayProvider $campStayProvider = null,
+        private ?MemberDiscussionGroupProvider $discussionGroupProvider = null
     ) {
     }
 
@@ -97,7 +120,11 @@ class AdminMemberPageService
      *   open_payments: list<MemberPaymentView>,
      *   settled_payments: list<MemberSettledPaymentView>,
      *   settled_payments_capped: bool,
-     *   registration_origin: ?MemberRegistrationOriginView
+     *   registration_origin: ?MemberRegistrationOriginView,
+     *   formation_path: ?FormationPathView,
+     *   camp_stays: list<MemberCampStayView>,
+     *   camp_stays_capped: bool,
+     *   discussion_groups: list<MemberDiscussionGroupView>
      * }
      */
     public function buildPageData(MemberProfile $profile, int $scoutYearId): array
@@ -106,6 +133,7 @@ class AdminMemberPageService
         // when the scout year turns, and a registration request produced
         // a person rather than one year's row.
         $settled = $this->memberPaymentProvider?->getSettledPayments($profile->memberId) ?? [];
+        $campStays = $this->campStayProvider?->getCampStays($profile->memberId) ?? [];
 
         return [
             'photo_file_id' => $this->memberPhotoService->resolveFileId($profile->memberId, $scoutYearId),
@@ -120,6 +148,14 @@ class AdminMemberPageService
             // silently truncated list reads as a complete one.
             'settled_payments_capped' => count($settled) >= MemberPaymentProvider::SETTLED_LIMIT,
             'registration_origin' => $this->registrationOriginProvider?->getRegistrationOrigin($profile->memberId),
+            // Scoped to the year the page is showing, unlike everything
+            // else here: a training path is a statement about where
+            // somebody stood in a given season, not a fact that
+            // accumulates.
+            'formation_path' => $this->formationPathProvider?->getFormationPath($profile->memberId, $scoutYearId),
+            'camp_stays' => $campStays,
+            'camp_stays_capped' => count($campStays) >= MemberCampStayProvider::LIMIT,
+            'discussion_groups' => $this->discussionGroupProvider?->getDiscussionGroups($profile->memberId) ?? [],
         ];
     }
 

--- a/core/Module/FormationPathProvider.php
+++ b/core/Module/FormationPathProvider.php
@@ -17,14 +17,22 @@ namespace Core\Module;
  * implements it, and the composition root wires it in only while that
  * module is enabled. The `leadership` module implements this today.
  *
- * **Self only.** The block this feeds is rendered under the member page's
- * own `is_self` test, separately from the route's authorization — exactly
- * like the photo the member may replace and the private documents. A chief
- * or a chef d'unité viewing somebody else's page does not see it, even
- * though Core\Http\Controller\MemberController::show() lets them onto the
- * page. Where the unit as a whole stands is a question for that module's
- * own admin pages, which are role-gated in their own right; a member's
- * page answers a question that member asked about themselves.
+ * **Self only on the member's own page.** There the block is rendered
+ * under `is_self`, separately from the route's authorization — exactly
+ * like the photo the member may replace and the private documents. A
+ * chief or a chef d'unité viewing somebody else's page does not see it,
+ * even though Core\Http\Controller\MemberController::show() lets them
+ * onto the page: a member's page answers a question that member asked
+ * about themselves.
+ *
+ * **The staff answer lives on staff pages**, which is the other half of
+ * that rule and not a contradiction of it. `Core\Member\
+ * AdminMemberPageService` shows this block on `/admin/members/{id}`,
+ * `role_min: admin` — the same floor as the leadership module's own
+ * `/admin/leadership/training`, so nothing reaches a reader there who
+ * could not already open it one menu away. What "self only" forbids is a
+ * chief reading it off a page built for the member; it was never a rule
+ * that the unit may not know where its own staff stand.
  */
 interface FormationPathProvider
 {

--- a/core/Module/MemberCampStayProvider.php
+++ b/core/Module/MemberCampStayProvider.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module;
+
+/**
+ * Optional hook a module can implement to say which stays a member went
+ * on, for the « parcours » of the admin member page — without core
+ * knowing what a camp is. Same precedent as
+ * Core\Module\FormationPathProvider (ARCHITECTURE.md §7.4): core defines
+ * the interface, the module implements it, and the composition root
+ * wires it only while that module is enabled. The `camps` module
+ * implements this today.
+ *
+ * **What "went on" means, and why it is an inference.** Nothing records
+ * a camp's participants one by one — `camp_camps` links to *sections*,
+ * not to people. So a stay counts as this member's when their section
+ * went on it during a scout year in which they belonged to that section,
+ * read from `member_section_periods`. That is genuinely what the site
+ * knows, and a block claiming more would be inventing a roster it does
+ * not have.
+ *
+ * **This hook decides nothing about who may look.** The page is
+ * `role_min: admin` and the stay pages it links to are `chief`, so a
+ * reader who sees a link can always open it. A provider that re-derived
+ * its own audience would be a second answer waiting to disagree with the
+ * router's.
+ */
+interface MemberCampStayProvider
+{
+    /**
+     * How many stays the list may carry. On the interface so the page can
+     * say how many it is showing without guessing, and a second
+     * implementation cannot answer at a different scale — same reason as
+     * MemberPaymentProvider::SETTLED_LIMIT.
+     */
+    public const LIMIT = 20;
+
+    /**
+     * The stays this member's sections went on while they were in them,
+     * most recent first, capped at self::LIMIT — or an empty list when
+     * there are none, which is the ordinary answer for a member who
+     * joined this year.
+     *
+     * The id is a `members.id`, the persistent identity: a camp somebody
+     * went on in 2019 is still a camp they went on.
+     *
+     * @return list<MemberCampStayView>
+     */
+    public function getCampStays(int $memberId): array;
+}

--- a/core/Module/MemberCampStayView.php
+++ b/core/Module/MemberCampStayView.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module;
+
+/**
+ * One stay this member's section went on, as the admin member page draws
+ * it.
+ *
+ * Presentation-ready, like every DTO in this folder: the module hands
+ * over a place name, a period already worded and a path, rather than its
+ * own camp vocabulary. Core never learns what a `stay_type` is, and the
+ * module can reword « Grand camp » without touching a core template.
+ */
+final class MemberCampStayView
+{
+    /**
+     * @param string $placeLabel  where they went
+     * @param string $periodLabel when, already worded — a real range when the
+     *        stay carries dates, a bare year when all the unit remembers is
+     *        "on est allés là en 2012"
+     * @param string $sectionName which of the member's sections went
+     * @param string $scoutYearLabel the scout year the stay falls in
+     * @param string $path        site-absolute path of the stay's own page
+     */
+    public function __construct(
+        public readonly string $placeLabel,
+        public readonly string $periodLabel,
+        public readonly string $sectionName,
+        public readonly string $scoutYearLabel,
+        public readonly string $path,
+    ) {
+    }
+}

--- a/core/Module/MemberDiscussionGroupProvider.php
+++ b/core/Module/MemberDiscussionGroupProvider.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module;
+
+/**
+ * Optional hook a module can implement to say which discussion groups a
+ * member belongs to, for the « parcours » of the admin member page —
+ * without core knowing what a discussion group is. Same precedent as
+ * Core\Module\FormationPathProvider (ARCHITECTURE.md §7.4): core defines
+ * the interface, the module implements it, and the composition root
+ * wires it only while that module is enabled. The `groups` module
+ * implements this today.
+ *
+ * **Membership, and nothing else.** No post, no reply, no count of
+ * either. A chef d'unité fielding "elle ne reçoit rien" needs to know
+ * which groups reach this person; what people write to each other is not
+ * a fact about a member to be summarised on a staff page. That is the
+ * whole boundary of this hook, and it is the reason it returns what it
+ * returns.
+ *
+ * **This hook decides nothing about who may look.** The page is
+ * `role_min: admin`, and a site admin reads every group by the module's
+ * own rule (Modules\Groups\Service\GroupAccessService::canRead()), so a
+ * reader who sees a link can always open it. A provider that re-derived
+ * its own audience would be a second answer waiting to disagree with
+ * that one.
+ */
+interface MemberDiscussionGroupProvider
+{
+    /**
+     * The groups this member belongs to, open ones first and each side
+     * most recently active first — or an empty list when they belong to
+     * none, which is the ordinary answer and not an anomaly.
+     *
+     * The id is a `members.id`: `discussion_group_members.member_id` is
+     * the persistent identity too, so a membership survives the scout
+     * year that saw it created.
+     *
+     * @return list<MemberDiscussionGroupView>
+     */
+    public function getDiscussionGroups(int $memberId): array;
+}

--- a/core/Module/MemberDiscussionGroupView.php
+++ b/core/Module/MemberDiscussionGroupView.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module;
+
+/**
+ * One discussion group this member belongs to, as the admin member page
+ * draws it.
+ *
+ * Membership only — never a post, never a reply, never a count of
+ * either. What people write to each other is not a fact about a member
+ * to be listed on a staff page; that a chef d'unité can tell who is
+ * reachable in which group is.
+ */
+final class MemberDiscussionGroupView
+{
+    /**
+     * @param string $name        the group's name
+     * @param string $path        site-absolute path of the group's page
+     * @param bool $isModerator   whether they run it, not merely belong to it
+     * @param bool $isClosed      a closed group is still part of the journey,
+     *        and saying so is what stops it reading as current
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $path,
+        public readonly bool $isModerator,
+        public readonly bool $isClosed,
+    ) {
+    }
+}

--- a/core/View/templates/admin/members/show.html.twig
+++ b/core/View/templates/admin/members/show.html.twig
@@ -364,6 +364,115 @@
                 </section>
             {% endif %}
 
+            {# Parcours de formation — alimenté par
+               Core\Module\FormationPathProvider, que le module leadership
+               implémente. Sur la page du membre lui-même ce bloc est
+               réservé à lui seul ; ici il est visible du Staff d'Unité, et
+               c'est délibéré : « /admin/leadership/training » porte
+               exactement le même plancher `admin`, donc rien n'apparaît ici
+               qu'un lecteur ne puisse déjà ouvrir à un menu de distance. #}
+            {% if formation_path %}
+                <section class="card mb-3">
+                    <div class="card-header d-flex align-items-center gap-2">
+                        <i class="bi bi-mortarboard" aria-hidden="true"></i>
+                        <h2 class="h6 mb-0">Parcours de formation</h2>
+                    </div>
+                    <div class="card-body">
+                        {% if formation_path.isRecognised %}
+                            <ol class="list-unstyled d-flex flex-wrap gap-2 mb-3">
+                                {% for step in formation_path.steps %}
+                                    <li class="badge rounded-pill {{ step.reached ? 'text-bg-primary' : 'text-bg-light border' }}">
+                                        {{ step.label }}{% if step.current %} <span class="visually-hidden">(étape actuelle)</span>{% endif %}
+                                    </li>
+                                {% endfor %}
+                            </ol>
+                        {% endif %}
+                        <p class="small mb-0">
+                            {{ formation_path.currentLabel }}.
+                            {% if formation_path.nextLabel %}
+                                Prochaine étape connue : {{ formation_path.nextLabel }}.
+                            {% endif %}
+                        </p>
+                        {% if not formation_path.isRecognised %}
+                            <p class="small text-body-secondary mb-0 mt-2">
+                                Le site ne sait pas à quelle étape rattacher ce qui est encodé dans Desk ;
+                                rien n'est déduit tant qu'on ne le lui indique pas.
+                            </p>
+                        {% endif %}
+                    </div>
+                </section>
+            {% endif %}
+
+            {# Camps — rien n'enregistre les participants d'un camp un par
+               un : ce sont des SECTIONS qui partent. Une ligne apparaît
+               donc quand la section de la personne est partie une année où
+               elle en faisait partie. C'est ce que le site sait ; un bloc
+               qui prétendrait à une liste de participants l'inventerait. #}
+            {% if camp_stays is not empty %}
+                <section class="card mb-3">
+                    <div class="card-header d-flex align-items-center gap-2">
+                        <i class="bi bi-tree" aria-hidden="true"></i>
+                        <h2 class="h6 mb-0">Camps</h2>
+                    </div>
+                    <ul class="list-group list-group-flush">
+                        {% for stay in camp_stays %}
+                            <li class="list-group-item p-0">
+                                <a href="{{ stay.path }}" class="d-flex align-items-center gap-3 p-3 text-decoration-none text-body">
+                                    <span class="flex-grow-1 min-w-0">
+                                        <span class="fw-medium d-block">{{ stay.placeLabel }}</span>
+                                        <span class="text-body-secondary small">
+                                            {{ stay.periodLabel ?: stay.scoutYearLabel }} · {{ stay.sectionName }}
+                                        </span>
+                                    </span>
+                                    <i class="bi bi-chevron-right text-body-secondary flex-shrink-0" aria-hidden="true"></i>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                    {% if camp_stays_capped %}
+                        <div class="card-body pt-2">
+                            <p class="small text-body-secondary mb-0">
+                                Les {{ camp_stays|length }} plus récents.
+                            </p>
+                        </div>
+                    {% endif %}
+                </section>
+            {% endif %}
+
+            {# Groupes de discussion — l'appartenance, et rien d'autre :
+               aucun message, aucune réponse, aucun décompte. Un chef
+               d'unité a besoin de savoir par quels groupes la personne est
+               joignable ; ce que les gens s'écrivent n'est pas un fait à
+               résumer sur une page de staff.
+
+               Seules les appartenances explicites : un membre « dérivé »
+               l'est à cause de sa section, ce que la carte « Parcours dans
+               l'unité » dit déjà. #}
+            {% if discussion_groups is not empty %}
+                <section class="card mb-3">
+                    <div class="card-header d-flex align-items-center gap-2">
+                        <i class="bi bi-chat-dots" aria-hidden="true"></i>
+                        <h2 class="h6 mb-0">Groupes de discussion</h2>
+                    </div>
+                    <ul class="list-group list-group-flush">
+                        {% for group in discussion_groups %}
+                            <li class="list-group-item p-0">
+                                <a href="{{ group.path }}" class="d-flex align-items-center gap-2 p-3 text-decoration-none text-body">
+                                    <span class="flex-grow-1 min-w-0">{{ group.name }}</span>
+                                    {% if group.isModerator %}
+                                        <span class="badge text-bg-light border flex-shrink-0">Animateur</span>
+                                    {% endif %}
+                                    {% if group.isClosed %}
+                                        {% include 'partials/status_badge.html.twig' with { status: 'closed', label: 'clôturé' } only %}
+                                    {% endif %}
+                                    <i class="bi bi-chevron-right text-body-secondary flex-shrink-0" aria-hidden="true"></i>
+                                </a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </section>
+            {% endif %}
+
             {# D'où vient cette personne — un lien, jamais une copie. La
                demande garde sa propre page, construite par le module qui la
                possède ; en recopier trois champs ici créerait un second

--- a/docs/help/fiche-membre-admin.md
+++ b/docs/help/fiche-membre-admin.md
@@ -17,21 +17,24 @@ ancienne ne sont pas celles d'aujourd'hui.
 
 ## Données Desk
 
-En lecture seule : ce que la fédération connaît — coordonnées, date de
-naissance, section, fonction, téléphones des parents. Une correction s'y
-fait dans Desk, puis par un nouvel import. Les adresses secondaires du
-membre y figurent aussi : lui seul les gère.
+En lecture seule : coordonnées, date de naissance, section, fonction,
+téléphones des parents. Une correction se fait dans Desk, puis par un
+nouvel import. Les adresses secondaires y figurent aussi : le membre
+seul les gère.
 
 ## Ce que le site sait
 
 La photo, les badges et les fonctions de l'année, et le **parcours dans
 l'unité** : chaque section où la personne est passée, année par année.
 
-Si le module Cotisations est actif, les **paiements** : ce qui reste dû
-d'abord, l'historique replié en dessous. Vous y lisez où en est un
-paiement ; c'est la page du membre, elle, qui porte le QR et l'IBAN.
-Enfin, un lien vers la **demande d'inscription d'origine**, s'il y en a
-une.
+Selon les modules actifs : les **paiements** — ce qui reste dû d'abord,
+l'historique replié en dessous ; un lien vers la **demande d'inscription
+d'origine** ; le **parcours de formation** ; les **camps** où sa section
+est partie ; et les **groupes de discussion** dont elle fait partie.
+
+Les camps sont déduits : ce sont des sections qui partent, pas des
+personnes une par une. Une ligne apparaît quand sa section est partie
+une année où elle en faisait partie.
 
 Les documents privés d'un membre n'apparaissent pas ici : ils restent
 accessibles au seul membre, sans contournement possible par le staff.
@@ -40,22 +43,20 @@ accessibles au seul membre, sans contournement possible par le staff.
 
 - **Année dans la branche** : « −1 an », « Normal » ou « +1 an », pour
   un enfant maintenu ou avancé d'un an. Le choix s'enregistre aussitôt
-  et replace le membre dans la bonne année de branche partout sur le
-  site, statistiques comprises.
+  et vaut partout sur le site, statistiques comprises.
 - **Départ** : la même case que sur la page Départs, avec un
-  commentaire facultatif. Disponible pour tout membre trouvé, animateurs
-  compris.
+  commentaire facultatif. Disponible pour tout membre trouvé.
 - **Voir le site à sa place** : vous agissez réellement au nom du
   membre, jusqu'à ses adresses e-mail, le temps de votre session. Un
-  bandeau le rappelle sur chaque page, « Retirer » ou la déconnexion
-  annule tout, et chaque activation est consignée au journal.
+  bandeau le rappelle, « Retirer » ou la déconnexion annule tout, et
+  chaque activation est consignée au journal.
 
 ## Les notes internes
 
 Des notes libres **datées**, chacune signée de son auteur : ce qu'un
 staff transmet au suivant pour bien accompagner un enfant. Une note par
-observation, jamais un champ unique — un membre reste dix ans dans
-l'unité, et un champ unique s'écrase sans que personne ne le sache.
+observation — un champ unique s'écraserait sans que personne ne le
+sache.
 
 Tout chef d'unité peut corriger ou supprimer n'importe quelle note, y
 compris celle d'un autre : une note écrite par erreur sur la mauvaise

--- a/docs/module-development.md
+++ b/docs/module-development.md
@@ -508,6 +508,8 @@ The ones that exist today:
 | `Core\Module\MemberPaymentProvider` | `getOpenPayments()` — what is still owed | both pages |
 | `Core\Module\MemberPaymentProvider` | `getSettledPayments()` — what is over, capped at `SETTLED_LIMIT`, most recent first | the admin page only |
 | `Core\Module\MemberRegistrationOriginProvider` | which registration request this member came from | the admin page only |
+| `Core\Module\MemberCampStayProvider` | which stays this member's sections went on, capped at `LIMIT` | the admin page only |
+| `Core\Module\MemberDiscussionGroupProvider` | which discussion groups this member belongs to | the admin page only |
 | `Core\Module\SectionResponsableProvider` | who runs this member's section | the member's own page |
 
 Before writing a new one, check whether one of these already asks your question. The shape to copy, when none does:
@@ -524,6 +526,7 @@ interface MyThingProvider
 - **A read DTO beside the interface**, `public readonly` properties and no logic. Return `?XxxView` for one object, `list<XxxView>` for a collection, never an improvised associative array.
 - **Presentation-ready, in the module's own words.** Core owns the template but not the domain: hand over a label and an amount in cents, not your internal vocabulary. The exception is anything core has to *branch* on — a status that picks a badge colour — which is a small set of constants core declares, and your module maps onto.
 - **Say what `null` means** in the docblock: module absent, or no data. And treat "no data" as the ordinary case — most members owe nothing and came from no request, so the page draws nothing rather than « aucune donnée ».
+- **Say what your answer INFERS, when it infers anything.** `MemberCampStayProvider` is the example: nothing records a camp's participants one by one, so "went on" means "their section went, in a year they were in it". Write that in the interface's docblock. A hook that quietly claims more than the tables hold is the kind of wrong nobody catches, because the page looks right.
 - **The hook decides nothing about who may look.** The page has already answered that. A provider that re-derived its own audience would be a second answer waiting to disagree with the router's.
 - **The implementation lives in your module's `Service\`, not its `Api\`.** `Api\` is where a module *publishes* an interface of its own for others to consume (§7.5); here the interface is core's and you are implementing it (§7.4). Wiring it is one nullable argument in the composition root, inside your module's own `if (in_array('my_module', …))` block.
 

--- a/modules/camps/src/Repository/CampRepository.php
+++ b/modules/camps/src/Repository/CampRepository.php
@@ -68,6 +68,35 @@ class CampRepository
     }
 
     /**
+     * Every stay one of these sections went on, newest first.
+     *
+     * The other axis of findByPlace(): "which stays involved these
+     * sections" rather than "which stays happened here". Feeds
+     * Service\MemberCampStayService, and the DISTINCT matters — a stay
+     * that two of a member's sections both went on is one stay.
+     *
+     * @param int[] $sectionIds
+     * @return Camp[]
+     */
+    public function findBySectionIds(array $sectionIds): array
+    {
+        if ($sectionIds === []) {
+            return [];
+        }
+
+        $placeholders = implode(',', array_fill(0, count($sectionIds), '?'));
+        $stmt = $this->pdo->prepare(
+            "SELECT DISTINCT c.* FROM camp_camps c
+               JOIN camp_camp_sections cs ON cs.camp_id = c.id
+              WHERE cs.section_id IN ({$placeholders})
+              ORDER BY COALESCE(c.end_date, CONCAT(c.year_only, '-12-31')) DESC, c.id DESC"
+        );
+        $stmt->execute(array_map('intval', array_values($sectionIds)));
+
+        return $this->hydrateAll($stmt->fetchAll(\PDO::FETCH_ASSOC));
+    }
+
+    /**
      * Every upcoming stay, soonest first — the "À venir" list.
      *
      * @return Camp[]

--- a/modules/camps/src/Service/MemberCampStayService.php
+++ b/modules/camps/src/Service/MemberCampStayService.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Camps\Service;
+
+use Core\Config\ScoutYearService;
+use Core\Member\SectionMembershipRepository;
+use Core\Member\SectionService;
+use Core\Module\MemberCampStayProvider;
+use Core\Module\MemberCampStayView;
+use Core\Service\DateInput;
+use Modules\Camps\Repository\Camp;
+use Modules\Camps\Repository\CampRepository;
+use Modules\Camps\Repository\PlaceRepository;
+
+/**
+ * This module's answer to core's « où est-elle partie » hook
+ * (Core\Module\MemberCampStayProvider, ARCHITECTURE.md §7.4).
+ *
+ * **The inference, stated plainly.** Nothing here records a camp's
+ * participants one by one: `camp_camps` links to *sections*. So a stay
+ * counts as this member's when their section went on it during a scout
+ * year in which they belonged to that section — core's
+ * `member_section_periods` crossed with this module's
+ * `camp_camp_sections`. That is what the site actually knows. A block
+ * claiming a real roster would be inventing one.
+ *
+ * **A stay carries no scout year**, only dates — or, for half of what a
+ * unit remembers about its own past, a bare year. Placing it is
+ * therefore ScoutYearService::labelForDate() on its END date, the same
+ * rule the whole site uses. A `year_only` stay is read as the scout year
+ * ENDING in that year: a grand camp happens in July or August, so "2012"
+ * means 2011-2012. It is a convention, not a fact, and it is the least
+ * wrong one available — the alternative, dropping those stays, would
+ * silently empty the block for exactly the old camps this feature exists
+ * to remember.
+ */
+class MemberCampStayService implements MemberCampStayProvider
+{
+    public function __construct(
+        private CampRepository $camps,
+        private PlaceRepository $places,
+        private SectionMembershipRepository $memberships,
+        private SectionService $sections,
+        private ScoutYearService $scoutYears
+    ) {
+    }
+
+    /**
+     * @return list<MemberCampStayView>
+     */
+    public function getCampStays(int $memberId): array
+    {
+        $periods = $this->memberships->findAllForMember($memberId);
+        if ($periods === []) {
+            return [];
+        }
+
+        // (scout year label, section id) => the section's name. The key is
+        // the label rather than the id because a stay carries a date, not
+        // a scout_year_id, and a label is what a date resolves to.
+        $wasThere = [];
+        $sectionIds = [];
+        foreach ($periods as $period) {
+            $scoutYear = $this->scoutYears->findById($period->scoutYearId);
+            $section = $this->sections->getSection($period->sectionId);
+            if ($scoutYear === null || $section === null) {
+                // A year or a section that no longer resolves is skipped
+                // rather than rendered as a blank row, same as the
+                // section history above it on the page.
+                continue;
+            }
+
+            $label = (string) $scoutYear['label'];
+            $wasThere[$label . ':' . $period->sectionId] = (string) ($section['name'] ?? $section['desk_code']);
+            $sectionIds[$period->sectionId] = true;
+        }
+        if ($sectionIds === []) {
+            return [];
+        }
+
+        $camps = $this->camps->findBySectionIds(array_keys($sectionIds));
+
+        // Place names in one query rather than one per stay: a member of
+        // ten years brings back twenty rows.
+        $placeNames = [];
+        foreach ($this->places->findByIds(array_map(static fn(Camp $c): int => $c->placeId, $camps)) as $place) {
+            $placeNames[$place->id] = $place->name;
+        }
+
+        $views = [];
+        foreach ($camps as $camp) {
+            $label = self::scoutYearLabelOf($camp);
+            if ($label === null) {
+                continue;
+            }
+
+            foreach ($camp->sectionIds as $sectionId) {
+                $sectionName = $wasThere[$label . ':' . $sectionId] ?? null;
+                if ($sectionName === null) {
+                    continue;
+                }
+
+                $views[] = new MemberCampStayView(
+                    $placeNames[$camp->placeId] ?? 'Lieu inconnu',
+                    CampLabels::dateRange($camp->startDate, $camp->endDate, $camp->yearOnly),
+                    $sectionName,
+                    $label,
+                    '/chefs/camps/sejours/' . $camp->id
+                );
+
+                // One line per stay even when two of the member's sections
+                // both went: the reader wants where they went, not how
+                // many rows the join produced.
+                break;
+            }
+
+            if (count($views) >= MemberCampStayProvider::LIMIT) {
+                break;
+            }
+        }
+
+        return $views;
+    }
+
+    /**
+     * The scout year a stay falls in, or null when it carries neither a
+     * readable end date nor a year — in which case the site does not know
+     * when it happened and cannot honestly attach it to anybody.
+     */
+    private static function scoutYearLabelOf(Camp $camp): ?string
+    {
+        $end = DateInput::fromStorage($camp->endDate);
+        if ($end !== null) {
+            return ScoutYearService::labelForDate($end);
+        }
+
+        if ($camp->yearOnly !== null) {
+            // See the class docblock: a bare year is read as the scout
+            // year ENDING in it.
+            return sprintf('%d-%d', $camp->yearOnly - 1, $camp->yearOnly);
+        }
+
+        return null;
+    }
+}

--- a/modules/groups/src/Service/MemberDiscussionGroupService.php
+++ b/modules/groups/src/Service/MemberDiscussionGroupService.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Groups\Service;
+
+use Core\Module\MemberDiscussionGroupProvider;
+use Core\Module\MemberDiscussionGroupView;
+use Modules\Groups\Repository\GroupMemberRepository;
+use Modules\Groups\Repository\GroupRepository;
+
+/**
+ * This module's answer to core's « dans quels groupes est-elle » hook
+ * (Core\Module\MemberDiscussionGroupProvider, ARCHITECTURE.md §7.4).
+ *
+ * Lives under Service\, not Api\: `Api\` is where this module publishes
+ * an interface of its own for others to consume (§7.5 —
+ * Api\HomeActivityService does exactly that), and here the interface is
+ * core's.
+ *
+ * **Explicit memberships only**, the rows of `discussion_group_members`.
+ * The module also derives membership from a section group's own
+ * composition (GroupAccessService::isDerivedMember()), and that
+ * deliberately does not appear here: a derived member is in the group
+ * *because* of the section they are in this year, which the page already
+ * states one card above under « Parcours dans l'unité ». Repeating it as
+ * a group membership would say a chef d'unité did something they did
+ * not.
+ *
+ * **Membership, and nothing else** — no post, no reply, no count of
+ * either. See the interface's own docblock for why that boundary is the
+ * point of this hook rather than an omission.
+ */
+class MemberDiscussionGroupService implements MemberDiscussionGroupProvider
+{
+    public function __construct(
+        private GroupMemberRepository $members,
+        private GroupRepository $groups
+    ) {
+    }
+
+    /**
+     * @return list<MemberDiscussionGroupView>
+     */
+    public function getDiscussionGroups(int $memberId): array
+    {
+        $rows = [];
+        foreach ($this->members->findByMemberIds([$memberId]) as $membership) {
+            $group = $this->groups->findById($membership->groupId);
+            if ($group === null) {
+                continue;
+            }
+            $rows[] = ['group' => $group, 'is_moderator' => $membership->isModerator];
+        }
+        if ($rows === []) {
+            return [];
+        }
+
+        // Open groups first, and each side most recently active first: a
+        // closed group is still part of the journey, but it is not where
+        // somebody is reachable today.
+        usort($rows, static function (array $a, array $b): int {
+            $closed = ($a['group']->isClosed() <=> $b['group']->isClosed());
+
+            return $closed !== 0 ? $closed : ($b['group']->lastActivityAt <=> $a['group']->lastActivityAt);
+        });
+
+        return array_map(
+            static fn(array $row): MemberDiscussionGroupView => new MemberDiscussionGroupView(
+                $row['group']->name,
+                '/groups/' . $row['group']->id,
+                $row['is_moderator'],
+                $row['group']->isClosed()
+            ),
+            $rows
+        );
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -2144,6 +2144,14 @@ $calendarEventLookup = null;
 // that module's block below, same pattern as the two above.
 $formationPathProvider = null;
 
+// The admin member page's « parcours » blocks (ARCHITECTURE.md §7.4),
+// set in the camps and groups blocks below and null when either module is
+// disabled — the block is then not built at all. The leadership half of
+// that parcours uses $formationPathProvider above, unchanged: the same
+// hook now feeds two pages.
+$memberCampStayProvider = null;
+$memberDiscussionGroupProvider = null;
+
 // Optional dependency on the finance module (ARCHITECTURE.md §7.5) for
 // keeping a document as a receipt on one of the unit's accounts — set in
 // finance's own block below. The fees module's federation invoice is the
@@ -3207,6 +3215,12 @@ if (in_array('groups', $moduleManager->getEnabledModuleIds(), true)) {
         $groupsMemberRepo, $groupsSectionRepo, $sectionMembershipRepository
     );
     $groupsService = new \Modules\Groups\Service\GroupService($groupsGroupRepo, $groupsSectionRepo, $groupsMemberRepo);
+    // Which groups a member belongs to, for the admin member page's
+    // « parcours » (ARCHITECTURE.md §7.4). Explicit memberships only,
+    // and membership only — never a post, never a count of them.
+    $memberDiscussionGroupProvider = new \Modules\Groups\Service\MemberDiscussionGroupService(
+        $groupsMemberRepo, $groupsGroupRepo
+    );
     // Per-member "last time I opened this group": drives the unread badge
     // on the group list, the home page's own activity card, and a post's
     // "vu par" list — all three read the same single mark, written once
@@ -3634,6 +3648,16 @@ if (in_array('camps', $moduleManager->getEnabledModuleIds(), true)) {
     $campsDocumentRepo = new \Modules\Camps\Repository\DocumentRepository($pdo);
     $campsReviewRepo = new \Modules\Camps\Repository\ReviewRepository($pdo);
     $campsProposalRepo = new \Modules\Camps\Repository\FieldProposalRepository($pdo, $encryptionService);
+
+    // Which stays a member's sections went on, for the admin member
+    // page's « parcours » (ARCHITECTURE.md §7.4). Nothing records a
+    // camp's participants one by one, so this crosses core's
+    // member_section_periods with this module's camp_camp_sections —
+    // see the service's own docblock for what that infers and what it
+    // does not claim.
+    $memberCampStayProvider = new \Modules\Camps\Service\MemberCampStayService(
+        $campsCampRepo, $campsPlaceRepo, $sectionMembershipRepository, $sectionService, $scoutYearService
+    );
 
     $campsSectionDescriber = new \Modules\Camps\Service\SectionDescriber($sectionService);
     $campsPlaceService = new \Modules\Camps\Service\PlaceService($campsPlaceRepo, $auditService);
@@ -4858,18 +4882,20 @@ if (
 
 // The admin member page, registered here rather than with the other core
 // controllers above for the same reason MemberController is: two of its
-// blocks come from optional modules — finance's open and closed payments
-// (via $memberPaymentProvider) and registration's origin link (via
-// $memberRegistrationOriginProvider) — and both are only in scope once
-// those modules' blocks have run. Each stays null when its module is
-// disabled, and the corresponding block is then not built at all.
+// blocks come from optional modules — finance's open and closed payments,
+// registration's origin link, and the three « parcours » hooks
+// (leadership's training path, camps' stays, groups' memberships) — and
+// none of them is in scope until those modules' blocks have run. Each
+// stays null when its module is disabled, and the corresponding block is
+// then not built at all.
 $frontController->registerController(MemberSearchController::class, new MemberSearchController(
     $twig, $memberSearchService, $memberService, $scoutYearResolver, $memberYearService, $departureService,
     $memberExportRowBuilder, $memberExportService, $journalService,
     new \Core\Member\AdminMemberPageService(
         $memberBadgeRepository, $memberPhotoService, $sectionMembershipRepository,
         $sectionService, $scoutYearService, $memberEmailRepository,
-        $memberPaymentProvider, $memberRegistrationOriginProvider
+        $memberPaymentProvider, $memberRegistrationOriginProvider,
+        $formationPathProvider, $memberCampStayProvider, $memberDiscussionGroupProvider
     ),
     $memberYearRepo,
     new \Core\Member\MemberNoteService(

--- a/specifications.md
+++ b/specifications.md
@@ -189,6 +189,12 @@ Pas de QR ni d'IBAN ici, contrairement à la page du membre : un chef d'unité r
 
 **N'avoir ni créance ni demande d'origine est le cas courant**, pas une anomalie : rien ne s'affiche, plutôt qu'un bloc vide annonçant « aucune donnée ».
 
+**Le parcours**, en trois blocs alimentés par des modules. Le **parcours de formation** — le même que sur la page de l'animateur, ici visible du Staff d'Unité : « Espace admin > Formations » porte déjà exactement le même plancher, donc rien n'y apparaît qu'un lecteur ne puisse ouvrir à un menu de distance. Les **camps** où sa section est partie, du plus récent au plus ancien. Et les **groupes de discussion** auxquels la personne appartient, les ouverts d'abord, avec la mention « Animateur » quand elle en anime un.
+
+**Les camps sont une déduction, et la page ne prétend pas le contraire.** Rien n'enregistre les participants d'un camp un par un : ce sont des **sections** qui partent. Une ligne apparaît donc quand la section de la personne est partie une année où elle en faisait partie. C'est ce que le site sait ; une liste de participants serait inventée.
+
+**Les groupes, c'est l'appartenance et rien d'autre** : aucun message, aucune réponse, aucun décompte. Un chef d'unité a besoin de savoir par quels groupes la personne est joignable ; ce que les gens s'écrivent n'est pas un fait à résumer sur une page de staff.
+
 **Two things are never on this page.** A member's **private documents**: `files.owner_member_id` carries an explicit guarantee (ARCHITECTURE.md §8.3) of no chief and no admin bypass, tax certificates will live there, and listing them here would revoke that guarantee in silence. And a **writable** secondary-address control, for the reason above.
 
 **Searching, and who it proposes.** The repository never filtered on `is_active` and the result has always carried the flag — what was missing was a way to narrow. The filter is **actifs** by default (what is wanted nine times out of ten), with *inactifs* and *tous* one tap away, and it travels with the query so a submit keeps it. The row is unchanged otherwise: the export checkbox, the initials pill, the totem after the first name, the section and function, and the status badge whose exact words stay « inscrit » / « non inscrit », never « actif ». **The two exports coexist** — the whole search, and the checked selection — and are never merged; both follow the filter the screen is showing.

--- a/tests/Core/Member/AdminMemberPageServiceTest.php
+++ b/tests/Core/Member/AdminMemberPageServiceTest.php
@@ -109,7 +109,10 @@ class AdminMemberPageServiceTest extends TestCase
      */
     private function serviceWith(
         ?\Core\Module\MemberPaymentProvider $payments,
-        ?\Core\Module\MemberRegistrationOriginProvider $origin
+        ?\Core\Module\MemberRegistrationOriginProvider $origin,
+        ?\Core\Module\FormationPathProvider $formation = null,
+        ?\Core\Module\MemberCampStayProvider $camps = null,
+        ?\Core\Module\MemberDiscussionGroupProvider $groups = null
     ): AdminMemberPageService {
         return new AdminMemberPageService(
             $this->badgeRepository,
@@ -119,7 +122,10 @@ class AdminMemberPageServiceTest extends TestCase
             $this->scoutYearService,
             $this->emailRepository,
             $payments,
-            $origin
+            $origin,
+            $formation,
+            $camps,
+            $groups
         );
     }
 
@@ -273,6 +279,91 @@ class AdminMemberPageServiceTest extends TestCase
         $this->assertSame([], $data['settled_payments']);
         $this->assertFalse($data['settled_payments_capped']);
         $this->assertNull($data['registration_origin']);
+        $this->assertNull($data['formation_path']);
+        $this->assertSame([], $data['camp_stays']);
+        $this->assertFalse($data['camp_stays_capped']);
+        $this->assertSame([], $data['discussion_groups']);
+    }
+
+    // ── the « parcours » blocks ────────────────────────────────────────
+
+    /**
+     * Three hooks take a `members.id`, and the training path takes a
+     * scout year on top — deliberately, because where somebody stood is
+     * a statement about a season, not a fact that accumulates.
+     */
+    public function testTheParcoursHooksAreAskedAboutThePersonAndTheYearOnScreen(): void
+    {
+        $formation = new class implements \Core\Module\FormationPathProvider {
+            public ?int $memberAskedFor = null;
+            public ?int $yearAskedFor = null;
+
+            public function getFormationPath(int $memberId, int $scoutYearId): ?\Core\Module\FormationPathView
+            {
+                $this->memberAskedFor = $memberId;
+                $this->yearAskedFor = $scoutYearId;
+
+                return null;
+            }
+        };
+        $camps = new class implements \Core\Module\MemberCampStayProvider {
+            public ?int $askedFor = null;
+
+            public function getCampStays(int $memberId): array
+            {
+                $this->askedFor = $memberId;
+
+                return [];
+            }
+        };
+        $groups = new class implements \Core\Module\MemberDiscussionGroupProvider {
+            public ?int $askedFor = null;
+
+            public function getDiscussionGroups(int $memberId): array
+            {
+                $this->askedFor = $memberId;
+
+                return [];
+            }
+        };
+
+        $this->serviceWith(null, null, $formation, $camps, $groups)->buildPageData(
+            $this->memberService->getMemberProfile($this->memberYearId),
+            $this->currentYearId
+        );
+
+        $this->assertSame($this->memberId, $formation->memberAskedFor);
+        $this->assertSame($this->currentYearId, $formation->yearAskedFor);
+        $this->assertSame($this->memberId, $camps->askedFor);
+        $this->assertSame($this->memberId, $groups->askedFor);
+    }
+
+    public function testAFullCampListIsFlaggedAsCapped(): void
+    {
+        $stays = [];
+        for ($i = 0; $i < \Core\Module\MemberCampStayProvider::LIMIT; $i++) {
+            $stays[] = new \Core\Module\MemberCampStayView('Lieu ' . $i, '2026', 'Meute', '2025-2026', '/chefs/camps/sejours/' . $i);
+        }
+
+        $camps = new class ($stays) implements \Core\Module\MemberCampStayProvider {
+            /** @param list<\Core\Module\MemberCampStayView> $stays */
+            public function __construct(private array $stays)
+            {
+            }
+
+            public function getCampStays(int $memberId): array
+            {
+                return $this->stays;
+            }
+        };
+
+        $data = $this->serviceWith(null, null, null, $camps, null)->buildPageData(
+            $this->memberService->getMemberProfile($this->memberYearId),
+            $this->currentYearId
+        );
+
+        $this->assertCount(\Core\Module\MemberCampStayProvider::LIMIT, $data['camp_stays']);
+        $this->assertTrue($data['camp_stays_capped']);
     }
 
     /**

--- a/tests/Modules/Camps/Service/MemberCampStayServiceTest.php
+++ b/tests/Modules/Camps/Service/MemberCampStayServiceTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Camps\Service;
+
+use Core\Config\ScoutYearService;
+use Core\Database\Connection;
+use Core\Member\SectionMembershipRepository;
+use Core\Member\SectionService;
+use Core\Module\MemberCampStayProvider;
+use Core\Security\EncryptionService;
+use Modules\Camps\Repository\CampRepository;
+use Modules\Camps\Repository\PlaceRepository;
+use Modules\Camps\Service\MemberCampStayService;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Camps\CampsTestHelper;
+
+/**
+ * Where a member went, as the admin member page shows it.
+ *
+ * Nothing records a camp's participants one by one — camps link to
+ * SECTIONS — so every case here is really about the same question: does
+ * the inference claim only what the site knows?
+ *
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class MemberCampStayServiceTest extends TestCase
+{
+    private \PDO $pdo;
+    private CampRepository $camps;
+    private PlaceRepository $places;
+    private MemberCampStayService $service;
+    private int $memberId;
+    private int $meuteId;
+    private int $rucheId;
+    private int $year2526;
+    private int $year2425;
+    private int $placeId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        CampsTestHelper::createTables($this->pdo);
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $connection = Connection::withPdo($this->pdo);
+
+        $this->camps = new CampRepository($this->pdo, $encryption);
+        $this->places = new PlaceRepository($this->pdo);
+
+        $scoutYearService = new ScoutYearService($this->pdo);
+        $this->year2425 = $scoutYearService->ensureYear('2024-2025');
+        $this->year2526 = $scoutYearService->ensureYear('2025-2026');
+
+        $this->pdo->exec("INSERT INTO age_branches (desk_code, label, sort_order) VALUES ('LOU', 'Louveteaux', 1)");
+        $branchId = (int) $this->pdo->lastInsertId();
+        $this->pdo->exec("INSERT INTO sections (desk_code, age_branch_id, name) VALUES ('LOU01', {$branchId}, 'Meute')");
+        $this->meuteId = (int) $this->pdo->lastInsertId();
+        $this->pdo->exec("INSERT INTO sections (desk_code, age_branch_id, name) VALUES ('BAL01', {$branchId}, 'Ruche')");
+        $this->rucheId = (int) $this->pdo->lastInsertId();
+
+        $this->pdo->exec("INSERT INTO members (desk_id) VALUES ('D1')");
+        $this->memberId = (int) $this->pdo->lastInsertId();
+
+        $this->placeId = $this->places->create('Ferme de Beaumont', null, null, 'Beaumont', 'BE', null);
+
+        $this->service = new MemberCampStayService(
+            $this->camps,
+            $this->places,
+            new SectionMembershipRepository($this->pdo),
+            new SectionService($connection, $encryption, new \Core\Badge\MemberBadgeRepository($this->pdo)),
+            $scoutYearService
+        );
+    }
+
+    private function wasIn(int $sectionId, int $scoutYearId, string $startDate): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO member_section_periods (member_id, section_id, scout_year_id, start_date, end_date) VALUES (?, ?, ?, ?, NULL)'
+        );
+        $stmt->execute([$this->memberId, $sectionId, $scoutYearId, $startDate]);
+    }
+
+    /**
+     * @param int[] $sectionIds
+     */
+    private function stay(?string $start, ?string $end, ?int $yearOnly, array $sectionIds): int
+    {
+        return $this->camps->create(
+            $this->placeId,
+            'grand_camp',
+            $start,
+            $end,
+            $yearOnly,
+            'confirmed',
+            null,
+            null,
+            null,
+            null,
+            $sectionIds
+        );
+    }
+
+    public function testAStayHerSectionWentOnThatYearIsHers(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2526, '2025-09-01');
+        $stayId = $this->stay('2026-07-12', '2026-07-19', null, [$this->meuteId]);
+
+        $stays = $this->service->getCampStays($this->memberId);
+
+        $this->assertCount(1, $stays);
+        $this->assertSame('Ferme de Beaumont', $stays[0]->placeLabel);
+        $this->assertSame('Meute', $stays[0]->sectionName);
+        $this->assertSame('2025-2026', $stays[0]->scoutYearLabel);
+        $this->assertSame('/chefs/camps/sejours/' . $stayId, $stays[0]->path);
+        $this->assertNotSame('', $stays[0]->periodLabel);
+    }
+
+    /**
+     * The heart of the inference: belonging to the section is not enough,
+     * she has to have belonged to it IN the year the stay happened.
+     */
+    public function testAStayHerSectionWentOnBeforeSheJoinedItIsNotHers(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2526, '2025-09-01');
+        $this->stay('2025-07-12', '2025-07-19', null, [$this->meuteId]);
+
+        $this->assertSame([], $this->service->getCampStays($this->memberId));
+    }
+
+    public function testAStayAnotherSectionWentOnIsNotHers(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2526, '2025-09-01');
+        $this->stay('2026-07-12', '2026-07-19', null, [$this->rucheId]);
+
+        $this->assertSame([], $this->service->getCampStays($this->memberId));
+    }
+
+    /**
+     * A grand camp happens in July or August, so a bare "2012" is read as
+     * the scout year ENDING in it. Dropping those stays instead would
+     * silently empty the block for exactly the old camps this exists to
+     * remember.
+     */
+    public function testAStayRememberedOnlyByItsYearIsPlacedAtTheEndOfThatScoutYear(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2425, '2024-09-01');
+        $this->stay(null, null, 2025, [$this->meuteId]);
+
+        $stays = $this->service->getCampStays($this->memberId);
+
+        $this->assertCount(1, $stays);
+        $this->assertSame('2024-2025', $stays[0]->scoutYearLabel);
+        $this->assertSame('2025', $stays[0]->periodLabel);
+    }
+
+    public function testMostRecentFirst(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2425, '2024-09-01');
+        $this->wasIn($this->meuteId, $this->year2526, '2025-09-01');
+        $this->stay('2025-07-12', '2025-07-19', null, [$this->meuteId]);
+        $this->stay('2026-07-12', '2026-07-19', null, [$this->meuteId]);
+
+        $stays = $this->service->getCampStays($this->memberId);
+
+        $this->assertSame(['2025-2026', '2024-2025'], array_map(fn($s) => $s->scoutYearLabel, $stays));
+    }
+
+    /**
+     * A stay two of her sections both went on is ONE stay: the reader
+     * wants where she went, not how many rows the join produced.
+     */
+    public function testAStayTwoOfHerSectionsWentOnIsStillOneLine(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2526, '2025-09-01');
+        $this->wasIn($this->rucheId, $this->year2526, '2026-01-15');
+        $this->stay('2026-07-12', '2026-07-19', null, [$this->meuteId, $this->rucheId]);
+
+        $this->assertCount(1, $this->service->getCampStays($this->memberId));
+    }
+
+    public function testAMemberWithNoSectionHistoryGetsNothingRatherThanAnError(): void
+    {
+        $this->stay('2026-07-12', '2026-07-19', null, [$this->meuteId]);
+
+        $this->assertSame([], $this->service->getCampStays($this->memberId));
+    }
+
+    /**
+     * A stay with neither a readable date nor a year cannot be attached
+     * to anybody: the site does not know when it happened.
+     */
+    public function testAnUndatableStayIsAttachedToNobody(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2526, '2025-09-01');
+        $this->stay(null, null, null, [$this->meuteId]);
+
+        $this->assertSame([], $this->service->getCampStays($this->memberId));
+    }
+
+    public function testTheListIsCapped(): void
+    {
+        $this->wasIn($this->meuteId, $this->year2526, '2025-09-01');
+        for ($i = 0; $i < MemberCampStayProvider::LIMIT + 3; $i++) {
+            $this->stay('2026-07-0' . (($i % 8) + 1), '2026-07-1' . (($i % 9) + 1), null, [$this->meuteId]);
+        }
+
+        $this->assertCount(MemberCampStayProvider::LIMIT, $this->service->getCampStays($this->memberId));
+    }
+}

--- a/tests/Modules/Groups/Service/MemberDiscussionGroupServiceTest.php
+++ b/tests/Modules/Groups/Service/MemberDiscussionGroupServiceTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Groups\Service;
+
+use Modules\Groups\Repository\GroupMemberRepository;
+use Modules\Groups\Repository\GroupRepository;
+use Modules\Groups\Service\MemberDiscussionGroupService;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Groups\GroupsTestHelper;
+
+/**
+ * Which groups a member belongs to, as the admin member page shows it.
+ *
+ * The case that matters most is the one about what must NOT be there:
+ * this hook answers "who is reachable where", never "what did they
+ * write".
+ *
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class MemberDiscussionGroupServiceTest extends TestCase
+{
+    private \PDO $pdo;
+    private GroupRepository $groups;
+    private GroupMemberRepository $members;
+    private MemberDiscussionGroupService $service;
+    private int $memberId;
+    private int $otherMemberId;
+    private int $scoutYearId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        GroupsTestHelper::createTables($this->pdo);
+
+        $this->groups = new GroupRepository($this->pdo);
+        $this->members = new GroupMemberRepository($this->pdo);
+        $this->service = new MemberDiscussionGroupService($this->members, $this->groups);
+
+        $this->scoutYearId = GroupsTestHelper::createScoutYear($this->pdo, '2025-2026', true);
+        $this->memberId = GroupsTestHelper::createMember($this->pdo, 'D1');
+        $this->otherMemberId = GroupsTestHelper::createMember($this->pdo, 'D2');
+    }
+
+    private function group(string $name): int
+    {
+        return $this->groups->create($name, $this->scoutYearId, null, null);
+    }
+
+    public function testAMemberSGroupsComeBackWithTheirNameAndAPath(): void
+    {
+        $groupId = $this->group('Staff d\'unité');
+        $this->members->add($groupId, $this->memberId, false, null);
+
+        $groups = $this->service->getDiscussionGroups($this->memberId);
+
+        $this->assertCount(1, $groups);
+        $this->assertSame('Staff d\'unité', $groups[0]->name);
+        $this->assertSame('/groups/' . $groupId, $groups[0]->path);
+        $this->assertFalse($groups[0]->isModerator);
+        $this->assertFalse($groups[0]->isClosed);
+    }
+
+    public function testRunningAGroupIsDistinguishedFromMerelyBeingInIt(): void
+    {
+        $groupId = $this->group('Intendance');
+        $this->members->add($groupId, $this->memberId, true, null);
+
+        $groups = $this->service->getDiscussionGroups($this->memberId);
+
+        $this->assertTrue($groups[0]->isModerator);
+    }
+
+    /**
+     * A closed group is still part of the journey. Saying so is what
+     * stops it reading as somewhere the person is reachable today.
+     */
+    public function testAClosedGroupIsListedAndSaysSo(): void
+    {
+        $groupId = $this->group('Camp 2024');
+        $this->members->add($groupId, $this->memberId, false, null);
+        $this->groups->setClosed($groupId, '2024-09-01 10:00:00');
+
+        $groups = $this->service->getDiscussionGroups($this->memberId);
+
+        $this->assertCount(1, $groups);
+        $this->assertTrue($groups[0]->isClosed);
+    }
+
+    public function testOpenGroupsComeBeforeClosedOnes(): void
+    {
+        $closed = $this->group('Camp 2024');
+        $open = $this->group('Staff d\'unité');
+        $this->members->add($closed, $this->memberId, false, null);
+        $this->members->add($open, $this->memberId, false, null);
+        $this->groups->setClosed($closed, '2024-09-01 10:00:00');
+
+        $groups = $this->service->getDiscussionGroups($this->memberId);
+
+        $this->assertSame(['Staff d\'unité', 'Camp 2024'], array_map(fn($g) => $g->name, $groups));
+    }
+
+    public function testOneMembersGroupsNeverLeakIntoAnothers(): void
+    {
+        $groupId = $this->group('Staff d\'unité');
+        $this->members->add($groupId, $this->memberId, false, null);
+
+        $this->assertCount(1, $this->service->getDiscussionGroups($this->memberId));
+        $this->assertSame([], $this->service->getDiscussionGroups($this->otherMemberId));
+    }
+
+    public function testBelongingToNoGroupIsAnEmptyListRatherThanAnError(): void
+    {
+        $this->assertSame([], $this->service->getDiscussionGroups($this->memberId));
+    }
+
+    /**
+     * The whole boundary of this hook: a chef d'unité needs to know which
+     * groups reach this person, and nothing about what people write to
+     * each other. Nothing in the DTO can carry a message.
+     */
+    public function testNothingAboutWhatIsWrittenInAGroupTravelsWithTheMembership(): void
+    {
+        $groupId = $this->group('Staff d\'unité');
+        $this->members->add($groupId, $this->memberId, false, null);
+
+        $properties = array_keys(get_object_vars($this->service->getDiscussionGroups($this->memberId)[0]));
+        sort($properties);
+
+        $this->assertSame(['isClosed', 'isModerator', 'name', 'path'], $properties);
+    }
+}


### PR DESCRIPTION
## Ce que ça change

Trois blocs de plus sur `/admin/members/{id}`, qui répondent tous à la même question : **où cette personne est-elle passée ?** Tous les trois sont des hooks §7.4 — le cœur déclare l'interface, le module l'implémente, la racine de composition câble en **nullable** — donc un site sans `leadership`, sans `camps` ou sans `groups` ne dessine tout simplement pas le bloc correspondant.

### Les formations ne créent rien

`Core\Module\FormationPathProvider` existait déjà et `Modules\Leadership\Service\MemberFormationPathService` l'implémentait déjà. La fiche admin en devient un **second consommateur**, exactement comme la feuille de route l'annonce. C'est aussi le seul bloc ici rattaché à une **année scoute** : où quelqu'un en est est une affirmation sur une saison, pas un fait qui s'accumule.

**Le docblock de cette interface disait « Self only » de façon plate. Il est réécrit dans la même PR plutôt que contredit en silence.** Ce que « self only » interdisait, c'est qu'un chef lise le parcours d'un membre sur une page construite **pour ce membre** ; ça n'a jamais été une règle disant que l'unité ne peut pas savoir où en sont ses propres animateurs. `/admin/leadership/training` porte exactement le même plancher `admin` que cette page — **aucune frontière ne bouge**, rien n'apparaît ici qu'un lecteur ne puisse déjà ouvrir à un menu de distance.

### Les camps sont une déduction, et l'interface le dit là où un implémenteur le lira

Rien n'enregistre les participants d'un séjour un par un : `camp_camps` pointe vers des **sections**. Un séjour compte donc pour ce membre quand sa section est partie une année scoute où il en faisait partie — `member_section_periods` (cœur) croisé avec `camp_camp_sections` (module). C'est ce que le site sait ; un bloc prétendant à une vraie liste de participants l'inventerait.

**Un séjour ne porte pas d'année scoute**, seulement des dates — ou, pour la moitié de ce qu'une unité se rappelle de son passé, une année nue. Le placer, c'est donc `ScoutYearService::labelForDate()` sur la date de **fin**, la règle du site.

Un séjour `year_only` est lu comme l'année scoute **se terminant** cette année-là : un grand camp a lieu en juillet ou août, donc « 2012 » veut dire 2011-2012. **C'est une convention, pas un fait**, et c'est la moins fausse disponible — les écarter reviendrait à vider silencieusement le bloc pour exactement les vieux camps que cette fonctionnalité existe pour se rappeler. Un séjour sans date lisible **ni** année n'est rattaché à personne : le site ne sait pas quand il a eu lieu.

Une ligne par séjour même quand deux des sections du membre y sont allées : le lecteur veut savoir **où** il est parti, pas combien de lignes la jointure a produites. Plafonné à `MemberCampStayProvider::LIMIT`, sur l'interface pour la même raison que `SETTLED_LIMIT` en IT-07, et la page le dit quand le plafond mord.

### Les groupes, c'est l'appartenance et rien d'autre

Aucun message, aucune réponse, aucun décompte de l'un ou de l'autre. Un chef d'unité qui reçoit « elle ne reçoit rien » a besoin de savoir par quels groupes cette personne est joignable ; **ce que les gens s'écrivent n'est pas un fait à résumer sur une page de staff**. `testNothingAboutWhatIsWrittenInAGroupTravelsWithTheMembership` épingle la liste des propriétés du DTO, pour qu'un futur « et si on ajoutait juste le nombre de messages » ne passe pas inaperçu.

**Appartenances explicites uniquement.** Le module dérive aussi l'appartenance de la composition d'un groupe de section (`GroupAccessService::isDerivedMember()`), et c'est délibérément absent : un membre dérivé est dans le groupe **à cause de** sa section de cette année, ce que la carte « Parcours dans l'unité » dit déjà une carte plus haut. Le répéter comme une appartenance dirait qu'un chef d'unité a fait quelque chose qu'il n'a pas fait.

Les groupes ouverts d'abord, chaque côté par activité la plus récente : un groupe clôturé fait toujours partie du parcours, mais ce n'est pas là que la personne est joignable aujourd'hui.

### Les liens sont toujours ouvrables par qui les voit

Une page de séjour est `chief`, sous le `admin` de cette page. Et un administrateur du site lit **tous** les groupes par la règle propre au module (`GroupAccessService::canRead()` → `isSiteAdmin()`). Aucun lien ne mène à un 403.

## Points de forme

- **Chaque implémentation vit dans le `Service\` de son module, pas dans son `Api\`.** `Api\` est là où un module **publie** une interface à lui (§7.5) ; ici l'interface est celle du cœur (§7.4). La feuille de route le dit explicitement, et j'ai aussi déplacé `MemberRegistrationOriginService` d'IT-07 pour la même raison, avant que cette PR-là ne fusionne.
- **`bi-tent` n'existe pas dans la feuille de style embarquée** — le docblock de `UxConventionsTest` raconte que c'est exactement comme ça que le module Camps avait livré une icône invisible. Le bloc utilise `bi-tree`, l'icône que le module Camps porte lui-même dans son manifeste.
- **Aucun `schema.sql` ne bouge.** Une interface de lecture ne change aucune table, donc aucun bump de version de module. Une seule méthode de dépôt ajoutée (`CampRepository::findBySectionIds()`, avec `DISTINCT`).

## Documentation mise à jour dans la même PR

- `ARCHITECTURE.md` **§8.62quinquies** (nouveau) — les trois blocs, la déduction des camps et sa convention d'année, la frontière du bloc groupes, et pourquoi le docblock de `FormationPathProvider` est réécrit.
- `core/Module/FormationPathProvider.php` — le contrat lui-même, pour que le code et la doc ne se contredisent pas.
- `specifications.md` **§4.4** — les trois blocs et ce qu'ils ne prétendent pas.
- `docs/module-development.md` — les deux nouvelles interfaces dans le tableau de la section « Filling a block on a member's page » (créée en IT-07), plus une règle de plus : **dis ce que ta réponse déduit**, quand elle déduit quelque chose. Un hook qui prétend discrètement plus que ce que les tables contiennent est le genre d'erreur que personne n'attrape, parce que la page a l'air juste.
- `docs/help/fiche-membre-admin.md` — les trois blocs et la nature déduite des camps (463 mots, sous la butée de 500 de design.md §7.11, un seul bloc de rappel).

## Tests

- `MemberCampStayServiceTest` (9, nouveau) — un séjour de sa section cette année-là est le sien ; **un séjour de sa section avant qu'elle ne la rejoigne ne l'est pas** (le cœur de la déduction) ; un séjour d'une autre section non plus ; un séjour connu par sa seule année est placé à la fin de cette année scoute ; le plus récent d'abord ; deux de ses sections au même camp font toujours une ligne ; aucun historique de section = rien plutôt qu'une erreur ; un séjour indatable n'est rattaché à personne ; le plafond.
- `MemberDiscussionGroupServiceTest` (7, nouveau) — le nom et le chemin ; animer un groupe se distingue d'y appartenir ; un groupe clôturé est listé **et le dit** ; les ouverts d'abord ; les groupes d'un membre ne fuient jamais chez un autre ; aucune appartenance = liste vide ; et **rien de ce qui s'écrit dans un groupe ne voyage avec l'appartenance**.
- `AdminMemberPageServiceTest` (+2) — les trois hooks du parcours sont interrogés sur `members.id`, et le parcours de formation reçoit en plus **l'année affichée à l'écran** ; une liste de camps pleine est signalée comme plafonnée. Le cas « sans aucun module » couvre désormais aussi les quatre nouvelles clés.
- RBAC : aucune frontière déplacée. Les trois blocs vivent sur `/admin/members/{id}` (`role_min: admin`, couvert par `MemberSearchRbacTest`), et les deux liens sortants pointent vers des routes que ce plancher ouvre déjà.

PHPStan **OK**, PHPUnit **12 142 tests**, `npm run typecheck` **OK**, Vitest **1 579 tests** — tous verts localement.

---
_Generated by [Claude Code](https://claude.ai/code/session_019EgucjNpHf217pBeCuUSTN)_