### PR TITLE
IT-02 — Lock the scheduler zones IT-03 will rework (tests only)

### DIFF
--- a/tests/Core/Scheduler/CoreTaskHandlersTest.php
+++ b/tests/Core/Scheduler/CoreTaskHandlersTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Scheduler;
+
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Scheduler\CoreTaskHandlers;
+use Core\Scheduler\SchedulerRepository;
+use Core\Scheduler\SchedulerRunner;
+use Core\Scheduler\TaskHandlerInterface;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+
+/**
+ * CoreTaskHandlers is the single declaration both entry points register
+ * from — the mechanism that ended the create_backup drift (§8.17). These
+ * tests pin the declaration itself before the scheduler bootstrap is
+ * reworked (chantier « dépendances entre modules », IT-03).
+ */
+class CoreTaskHandlersTest extends TestCase
+{
+    public function testEveryDeclaredHandlerClassExistsAndImplementsTheInterface(): void
+    {
+        $all = CoreTaskHandlers::all();
+
+        $this->assertNotEmpty($all);
+
+        foreach ($all as $taskKey => $handlerClass) {
+            $this->assertIsString($taskKey);
+            $this->assertNotSame('', $taskKey);
+            $this->assertTrue(class_exists($handlerClass), "{$handlerClass} (task '{$taskKey}') does not exist");
+            $this->assertTrue(
+                is_subclass_of($handlerClass, TaskHandlerInterface::class),
+                "{$handlerClass} (task '{$taskKey}') must implement TaskHandlerInterface"
+            );
+        }
+    }
+
+    public function testEveryDeclaredHandlerIsConstructibleWithoutArguments(): void
+    {
+        // registerAll() does `new $handlerClass()`: a core handler that
+        // grows a required constructor parameter breaks BOTH entry points
+        // at boot. This says so at unit-test speed instead.
+        foreach (CoreTaskHandlers::all() as $taskKey => $handlerClass) {
+            $constructor = (new \ReflectionClass($handlerClass))->getConstructor();
+            $required = $constructor === null ? 0 : $constructor->getNumberOfRequiredParameters();
+            $this->assertSame(
+                0,
+                $required,
+                "{$handlerClass} (task '{$taskKey}') must stay constructible with no arguments"
+            );
+        }
+    }
+
+    public function testRegisterAllRegistersExactlyTheDeclaredSetUnderTheCoreModuleId(): void
+    {
+        $pdo = DatabaseTestHelper::createTestDatabase();
+        $runner = new SchedulerRunner(new SchedulerRepository($pdo), new JournalService(new JournalRepository($pdo)));
+
+        CoreTaskHandlers::registerAll($runner);
+
+        // The runner keeps its handlers private; the registration's whole
+        // observable contract is the key set, read through reflection so
+        // this stays a test of registerAll() and not of processOverdue().
+        $property = new \ReflectionProperty(SchedulerRunner::class, 'handlers');
+        /** @var array<string, TaskHandlerInterface> $registered */
+        $registered = $property->getValue($runner);
+
+        $expectedKeys = array_map(
+            static fn (string $taskKey): string => 'core::' . $taskKey,
+            array_keys(CoreTaskHandlers::all())
+        );
+
+        $this->assertSame($expectedKeys, array_keys($registered));
+
+        foreach (CoreTaskHandlers::all() as $taskKey => $handlerClass) {
+            $this->assertInstanceOf($handlerClass, $registered['core::' . $taskKey]);
+        }
+    }
+}

--- a/tests/Core/Scheduler/SchedulerRunnerTest.php
+++ b/tests/Core/Scheduler/SchedulerRunnerTest.php
@@ -274,7 +274,7 @@ class SchedulerRunnerTest extends TestCase
     public function testProcessOverdueResolvesAHandlerClassThroughTheModuleManager(): void
     {
         $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
-        $moduleManager->method('getTaskHandler')
+        $moduleManager->expects($this->once())->method('getTaskHandler')
             ->with('some_module', 'auto_task')
             ->willReturn(ModuleResolvedFixtureHandler::class);
         $this->runner->setModuleManager($moduleManager);

--- a/tests/Core/Scheduler/SchedulerRunnerTest.php
+++ b/tests/Core/Scheduler/SchedulerRunnerTest.php
@@ -261,6 +261,108 @@ class SchedulerRunnerTest extends TestCase
         $this->assertInstanceOf(UserAccountRepository::class, $handler->seenUserAccounts);
     }
 
