### PR TITLE
IT-01 — the admin auto-repair stops deleting every other super admin

### DIFF
--- a/core/Security/UserAccountRepository.php
+++ b/core/Security/UserAccountRepository.php
@@ -258,6 +258,70 @@ class UserAccountRepository
     }
 
     /**
+     * Re-key, or create, the one super-admin account named by
+     * `secrets['admin_email']` — the repair `public/index.php` runs when
+     * that address can no longer be found in the database.
+     *
+     * It used to be `DELETE FROM user_accounts WHERE is_super_admin = TRUE`
+     * followed by a fresh create(). With a single super admin that was
+     * merely blunt; with several it is destructive, because the trigger is
+     * not "the admin row is broken" but "the lookup missed" — and the
+     * lookup misses for the whole table at once when the blind-index key
+     * changes. One key problem would therefore have wiped every other
+     * super admin, silently, on whatever request happened to run next.
+     *
+     * So: find the row that really is this address by decrypting the
+     * super-admin rows one by one (the blind index is exactly what cannot
+     * be trusted here), and rewrite that row's encrypted email and blind
+     * index with the current keys. A row that cannot be decrypted at all
+     * is skipped rather than deleted — it may be someone else's, and this
+     * code cannot tell. When no row matches, the account is created.
+     *
+     * Nothing is ever deleted: `user_accounts` carries passwords,
+     * passkeys and notification preferences, and is referenced by
+     * `event_log`, `scheduled_actions` and `files.created_by` among
+     * others. A chef d'unité who also holds a legitimate Desk access must
+     * not lose their credentials to a repair aimed at someone else.
+     */
+    public function repairSuperAdmin(string $email): UserAccount
+    {
+        // strtolower(), exactly as create() and findByEmail() spell it:
+        // a repair whose blind index disagrees with the lookup that
+        // triggered it would repair the same account on every request.
+        $normalizedEmail = strtolower($email);
+
+        $stmt = $this->pdo->query('SELECT * FROM user_accounts WHERE is_super_admin = 1 ORDER BY id ASC');
+        $rows = $stmt !== false ? $stmt->fetchAll(\PDO::FETCH_ASSOC) : [];
+
+        foreach ($rows as $row) {
+            try {
+                $decryptedEmail = $this->encryption->decrypt($row['email_encrypted'], 'user_accounts.email');
+            } catch (\Throwable) {
+                // Unreadable with the current key: it may belong to someone
+                // else entirely, so it is left exactly as it is.
+                continue;
+            }
+
+            if (strtolower($decryptedEmail) !== $normalizedEmail) {
+                continue;
+            }
+
+            $update = $this->pdo->prepare(
+                'UPDATE user_accounts SET email_encrypted = ?, email_blind_index = ?, is_super_admin = 1 WHERE id = ?'
+            );
+            $update->execute([
+                $this->encryption->encrypt($normalizedEmail, 'user_accounts.email'),
+                $this->encryption->blindIndex($normalizedEmail, 'email'),
+                (int) $row['id'],
+            ]);
+
+            return $this->hydrate($row, $normalizedEmail);
+        }
+
+        return $this->create($normalizedEmail, true);
+    }
+
+    /**
      * Update last_login_at for the given user.
      */
     public function updateLastLogin(int $id): void

--- a/public/index.php
+++ b/public/index.php
@@ -508,9 +508,9 @@ if (!empty($secrets['admin_email'])) {
     $userAccountRepo = new UserAccountRepository($connection->getPdo(), $encryptionService);
     $adminUser = $userAccountRepo->findByEmail($secrets['admin_email']);
     if ($adminUser === null) {
-        // Delete any broken admin rows and recreate with correct keys
-        $connection->getPdo()->exec('DELETE FROM user_accounts WHERE is_super_admin = TRUE');
-        $userAccountRepo->create($secrets['admin_email'], true);
+        // Re-key that one account, or create it — never touching any other
+        // super admin. See UserAccountRepository::repairSuperAdmin().
+        $userAccountRepo->repairSuperAdmin($secrets['admin_email']);
     }
 }
 

--- a/tests/Core/Security/UserAccountRepositoryTest.php
+++ b/tests/Core/Security/UserAccountRepositoryTest.php
@@ -165,4 +165,94 @@ class UserAccountRepositoryTest extends TestCase
     {
         $this->assertSame([], $this->repo->findAllIds());
     }
