### PR TITLE
IT-04 — Migrate the leaking task handlers to TaskContext capabilities

### DIFF
--- a/modules/calendar/src/Task/AutoCreateRetroHandler.php
+++ b/modules/calendar/src/Task/AutoCreateRetroHandler.php
@@ -27,9 +27,9 @@ use Modules\Retro\Repository\BoardRepository;
  * docs/module-development.md) — and re-checks everything fresh at run
  * time rather than trusting anything true when it was scheduled, since a
  * task can be scheduled weeks in advance:
- *   1. the retro module must still be enabled right now (task handlers get
- *      no ModuleManager — the established raw-query workaround, same
- *      precedent used wherever else this codebase needs it);
+ *   1. the retro module must still be enabled right now
+ *      (TaskContext::isModuleEnabled() — the supported replacement for
+ *      the raw module_registry query this handler once had to invent);
  *   2. the event must still exist;
  *   3. no board must already be linked (idempotency — a chief may have
  *      manually created/linked one before this ran, or this handler may
@@ -54,8 +54,7 @@ class AutoCreateRetroHandler implements TaskHandlerInterface
 
         $pdo = $context->connection->getPdo();
 
-        $retroEnabled = $pdo->query("SELECT enabled FROM module_registry WHERE module_id = 'retro'")->fetchColumn();
-        if ((int) $retroEnabled !== 1) {
+        if (!$context->isModuleEnabled('retro')) {
             return;
         }
 

--- a/modules/camps/src/Task/PurgeUnsortedMailHandler.php
+++ b/modules/camps/src/Task/PurgeUnsortedMailHandler.php
@@ -8,15 +8,12 @@ declare(strict_types=1);
 
 namespace Modules\Camps\Task;
 
-use Core\File\FileRepository;
 use Core\Scheduler\SchedulerService;
 use Core\Scheduler\TaskContext;
 use Core\Scheduler\TaskHandlerInterface;
 use Modules\Camps\Mail\CampsMessageConsumer;
+use Modules\InboundMail\Api\InboundMailInterface;
 use Modules\InboundMail\Api\InboundMessage;
-use Modules\InboundMail\Repository\InboundMailboxRepository;
-use Modules\InboundMail\Repository\InboundMessageRepository;
-use Modules\InboundMail\Service\InboundMailService;
 
 /**
  * Erases unsorted mail older than the configured retention, then
@@ -48,8 +45,14 @@ class PurgeUnsortedMailHandler implements TaskHandlerInterface
         $months = max(1, (int) ($context->settings->get('camps_unsorted_retention_months', 'camps', '6') ?? 6));
         $pdo = $context->connection->getPdo();
 
-        if (class_exists(InboundMailService::class)) {
-            $purged = $this->purge($pdo, $context, $months);
+        // The gateway is a capability (ARCHITECTURE.md §7.5 on the
+        // scheduled path): null — inbound_mail absent or disabled — means
+        // there is no live mailbox feeding « Courrier non classé », so
+        // there is nothing this retention is a counterweight to; the task
+        // just keeps its own chain armed for the day the module returns.
+        $inboundMail = $context->getOptional(InboundMailInterface::class);
+        if ($inboundMail !== null) {
+            $purged = $this->purge($inboundMail, $months);
             if ($purged > 0) {
                 $context->journal->log(
                     'camps',
@@ -63,14 +66,8 @@ class PurgeUnsortedMailHandler implements TaskHandlerInterface
         $this->rescheduleTomorrow($pdo);
     }
 
-    private function purge(\PDO $pdo, TaskContext $context, int $months): int
+    private function purge(InboundMailInterface $inboundMail, int $months): int
     {
-        $inboundMail = new InboundMailService(
-            new InboundMessageRepository($pdo, $context->encryption),
-            new InboundMailboxRepository($pdo, $context->encryption),
-            new FileRepository($pdo)
-        );
-
         $cutoff = (new \DateTimeImmutable())->modify('-' . $months . ' months');
         $purged = 0;
 

--- a/modules/finance/src/Task/ExtractReceiptDataHandler.php
+++ b/modules/finance/src/Task/ExtractReceiptDataHandler.php
@@ -20,12 +20,10 @@ use Modules\Finance\Repository\TransactionAttachmentRepository;
 use Modules\Finance\Repository\TransactionRepository;
 use Modules\Finance\Service\ReceiptDateNormalizer;
 use Modules\Finance\Service\ReceiptMatchingService;
+use Modules\LlmConnector\Api\LlmConnectorInterface;
 use Modules\LlmConnector\Api\LlmException;
 use Modules\LlmConnector\Api\LlmRequest;
 use Modules\LlmConnector\Api\LlmTier;
-use Modules\LlmConnector\Repository\ProviderModelRepository;
-use Modules\LlmConnector\Repository\ProviderRepository;
-use Modules\LlmConnector\Service\LlmConnectorService;
 
 /**
  * One-shot task (scheduled by Service\ReceiptExtractionService right
@@ -99,13 +97,12 @@ class ExtractReceiptDataHandler implements TaskHandlerInterface
             return;
         }
 
-        $llmConnector = new LlmConnectorService(
-            new ProviderRepository($pdo, $context->encryption),
-            new ProviderModelRepository($pdo),
-            $context->journal
-        );
-
-        if (!$llmConnector->isAvailable()) {
+        // The connector is a capability (ARCHITECTURE.md §7.5 on the
+        // scheduled path): null — llm_connector absent or disabled —
+        // means no suggestion is written and the receipt stays fully
+        // usable manually, same degradation as no configured provider.
+        $llmConnector = $context->getOptional(LlmConnectorInterface::class);
+        if ($llmConnector === null || !$llmConnector->isAvailable()) {
             return;
         }
 

--- a/modules/finance/src/Task/RunCategorizationRulesHandler.php
+++ b/modules/finance/src/Task/RunCategorizationRulesHandler.php
@@ -10,7 +10,6 @@ namespace Modules\Finance\Task;
 
 use Core\Config\SettingRepository;
 use Core\Config\SettingService;
-use Core\Module\ModuleRegistryRepository;
 use Core\Scheduler\SchedulerRepository;
 use Core\Scheduler\SchedulerService;
 use Core\Scheduler\TaskContext;
@@ -27,9 +26,7 @@ use Modules\Finance\Repository\TransactionRepository;
 use Modules\Finance\Service\AiCategorizationService;
 use Modules\Finance\Service\BulkCategorizationService;
 use Modules\Finance\Service\CategoryRuleEngine;
-use Modules\LlmConnector\Repository\ProviderModelRepository;
-use Modules\LlmConnector\Repository\ProviderRepository;
-use Modules\LlmConnector\Service\LlmConnectorService;
+use Modules\LlmConnector\Api\LlmConnectorInterface;
 
 /**
  * Runs Controller\ConfigCategoryController's "Exécuter les règles sur les
@@ -57,13 +54,13 @@ class RunCategorizationRulesHandler implements TaskHandlerInterface
         $categoryRepository = new CategoryRepository($pdo);
         $ruleEngine = new CategoryRuleEngine($transactionRepository, $categoryRuleRepository);
 
-        $llmConnector = new LlmConnectorService(
-            new ProviderRepository($pdo, $context->encryption),
-            new ProviderModelRepository($pdo),
-            $context->journal
-        );
+        // The connector is a capability (ARCHITECTURE.md §7.5 on the
+        // scheduled path): null — llm_connector absent or disabled —
+        // means AiCategorizationService reports unavailable, keyword
+        // rules still apply, and nothing fails.
+        $llmConnector = $context->getOptional(LlmConnectorInterface::class);
 
-        $calendarEnabled = (new ModuleRegistryRepository($pdo))->findByModuleId('calendar')['enabled'] ?? false;
+        $calendarEnabled = $context->isModuleEnabled('calendar');
 
         $aiCategorizationService = new AiCategorizationService(
             $llmConnector,

--- a/modules/retro/src/Task/AutoCloseHandler.php
+++ b/modules/retro/src/Task/AutoCloseHandler.php
@@ -10,9 +10,7 @@ namespace Modules\Retro\Task;
 
 use Core\Scheduler\TaskContext;
 use Core\Scheduler\TaskHandlerInterface;
-use Modules\LlmConnector\Repository\ProviderModelRepository;
-use Modules\LlmConnector\Repository\ProviderRepository;
-use Modules\LlmConnector\Service\LlmConnectorService;
+use Modules\LlmConnector\Api\LlmConnectorInterface;
 use Modules\Retro\Repository\BoardRepository;
 use Modules\Retro\Repository\CommentRepository;
 use Modules\Retro\Service\RetroException;
@@ -32,10 +30,10 @@ use Twig\Loader\FilesystemLoader;
  * all irrelevant to auto-closing) — a small, self-contained duplication of
  * the close+optional-summary logic instead, same "small tolerated
  * duplication" convention as Core\Maintenance's purge-beyond-limit helpers.
- * LlmConnectorService is always constructed directly from $pdo regardless
- * of whether the llm_connector module is enabled — same precedent as
- * Modules\Finance\Task\ExtractReceiptDataHandler — its own isAvailable()
- * check degrades gracefully either way.
+ * The connector is a capability (TaskContext::getOptional(),
+ * ARCHITECTURE.md §7.5 on the scheduled path): null — module absent or
+ * disabled — means the board still closes and notifies, only the AI
+ * summary is skipped.
  */
 class AutoCloseHandler implements TaskHandlerInterface
 {
@@ -61,16 +59,12 @@ class AutoCloseHandler implements TaskHandlerInterface
         $boardRepository->close($boardId);
         $context->journal->log('retro', 'board_auto_closed', 'info', 'Rétrospective clôturée automatiquement', ['board_id' => $boardId]);
 
-        $llmConnector = new LlmConnectorService(
-            new ProviderRepository($pdo, $context->encryption),
-            new ProviderModelRepository($pdo),
-            $context->journal
-        );
-        $summaryService = new SummaryService($llmConnector);
+        $llmConnector = $context->getOptional(LlmConnectorInterface::class);
+        $summaryService = $llmConnector !== null ? new SummaryService($llmConnector) : null;
 
         $visible = array_values(array_filter($commentRepository->findByBoardId($boardId), fn($c) => !$c->hidden));
 
-        if ($summaryService->isAvailable()) {
+        if ($summaryService !== null && $summaryService->isAvailable()) {
             try {
                 $summary = $summaryService->generate($visible);
                 if ($summary !== '') {

--- a/tests/Modules/Calendar/Task/AutoCreateRetroHandlerTest.php
+++ b/tests/Modules/Calendar/Task/AutoCreateRetroHandlerTest.php
@@ -45,21 +45,38 @@ class AutoCreateRetroHandlerTest extends TestCase
         $this->eventRepository = new CalendarEventRepository($this->pdo);
         $this->boardRepository = new BoardRepository($this->pdo, new \Core\Security\EncryptionService(str_repeat('a', 32), str_repeat('b', 32)));
 
+        // Retro's enablement now reaches the handler through
+        // TaskContext::isModuleEnabled() (IT-04 — the raw module_registry
+        // query is gone): the default context knows retro as disabled,
+        // and enableRetro() swaps in one that knows it as enabled.
+        $this->context = $this->buildContext(['calendar']);
+    }
+
+    /**
+     * @param string[] $enabledModuleIds
+     */
+    private function buildContext(array $enabledModuleIds): TaskContext
+    {
+        $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
+        $moduleManager->method('getEnabledModuleIds')->willReturn($enabledModuleIds);
         $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
-        $this->context = new TaskContext(
+
+        return new TaskContext(
             Connection::withPdo($this->pdo),
             $encryption,
             $this->createMock(MailService::class),
             new JournalService(new JournalRepository($this->pdo)),
             new SettingService(new SettingRepository($this->pdo)),
             new UserAccountRepository($this->pdo, $encryption),
-            sys_get_temp_dir()
+            sys_get_temp_dir(),
+            null,
+            new \Core\Scheduler\TaskCapabilities($moduleManager)
         );
     }
 
     private function enableRetro(): void
     {
-        $this->pdo->exec("INSERT INTO module_registry (module_id, enabled, installed_version) VALUES ('retro', 1, '1.3.0')");
+        $this->context = $this->buildContext(['calendar', 'retro']);
     }
 
     private function createEvent(bool $autoCreateRetro = true, ?string $endDate = '2026-08-10'): int

--- a/tests/Modules/Camps/Task/PurgeUnsortedMailHandlerTest.php
+++ b/tests/Modules/Camps/Task/PurgeUnsortedMailHandlerTest.php
@@ -199,38 +199,63 @@ class PurgeUnsortedMailHandlerTest extends TestCase
         );
     }
 
-    public function testTodayThePurgeRunsWhetherOrNotTheInboundMailModuleIsEnabled(): void
+    public function testThePurgeIsANoOpWhenInboundMailIsAbsent(): void
     {
-        // The provider-absent case, stated explicitly (chantier
-        // « dépendances entre modules », IT-02). This handler reaches
-        // straight into inbound_mail's repositories and never consults
-        // the module registry, so a disabled provider module changes
-        // nothing — the purge still runs against its tables. Pinned here
-        // as the CURRENT behaviour: IT-04 migrates this handler to
-        // TaskContext::getOptional() and will deliberately flip this to
-        // "provider absent → no-op", updating this test in the same
-        // change.
-        $this->pdo->exec("INSERT INTO module_registry (module_id, enabled, installed_version) VALUES ('inbound_mail', 0, '1.0.0')");
+        // The provider-absent case. IT-02 pinned the OLD behaviour (the
+        // handler reached straight into inbound_mail's tables and purged
+        // whether or not the module was enabled); IT-04 deliberately
+        // flipped it: the gateway is now a capability, and with the
+        // module absent or disabled there is no live mailbox feeding
+        // « Courrier non classé », so nothing is touched — the task only
+        // keeps its own chain armed for the day the module returns.
         $old = $this->unsortedMessage('-8 months', 'vieux@mozet.be');
 
-        $this->handle();
+        $this->handleWithoutInboundMail();
 
-        $this->assertNull($this->find($old));
+        $this->assertNotNull($this->find($old));
     }
 
     // ── helpers ─────────────────────────────────────────────────────
 
     private function handle(): void
     {
-        (new PurgeUnsortedMailHandler())->handle([], new TaskContext(
+        // The inbound-mail gateway arrives as a capability (IT-04): the
+        // ordinary test context carries it, resolved against the same
+        // SQLite database the fixtures write to.
+        $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
+        $moduleManager->method('getEnabledModuleIds')->willReturn(['camps', 'inbound_mail']);
+        $capabilities = new \Core\Scheduler\TaskCapabilities($moduleManager);
+        $capabilities->register(
+            \Modules\InboundMail\Api\InboundMailInterface::class,
+            'inbound_mail',
+            fn (): object => new \Modules\InboundMail\Service\InboundMailService(
+                $this->messages,
+                new \Modules\InboundMail\Repository\InboundMailboxRepository($this->pdo, $this->encryption),
+                new \Core\File\FileRepository($this->pdo)
+            )
+        );
+
+        (new PurgeUnsortedMailHandler())->handle([], $this->context($capabilities));
+    }
+
+    private function handleWithoutInboundMail(): void
+    {
+        (new PurgeUnsortedMailHandler())->handle([], $this->context(null));
+    }
+
+    private function context(?\Core\Scheduler\TaskCapabilities $capabilities): TaskContext
+    {
+        return new TaskContext(
             Connection::withPdo($this->pdo),
             $this->encryption,
             $this->createMock(MailService::class),
             new JournalService(new JournalRepository($this->pdo)),
             new SettingService(new SettingRepository($this->pdo)),
             new UserAccountRepository($this->pdo, $this->encryption),
-            sys_get_temp_dir()
-        ));
+            sys_get_temp_dir(),
+            null,
+            $capabilities
+        );
     }
 
     private function setRetentionMonths(int $months): void

--- a/tests/Modules/Finance/Task/ExtractReceiptDataHandlerTest.php
+++ b/tests/Modules/Finance/Task/ExtractReceiptDataHandlerTest.php
@@ -72,8 +72,28 @@ class ExtractReceiptDataHandlerTest extends TestCase
         rmdir($dir);
     }
 
-    private function createTaskContext(): TaskContext
+    private function createTaskContext(bool $withLlmConnector = true): TaskContext
     {
+        // The connector arrives as a capability (IT-04): the ordinary
+        // test context carries it, backed by the real service over this
+        // test's own llm tables — empty tables still mean "no provider
+        // configured", exactly as before the migration.
+        $capabilities = null;
+        if ($withLlmConnector) {
+            $moduleManager = $this->createMock(\Core\Module\ModuleManager::class);
+            $moduleManager->method('getEnabledModuleIds')->willReturn(['finance', 'llm_connector']);
+            $capabilities = new \Core\Scheduler\TaskCapabilities($moduleManager);
+            $capabilities->register(
+                \Modules\LlmConnector\Api\LlmConnectorInterface::class,
+                'llm_connector',
+                fn (): object => new \Modules\LlmConnector\Service\LlmConnectorService(
+                    new \Modules\LlmConnector\Repository\ProviderRepository($this->pdo, $this->encryption),
+                    new \Modules\LlmConnector\Repository\ProviderModelRepository($this->pdo),
+                    new JournalService(new JournalRepository($this->pdo))
+                )
+            );
+        }
+
         return new TaskContext(
             Connection::withPdo($this->pdo),
             $this->encryption,
@@ -81,8 +101,28 @@ class ExtractReceiptDataHandlerTest extends TestCase
             new JournalService(new JournalRepository($this->pdo)),
             new SettingService(new SettingRepository($this->pdo)),
             $this->createMock(UserAccountRepository::class),
-            $this->storagePath
+            $this->storagePath,
+            null,
+            $capabilities
         );
+    }
+
+    public function testNoOpWhenTheLlmConnectorModuleIsAbsent(): void
+    {
+        // Provider MODULE absent — the capability resolves to null — must
+        // degrade exactly like a configured module with no provider: no
+        // suggestion written, no failure, receipt fully usable manually.
+        $providerId = $this->providerRepository->create('Test', 'anthropic', 'http://127.0.0.1:19', 'sk-test', true);
+        $this->modelRepository->upsert($providerId, 'test-model', 'Test Model');
+        $attachmentId = $this->createAttachment();
+
+        (new ExtractReceiptDataHandler())->handle(
+            ['attachment_id' => $attachmentId],
+            $this->createTaskContext(withLlmConnector: false)
+        );
+
+        $attachment = $this->attachmentRepository->findById($attachmentId);
+        $this->assertNull($attachment->suggestedAmount);
     }
 
     /**

--- a/tests/Modules/Finance/Task/RunCategorizationRulesHandlerTest.php
+++ b/tests/Modules/Finance/Task/RunCategorizationRulesHandlerTest.php
@@ -100,13 +100,11 @@ class RunCategorizationRulesHandlerTest extends TestCase
 
     public function testHandleAppliesKeywordRulesAndSkipsAiWhenNoLlmProviderIsConfigured(): void
     {
-        // The provider-absent case, stated explicitly (chantier
-        // « dépendances entre modules », IT-02): the llm_connector tables
-        // exist but hold no active provider — also what this handler sees
-        // today when the module is disabled, since it constructs
-        // LlmConnectorService unconditionally and only isAvailable() gates
-        // the calls. Keyword rules still categorize; no AI suggestion row
-        // is written and nothing fails.
+        // The provider-absent case, stated explicitly. Since IT-04 the
+        // connector is a capability, and this context carries none — the
+        // handler sees null, exactly what a disabled or unconfigured
+        // llm_connector resolves to. Keyword rules still categorize; no
+        // AI suggestion row is written and nothing fails.
         $categoryId = $this->categoryRepository->create('Alimentation');
         $this->categoryRuleRepository->create($categoryId, 0, 'delhaize', null, null);
         $matched = $this->transactionRepository->create(

--- a/tests/Modules/Retro/Task/AutoCloseHandlerTest.php
+++ b/tests/Modules/Retro/Task/AutoCloseHandlerTest.php
@@ -104,13 +104,12 @@ class AutoCloseHandlerTest extends TestCase
 
     public function testClosesAndNotifiesWithoutASummaryWhenNoLlmProviderIsConfigured(): void
     {
-        // The provider-absent case, stated explicitly (chantier
-        // « dépendances entre modules », IT-02): the llm_connector tables
-        // exist but hold no active provider — which is also what the
-        // handler sees today when the module is disabled, since it never
-        // consults the registry. Everything the board owner was promised
-        // still happens: the board closes, the notification email leaves;
-        // only the AI summary is skipped, silently.
+        // The provider-absent case, stated explicitly. Since IT-04 the
+        // connector is a capability, and this context carries none — the
+        // handler sees null, exactly what a disabled or unconfigured
+        // llm_connector resolves to. Everything the board owner was
+        // promised still happens: the board closes, the notification
+        // email leaves; only the AI summary is skipped, silently.
         $boardId = $this->createOpenBoard(true, 'chief@example.com');
         $this->context->mailService->expects($this->once())->method('send')->with('chief@example.com');
 


### PR DESCRIPTION
Fourth iteration of the chantier (ROADMAP-dependances-modules.md, IT-04 — C1, scheduled-path half). The five handlers that rebuilt other modules' internals from the PDO now reach them through IT-03's capabilities.

## What was done

| Handler | Before | After |
|---|---|---|
| `finance/ExtractReceiptDataHandler` | unconditional `new LlmConnectorService(Provider*Repository…)` | `getOptional(LlmConnectorInterface::class)` — null → no suggestion, receipt fully usable manually |
| `finance/RunCategorizationRulesHandler` | same + hand-rolled `ModuleRegistryRepository` lookup for calendar | capability + `isModuleEnabled('calendar')` |
| `retro/AutoCloseHandler` | unconditional connector construction (its own docblock admitted it) | capability — null → board still closes and notifies, summary skipped |
| `camps/PurgeUnsortedMailHandler` | direct construction of inbound_mail's repositories and service | `getOptional(InboundMailInterface::class)` — **behaviour deliberately flips**: module absent → no-op (nothing is feeding « Courrier non classé », so there is nothing this retention counters), exactly as IT-02's pin announced |
| `calendar/AutoCreateRetroHandler` | the repo's ONE raw `SELECT enabled FROM module_registry` | `isModuleEnabled('retro')` (the write moves behind retro's creation Api in IT-08) |

**Leak edges emptied**: `camps → inbound_mail`, `finance → llm_connector`, `retro → llm_connector` no longer have a single non-Api import. The remaining non-Api edges map one-to-one onto IT-05..IT-08 (verified by recounting the matrix).

## Tests

- Each handler suite's context now carries the capability, backed by the **real** provider service over the test database — so "no provider configured" keeps meaning exactly what it meant before the migration.
- New: module-absent no-op case for the extraction handler; the purge handler's IT-02 pin flipped as its own comment announced; AutoCreateRetro's enablement now driven through the context instead of registry rows.

## Notes / deviations

- `RunCategorizationRulesHandler` keeps its `Calendar\Repository` imports for now: the calendar read Api it (and `AiCategorizationService`) needs is IT-06's deliverable — migrating it here would have pulled IT-06's design decisions into this PR.

## Test state

- `vendor/bin/phpstan analyse`: OK — `vendor/bin/phpunit`: OK (12 185 tests) — `npm run e2e` (confidence): 41 passed, 7.9 min (no composition-root change; the matrix ran green on this code's base in IT-03)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018qA4tYCEkzkC9aLqFyy3tV

---
_Generated by [Claude Code](https://claude.ai/code/session_018qA4tYCEkzkC9aLqFyy3tV)_