+    // ── Auto-resolution through the ModuleManager ───────────────────────
+    //
+    // The other way a handler reaches the runner: no registerHandler()
+    // call, the class name comes from the enabled module's manifest via
+    // ModuleManager::getTaskHandler() and is instantiated with NO
+    // arguments (`new $handlerClass()`). That no-argument construction is
+    // the root cause behind the §7.5 leaks in task handlers (chantier
+    // « dépendances entre modules », C2) — these tests freeze the
+    // resolution contract before IT-03 reworks the bootstrap around it.
+
+    public function testProcessOverdueResolvesAHandlerClassThroughTheModuleManager(): void
+    {
+        $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
+        $moduleManager->method('getTaskHandler')
+            ->with('some_module', 'auto_task')
+            ->willReturn(ModuleResolvedFixtureHandler::class);
+        $this->runner->setModuleManager($moduleManager);
+
+        ModuleResolvedFixtureHandler::$payloads = [];
+        $pastTime = (new \DateTimeImmutable('-1 minute'))->format('Y-m-d H:i:s');
+        $id = $this->repo->create('some_module', 'auto_task', $pastTime, json_encode(['a' => 1]), null);
+
+        $processed = $this->runner->processOverdue();
+
+        $this->assertSame(1, $processed);
+        $this->assertSame('done', $this->repo->findById($id)['status']);
+        $this->assertCount(1, ModuleResolvedFixtureHandler::$payloads);
+        $this->assertSame(
+            ['a' => 1, 'requested_by_user_account_id' => null],
+            ModuleResolvedFixtureHandler::$payloads[0]
+        );
+    }
+
+    public function testATaskWhoseModuleIsDisabledFailsAsUnregistered(): void
+    {
+        // A disabled (or unknown) module has no manifest loaded, so
+        // getTaskHandler() answers null — the runner must fail the task
+        // with the "No handler registered" diagnostic, never crash and
+        // never silently drop the row.
+        $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
+        $moduleManager->method('getTaskHandler')->willReturn(null);
+        $this->runner->setModuleManager($moduleManager);
+
+        $pastTime = (new \DateTimeImmutable('-1 minute'))->format('Y-m-d H:i:s');
+        $id = $this->repo->create('disabled_module', 'their_task', $pastTime, null, null);
+
+        $processed = $this->runner->processOverdue();
+
+        $this->assertSame(0, $processed);
+        $action = $this->repo->findById($id);
+        $this->assertSame('failed', $action['status']);
+        $this->assertStringContainsString('No handler registered', $action['last_error']);
+    }
+
+    public function testAManifestNamingAMissingClassFailsTheTaskAsUnregistered(): void
+    {
+        // A manifest can name a class that is not on disk (a module
+        // half-deployed over FTP). class_exists() is the guard; the
+        // outcome must be the same clean failure as no handler at all.
+        $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
+        $moduleManager->method('getTaskHandler')->willReturn('\\Modules\\Nowhere\\Task\\GhostHandler');
+        $this->runner->setModuleManager($moduleManager);
+
+        $pastTime = (new \DateTimeImmutable('-1 minute'))->format('Y-m-d H:i:s');
+        $id = $this->repo->create('half_deployed', 'ghost_task', $pastTime, null, null);
+
+        $this->runner->processOverdue();
+
+        $action = $this->repo->findById($id);
+        $this->assertSame('failed', $action['status']);
+        $this->assertStringContainsString('No handler registered', $action['last_error']);
+    }
+
+    public function testADirectlyRegisteredHandlerWinsOverModuleManagerResolution(): void
+    {
+        // The composition roots hand-register a few module handlers WITH
+        // their dependencies (inbound_mail's sync, rental's reminders…);
+        // the same (module, key) may also be resolvable from the manifest.
+        // The hand-registered instance must win, or every carefully wired
+        // dependency would be silently replaced by a bare `new`.
+        $handler = new class implements TaskHandlerInterface {
+            public bool $called = false;
+
+            public function handle(array $payload, TaskContext $context): void
+            {
+                $this->called = true;
+            }
+        };
+        $this->runner->registerHandler('some_module', 'wired_task', $handler);
+
+        $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
+        $moduleManager->expects($this->never())->method('getTaskHandler');
+        $this->runner->setModuleManager($moduleManager);
+
+        $pastTime = (new \DateTimeImmutable('-1 minute'))->format('Y-m-d H:i:s');
+        $this->repo->create('some_module', 'wired_task', $pastTime, null, null);
+
+        $this->runner->processOverdue();
+
+        $this->assertTrue($handler->called);
+    }
+
     public function testJournalEntriesAreCreatedOnCompletion(): void
     {
         $handler = new class implements TaskHandlerInterface {
@@ -281,5 +383,21 @@ class SchedulerRunnerTest extends TestCase
         $entries = $journalRepo->search();
         $this->assertGreaterThan(0, count($entries));
         $this->assertSame('scheduler_task_done', $entries[0]['event_type']);
+    }
+}
+
+/**
+ * Named (not anonymous) because the runner instantiates it from its class
+ * NAME with no arguments — exactly what auto-resolution does to a real
+ * module handler.
+ */
+final class ModuleResolvedFixtureHandler implements TaskHandlerInterface
+{
+    /** @var list<array<string, mixed>> */
+    public static array $payloads = [];
+
+    public function handle(array $payload, TaskContext $context): void
+    {
+        self::$payloads[] = $payload;
     }
 }