+
+    /**
+     * The bug this replaced: `DELETE FROM user_accounts WHERE
+     * is_super_admin = TRUE` followed by a fresh create(). The repair
+     * fires when the lookup misses — and a blind-index key problem makes
+     * it miss for every row at once, so a single unreadable admin used to
+     * take every other super admin down with it, silently.
+     */
+    public function testRepairSuperAdminLeavesEveryOtherSuperAdminAlone(): void
+    {
+        $first = $this->repo->create('first-admin@test.com', true);
+        $second = $this->repo->create('second-admin@test.com', true);
+        $third = $this->repo->create('third-admin@test.com', true);
+
+        // The address secrets['admin_email'] names is no longer findable:
+        // its blind index was written under a key that no longer applies.
+        $this->pdo->exec(
+            "UPDATE user_accounts SET email_blind_index = 'stale-index' WHERE id = " . $third->id
+        );
+        $this->assertNull($this->repo->findByEmail('third-admin@test.com'));
+
+        $this->repo->repairSuperAdmin('third-admin@test.com');
+
+        $survivors = $this->repo->findAllIds();
+        $this->assertContains($first->id, $survivors);
+        $this->assertContains($second->id, $survivors);
+        $this->assertSame('first-admin@test.com', $this->repo->findById($first->id)?->email);
+        $this->assertSame('second-admin@test.com', $this->repo->findById($second->id)?->email);
+    }
+
+    public function testRepairSuperAdminRekeysTheExistingRowRatherThanAddingOne(): void
+    {
+        $admin = $this->repo->create('admin@test.com', true);
+        $this->pdo->exec(
+            "UPDATE user_accounts SET email_blind_index = 'stale-index' WHERE id = " . $admin->id
+        );
+
+        $repaired = $this->repo->repairSuperAdmin('admin@test.com');
+
+        $this->assertSame($admin->id, $repaired->id);
+        $this->assertCount(1, $this->repo->findAllIds());
+
+        // Findable again, which is what the repair exists to restore.
+        $found = $this->repo->findByEmail('admin@test.com');
+        $this->assertNotNull($found);
+        $this->assertSame($admin->id, $found->id);
+        $this->assertTrue($found->isSuperAdmin);
+    }
+
+    public function testRepairSuperAdminCreatesTheAccountWhenNoRowMatches(): void
+    {
+        $other = $this->repo->create('other-admin@test.com', true);
+
+        $created = $this->repo->repairSuperAdmin('missing-admin@test.com');
+
+        $this->assertNotSame($other->id, $created->id);
+        $this->assertSame('missing-admin@test.com', $created->email);
+        $this->assertTrue($created->isSuperAdmin);
+
+        // The existing super admin is still there, untouched.
+        $this->assertSame('other-admin@test.com', $this->repo->findById($other->id)?->email);
+    }
+
+    public function testRepairSuperAdminSkipsRowsItCannotDecrypt(): void
+    {
+        $unreadable = $this->repo->create('unreadable-admin@test.com', true);
+        $this->pdo->exec(
+            "UPDATE user_accounts SET email_encrypted = 'not-decryptable' WHERE id = " . $unreadable->id
+        );
+
+        $created = $this->repo->repairSuperAdmin('admin@test.com');
+
+        // The row nobody can read is neither claimed nor deleted: it may
+        // belong to somebody else, and this code cannot tell.
+        $this->assertNotSame($unreadable->id, $created->id);
+        $this->assertContains($unreadable->id, $this->repo->findAllIds());
+    }
+
+    public function testRepairSuperAdminNormalizesTheAddressLikeCreateDoes(): void
+    {
+        $admin = $this->repo->create('Mixed@Test.com', true);
+        $this->pdo->exec(
+            "UPDATE user_accounts SET email_blind_index = 'stale-index' WHERE id = " . $admin->id
+        );
+
+        $repaired = $this->repo->repairSuperAdmin('MIXED@TEST.COM');
+
+        $this->assertSame($admin->id, $repaired->id);
+        $this->assertNotNull($this->repo->findByEmail('mixed@test.com'));
+    }
 }


### PR DESCRIPTION
## Description

`public/index.php` (~line 503) re-created the account named by `secrets['admin_email']` whenever that address could no longer be found, and cleared the way with:

```php
$connection->getPdo()->exec('DELETE FROM user_accounts WHERE is_super_admin = TRUE');
$userAccountRepo->create($secrets['admin_email'], true);
```

With a single super admin that is merely blunt. With several it is destructive, because the trigger is not "the admin row is broken" but "the lookup missed" — and the lookup misses for the whole table at once when the blind-index key changes. One key problem would therefore wipe every other super admin, silently, on whatever request happened to run next. This is the blocker that has to be gone before any interface can hand out the flag.

**`UserAccountRepository::repairSuperAdmin()`** replaces the block:

- it finds the row that really is that address by decrypting the super-admin rows one by one — the blind index is exactly what cannot be trusted here — and rewrites that row's encrypted email and blind index with the current keys;
- a row it cannot decrypt is **skipped**, never claimed and never deleted: it may belong to someone else, and this code cannot tell;
- when no row matches, the account is created and nothing else is touched;
- **nothing is ever deleted.** `user_accounts` carries passwords, passkeys and notification preferences, and is referenced by `event_log`, `scheduled_actions` and `files.created_by` among others.

The address is normalised with `strtolower()`, exactly as `create()` and `findByEmail()` spell it — a repair whose blind index disagreed with the lookup that triggered it would repair the same account on every request.

Scope is IT-01 only: no schema change, no UI, no other behaviour touched.

### Tests

Five tests in `tests/Core/Security/UserAccountRepositoryTest.php`, all of which **fail against the previous delete-then-create behaviour** (verified by reinstating it):

- three super admins in the database, `admin_email` unfindable → the two bystanders survive, with their addresses intact (the reproduction the chantier asks for);
- the repair re-keys the existing row rather than adding a second one, and the account is findable again afterwards;
- no matching row → the account is created, the existing super admin untouched;
- an undecryptable row is neither claimed nor deleted;
- the address is normalised the same way `create()` normalises it.

### Verification

- `vendor/bin/phpunit` — 12245 tests, 40194 assertions, no failures
- `vendor/bin/phpunit --group=database` — 6065 tests, no failures
- `vendor/bin/phpstan analyse` — No errors
- `npm run typecheck` — 0 new findings

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French (no UI in this change)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, no JavaScript touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCFZiaeHecfW1shVLNKpM4)_