--- a/tests/Core/Scheduler/TaskContextTest.php
+++ b/tests/Core/Scheduler/TaskContextTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Scheduler;
+
+use Core\Config\SettingRepository;
+use Core\Config\SettingService;
+use Core\Database\Connection;
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Mail\MailService;
+use Core\Notification\NotificationService;
+use Core\Scheduler\TaskContext;
+use Core\Security\EncryptionService;
+use Core\Security\UserAccountRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+
+/**
+ * TaskContext is the whole world a task handler gets (module handlers are
+ * auto-resolved with `new $handlerClass()` and receive nothing else), so
+ * what it exposes — and what stays optional — is a contract worth pinning
+ * before the scheduler bootstrap is reworked (chantier « dépendances
+ * entre modules », IT-03).
+ */
+class TaskContextTest extends TestCase
+{
+    private function buildContext(?NotificationService $notifications = null, bool $withNotificationsArg = true): TaskContext
+    {
+        $pdo = DatabaseTestHelper::createTestDatabase();
+        $connection = Connection::withPdo($pdo);
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $mailService = $this->createMock(MailService::class);
+        $journal = new JournalService(new JournalRepository($pdo));
+        $settings = new SettingService(new SettingRepository($pdo));
+        $userAccounts = new UserAccountRepository($pdo, $encryption);
+
+        if (!$withNotificationsArg) {
+            return new TaskContext($connection, $encryption, $mailService, $journal, $settings, $userAccounts, '/tmp/storage-root');
+        }
+
+        return new TaskContext($connection, $encryption, $mailService, $journal, $settings, $userAccounts, '/tmp/storage-root', $notifications);
+    }
+
+    public function testExposesEveryDependencyItWasConstructedWith(): void
+    {
+        $pdo = DatabaseTestHelper::createTestDatabase();
+        $connection = Connection::withPdo($pdo);
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $mailService = $this->createMock(MailService::class);
+        $journal = new JournalService(new JournalRepository($pdo));
+        $settings = new SettingService(new SettingRepository($pdo));
+        $userAccounts = new UserAccountRepository($pdo, $encryption);
+        $notifications = $this->createMock(NotificationService::class);
+
+        $context = new TaskContext($connection, $encryption, $mailService, $journal, $settings, $userAccounts, '/srv/storage', $notifications);
+
+        $this->assertSame($connection, $context->connection);
+        $this->assertSame($encryption, $context->encryption);
+        $this->assertSame($mailService, $context->mailService);
+        $this->assertSame($journal, $context->journal);
+        $this->assertSame($settings, $context->settings);
+        $this->assertSame($userAccounts, $context->userAccounts);
+        $this->assertSame('/srv/storage', $context->storagePath);
+        $this->assertSame($notifications, $context->notifications);
+    }
+
+    public function testNotificationsDefaultsToNullSoEveryHandlerMustNullGuardIt(): void
+    {
+        // Both entry points legitimately construct a context without a
+        // NotificationService (VAPID keys absent or invalid — see
+        // public/cron.php), so the property being nullable-by-default is
+        // load-bearing, not an accident of signature.
+        $context = $this->buildContext(withNotificationsArg: false);
+
+        $this->assertNull($context->notifications);
+    }
+
+    public function testEveryExposedDependencyIsReadonly(): void
+    {
+        // A handler mutating the shared context would poison every later
+        // task in the same scheduler pass — the promotion to readonly
+        // properties is the guarantee, and this keeps it.
+        $reflection = new \ReflectionClass(TaskContext::class);
+
+        foreach ($reflection->getProperties() as $property) {
+            $this->assertTrue(
+                $property->isReadOnly(),
+                "TaskContext::\${$property->getName()} must be readonly"
+            );
+        }
+    }
+}

--- a/tests/Modules/Camps/Task/PurgeUnsortedMailHandlerTest.php
+++ b/tests/Modules/Camps/Task/PurgeUnsortedMailHandlerTest.php
@@ -199,6 +199,25 @@ class PurgeUnsortedMailHandlerTest extends TestCase
         );
     }
 
+    public function testTodayThePurgeRunsWhetherOrNotTheInboundMailModuleIsEnabled(): void
+    {
+        // The provider-absent case, stated explicitly (chantier
+        // « dépendances entre modules », IT-02). This handler reaches
+        // straight into inbound_mail's repositories and never consults
+        // the module registry, so a disabled provider module changes
+        // nothing — the purge still runs against its tables. Pinned here
+        // as the CURRENT behaviour: IT-04 migrates this handler to
+        // TaskContext::getOptional() and will deliberately flip this to
+        // "provider absent → no-op", updating this test in the same
+        // change.
+        $this->pdo->exec("INSERT INTO module_registry (module_id, enabled, installed_version) VALUES ('inbound_mail', 0, '1.0.0')");
+        $old = $this->unsortedMessage('-8 months', 'vieux@mozet.be');
+
+        $this->handle();
+
+        $this->assertNull($this->find($old));
+    }
+
     // ── helpers ─────────────────────────────────────────────────────
 
     private function handle(): void

--- a/tests/Modules/Finance/Task/RunCategorizationRulesHandlerTest.php
+++ b/tests/Modules/Finance/Task/RunCategorizationRulesHandlerTest.php
@@ -98,6 +98,34 @@ class RunCategorizationRulesHandlerTest extends TestCase
         $this->assertSame(1, $result['categorized_by_rules']);
     }
 
+    public function testHandleAppliesKeywordRulesAndSkipsAiWhenNoLlmProviderIsConfigured(): void
+    {
+        // The provider-absent case, stated explicitly (chantier
+        // « dépendances entre modules », IT-02): the llm_connector tables
+        // exist but hold no active provider — also what this handler sees
+        // today when the module is disabled, since it constructs
+        // LlmConnectorService unconditionally and only isAvailable() gates
+        // the calls. Keyword rules still categorize; no AI suggestion row
+        // is written and nothing fails.
+        $categoryId = $this->categoryRepository->create('Alimentation');
+        $this->categoryRuleRepository->create($categoryId, 0, 'delhaize', null, null);
+        $matched = $this->transactionRepository->create(
+            $this->accountId, $this->fiscalYearId, 'r1', '2026-10-01', 'VIR Delhaize', -20.0, null, null, Transaction::SOURCE_MANUAL, null
+        );
+        // A movement no keyword rule matches — the one an AI pass would
+        // have been asked about.
+        $this->transactionRepository->create(
+            $this->accountId, $this->fiscalYearId, 'r2', '2026-10-02', 'VIR Mystere', -10.0, null, null, Transaction::SOURCE_MANUAL, null
+        );
+
+        $handler = new RunCategorizationRulesHandler();
+        $handler->handle([], $this->createTaskContext());
+
+        $this->assertSame($categoryId, $this->transactionRepository->findById($matched)->categoryId);
+        $suggestionCount = (int) $this->pdo->query('SELECT COUNT(*) FROM finance_ai_category_suggestions')->fetchColumn();
+        $this->assertSame(0, $suggestionCount);
+    }
+
     public function testHandleDegradesGracefullyWhenCalendarModuleIsNotEnabled(): void
     {
         // No module_registry row for 'calendar' at all — the handler must

--- a/tests/Modules/Retro/Task/AutoCloseHandlerTest.php
+++ b/tests/Modules/Retro/Task/AutoCloseHandlerTest.php
@@ -102,6 +102,25 @@ class AutoCloseHandlerTest extends TestCase
         $this->assertTrue(true);
     }
 
+    public function testClosesAndNotifiesWithoutASummaryWhenNoLlmProviderIsConfigured(): void
+    {
+        // The provider-absent case, stated explicitly (chantier
+        // « dépendances entre modules », IT-02): the llm_connector tables
+        // exist but hold no active provider — which is also what the
+        // handler sees today when the module is disabled, since it never
+        // consults the registry. Everything the board owner was promised
+        // still happens: the board closes, the notification email leaves;
+        // only the AI summary is skipped, silently.
+        $boardId = $this->createOpenBoard(true, 'chief@example.com');
+        $this->context->mailService->expects($this->once())->method('send')->with('chief@example.com');
+
+        (new AutoCloseHandler())->handle(['board_id' => $boardId], $this->context);
+
+        $board = $this->boardRepository->findById($boardId);
+        $this->assertSame('closed', $board->status);
+        $this->assertNull($board->aiSummary);
+    }
+
     public function testSendsTheNotificationEmailWhenEnabledAndAddressPresent(): void
     {
         $boardId = $this->createOpenBoard(true, 'chief@example.com');


### PR DESCRIPTION
Second iteration of the chantier (ROADMAP-dependances-modules.md, IT-02). **No behaviour change — tests only**, freezing current behaviour where IT-03/IT-04 will intervene.

## What was done

- **`TaskContextTest` (new)**: construction exposes every dependency; `notifications` is nullable **by default** (both entry points legitimately build a context without it); every property is `readonly` (a handler mutating the shared context would poison every later task in the same pass).
- **`CoreTaskHandlersTest` (new)**: every declared class exists and implements `TaskHandlerInterface`; every one stays **no-arg constructible** (`registerAll()` does `new $handlerClass()`, so a core handler growing a required parameter breaks both entry points at boot — now said at unit-test speed); `registerAll()` registers exactly the declared set under `core::`.
- **`SchedulerRunnerTest`**: the auto-resolution path (`ModuleManager::getTaskHandler()` → `new $handlerClass()`) had zero coverage. Added: successful resolution with payload delivery; disabled/unknown module (null) → clean `No handler registered` failure; manifest naming a missing class → same; and **a directly-registered handler wins over resolution** — the guarantee that hand-wired dependencies (inbound_mail sync, rental reminders) are never silently replaced by a bare `new`.
- **Provider-absent cases on the handlers IT-04 migrates**:
  - `AutoCloseHandler`: no LLM provider → the board still closes, the notification email still leaves, `aiSummary` stays null.
  - `RunCategorizationRulesHandler`: no LLM provider → keyword rules still categorize, no AI suggestion row, no failure.
  - `PurgeUnsortedMailHandler`: today the purge runs **whether or not** `inbound_mail` is enabled (it never consults the registry) — pinned explicitly with a comment saying IT-04 will deliberately flip this to "provider absent → no-op" and update the test in the same change.
  - `AutoCreateRetroHandler` (retro disabled) and `ExtractReceiptDataHandler` (no provider) were already covered — verified, nothing added.

## Decisions taken alone

- The `PurgeUnsortedMailHandler` absence case is pinned as **current** behaviour rather than skipped: the intentional flip in IT-04 will then show up as an explicit test change in that PR instead of an unobserved side effect.

## Test state

- `vendor/bin/phpstan analyse`: OK
- `vendor/bin/phpunit`: OK — 12 163 tests (13 added)
- `npm run e2e` (confidence): 41 passed, 7.8 min
- `npm run typecheck`: unaffected (no JS touched), last run OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qA4tYCEkzkC9aLqFyy3tV

---
_Generated by [Claude Code](https://claude.ai/code/session_018qA4tYCEkzkC9aLqFyy3tV)_