### PR TITLE
IT-02 — is_active: a deactivated account can no longer log in, by any path

### DIFF
--- a/core/Import/RosterComparisonRepository.php
+++ b/core/Import/RosterComparisonRepository.php
@@ -152,17 +152,23 @@ class RosterComparisonRepository
 
     /**
      * Whether this installation has at least one `is_super_admin`
-     * account.
+     * account that can actually still log in.
      *
      * That flag is the one administrative access no Desk import can
      * touch (SECURITY.md §3, `Core\Security\RoleResolver::resolve()`
      * consults it first), so its presence is what decides whether a
      * roster left without a single admin function is a recoverable
      * situation or a locked door.
+     *
+     * `is_active` is part of the question, not a detail: a deactivated
+     * super admin is refused by every login path (`RoleResolver::
+     * isEmailAuthorizedToLogin()`), so counting one here would report an
+     * escape hatch that nobody can open — and let through exactly the
+     * import that leaves the unit locked out.
      */
     public function hasSuperAdminAccount(): bool
     {
-        $stmt = $this->pdo->query('SELECT COUNT(*) FROM user_accounts WHERE is_super_admin = 1');
+        $stmt = $this->pdo->query('SELECT COUNT(*) FROM user_accounts WHERE is_super_admin = 1 AND is_active = 1');
 
         return $stmt !== false && (int) $stmt->fetchColumn() > 0;
     }

--- a/core/Security/RoleResolver.php
+++ b/core/Security/RoleResolver.php
@@ -121,15 +121,32 @@ class RoleResolver
      * by this check). Deliberately the same current-year matching
      * resolve() itself uses — a member who dropped out has no current-year
      * row and is correctly rejected here too.
+     *
+     * This is also where a deactivated account is refused, and it is the
+     * only place it needs to be: the five ways into the site all come
+     * through here — AuthController::verifyMagicLink(), pollMagicLink(),
+     * loginWithPassword() and passkeyVerify() via isMemberAuthorized(),
+     * and SessionRevalidator::revalidate() on every request of a session
+     * already open.
+     *
+     * The is_active check comes BEFORE the super-admin shortcut, and the
+     * order is the whole point: the other way round, `is_super_admin` would
+     * return true first and a deactivated super admin — exactly the account
+     * an operator most wants to be able to shut out — would keep logging
+     * in.
      */
     public function isEmailAuthorizedToLogin(string $email, int $currentScoutYearId): bool
     {
         $normalizedEmail = strtolower(trim($email));
         $blindIndex = $this->encryption->blindIndex($normalizedEmail, 'email');
 
-        $stmt = $this->pdo->prepare('SELECT is_super_admin FROM user_accounts WHERE email_blind_index = ?');
+        $stmt = $this->pdo->prepare('SELECT is_super_admin, is_active FROM user_accounts WHERE email_blind_index = ?');
         $stmt->execute([$blindIndex]);
         $userRow = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+        if ($userRow !== false && !(bool) $userRow['is_active']) {
+            return false;
+        }
 
         if ($userRow !== false && (bool) $userRow['is_super_admin']) {
             return true;

--- a/core/Security/SuperAdminService.php
+++ b/core/Security/SuperAdminService.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security;
+
+use Core\Journal\JournalService;
+
+/**
+ * Deactivating and reactivating a super-admin account, with the journal
+ * entry each one owes.
+ *
+ * The repository writes the columns; this is where the act is recorded.
+ * It exists as a service rather than as controller code because a
+ * Controller holds no business logic (ARCHITECTURE.md's layering), and
+ * because the journal entry has to happen wherever the change does — a
+ * withdrawal of access that leaves no trace is the one kind an operator
+ * cannot audit afterwards.
+ *
+ * The entries carry the `user_account_id` and nothing else. Never the
+ * address: an email is personal data and the journal is not where it
+ * belongs (AGENTS.md § Security checklist #4, SECURITY.md §11).
+ */
+class SuperAdminService
+{
+    public function __construct(
+        private UserAccountRepository $userAccountRepo,
+        private JournalService $journalService
+    ) {
+    }
+
+    /**
+     * Withdraw access. The repository's deactivate() both clears
+     * is_active and stamps sessions_valid_from, so a session already open
+     * falls on its next request.
+     *
+     * $actorId is the account that performed it, for the journal entry's
+     * user column — null when nothing identified is behind the change.
+     */
+    public function deactivate(int $userAccountId, ?int $actorId): void
+    {
+        $this->userAccountRepo->deactivate($userAccountId);
+
+        $this->journalService->log(
+            'core',
+            'super_admin_deactivated',
+            'security',
+            'Compte superadmin désactivé',
+            ['user_account_id' => $userAccountId],
+            $actorId
+        );
+    }
+
+    /**
+     * Give access back. Sessions revoked by the deactivation stay revoked
+     * — see UserAccountRepository::reactivate().
+     */
+    public function reactivate(int $userAccountId, ?int $actorId): void
+    {
+        $this->userAccountRepo->reactivate($userAccountId);
+
+        $this->journalService->log(
+            'core',
+            'super_admin_reactivated',
+            'security',
+            'Compte superadmin réactivé',
+            ['user_account_id' => $userAccountId],
+            $actorId
+        );
+    }
+}

--- a/core/Security/UserAccount.php
+++ b/core/Security/UserAccount.php
@@ -18,6 +18,12 @@ class UserAccount
         public readonly ?string $passwordHash,
         public readonly bool $isSuperAdmin,
         public readonly ?\DateTimeImmutable $lastLoginAt,
+        /**
+         * Whether this account may still log in — see the
+         * user_accounts.is_active column comment. Defaults to true so a
+         * caller constructing an account by hand gets the ordinary case.
+         */
+        public readonly bool $isActive = true,
         public readonly ?\DateTimeImmutable $passwordChangedAt = null,
         /**
          * Sessions issued before this instant are revoked — see the

--- a/core/Security/UserAccountRepository.php
+++ b/core/Security/UserAccountRepository.php
@@ -377,6 +377,47 @@ class UserAccountRepository
     }
 
     /**
+     * Withdraw an account's access: is_active goes to false AND
+     * sessions_valid_from is stamped to now, in one write.
+     *
+     * The flag alone would only close the door for the NEXT login. A
+     * session already open carries a 30-day cookie and would keep working
+     * until it expired, which is not what "deactivate" means to whoever
+     * clicked it. SessionRevalidator re-reads sessions_valid_from on every
+     * request, so the stamp drops that session on the very next click.
+     * (The revalidator also re-runs the login gate itself, so this is
+     * belt and braces — deliberately, since the two protect against
+     * different mistakes.)
+     *
+     * Stamped from PHP rather than CURRENT_TIMESTAMP, for the same reason
+     * updatePasswordHash() does: comparability with the PHP-side login
+     * timestamp held in the session, and identical behaviour on the SQLite
+     * test database.
+     *
+     * The row itself is never deleted — see the is_active column comment.
+     */
+    public function deactivate(int $id): void
+    {
+        $now = (new \DateTimeImmutable())->format('Y-m-d H:i:s');
+        $stmt = $this->pdo->prepare(
+            'UPDATE user_accounts SET is_active = 0, sessions_valid_from = ? WHERE id = ?'
+        );
+        $stmt->execute([$now, $id]);
+    }
+
+    /**
+     * Give the access back. Deliberately does NOT touch
+     * sessions_valid_from: the sessions that stamp revoked are gone for
+     * good, and re-stamping it on the way back in would revoke sessions
+     * issued since, for no reason.
+     */
+    public function reactivate(int $id): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE user_accounts SET is_active = 1 WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    /**
      * Check if a user has a password set.
      */
     public function hasPassword(int $id): bool
@@ -429,6 +470,7 @@ class UserAccountRepository
             passwordHash: $row['password_hash'] ?? null,
             isSuperAdmin: (bool) $row['is_super_admin'],
             lastLoginAt: $lastLoginAt,
+            isActive: (bool) ($row['is_active'] ?? true),
             passwordChangedAt: $passwordChangedAt,
             sessionsValidFrom: $sessionsValidFrom,
             quietHoursStart: $row['quiet_hours_start'] ?? null,

--- a/schema/core.sql
+++ b/schema/core.sql
@@ -53,6 +53,18 @@ CREATE TABLE user_accounts (
     -- never logs the whole unit out on deploy.
     sessions_valid_from DATETIME,
     is_super_admin BOOLEAN NOT NULL DEFAULT FALSE,
+    -- Whether this account may still log in at all. FALSE refuses every
+    -- authentication path at once (Core\Security\RoleResolver::
+    -- isEmailAuthorizedToLogin(), which magic link, password, passkey and
+    -- SessionRevalidator all go through), and the deactivation that sets it
+    -- also bumps sessions_valid_from so a session already open falls on its
+    -- next request rather than lingering for the cookie's 30 days. It is a
+    -- withdrawal of access, never a deletion: the row keeps the password,
+    -- the passkeys and the notification preferences, and every table
+    -- referencing it (event_log, scheduled_actions, files.created_by, …)
+    -- keeps pointing at something. DEFAULT TRUE, so existing rows are
+    -- unaffected when this column is added on deploy.
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
     -- Per-account overrides for Core\Notification\NotificationService's
     -- push dispatch (Configuration > Notifications preferences, "Mon
     -- compte"). NULL on both means "follow the global

--- a/tests/Core/Import/RosterReplacementGuardTest.php
+++ b/tests/Core/Import/RosterReplacementGuardTest.php
@@ -262,6 +262,26 @@ class RosterReplacementGuardTest extends TestCase
         $this->assertTrue($assessment->unitStaffWipedOut());
     }
 
+    /**
+     * A deactivated super admin is refused by every login path, so it is
+     * not an escape hatch at all. Counting it here would report a way out
+     * that nobody can open, and let through exactly the import that
+     * leaves the unit with no administrative access whatsoever.
+     */
+    public function testADeactivatedSuperAdminDoesNotSatisfyTheInvariant(): void
+    {
+        $this->buildRoster(['BAL1' => 20, 'LOUV1' => 24]);
+        $this->addChiefToRoster('CU-1');
+        $accountId = $this->createUserAccount('super_idx', true);
+        $this->pdo->exec('UPDATE user_accounts SET is_active = 0 WHERE id = ' . $accountId);
+
+        $parsed = $this->parsedFile(['BAL1' => 20, 'LOUV1' => 24]);
+        $assessment = $this->guard->assess($parsed, $this->scoutYearId, 0);
+
+        $this->assertFalse($assessment->hasSuperAdminAccount);
+        $this->assertSame(RosterReplacementVerdict::NO_ADMIN_LEFT, $assessment->verdict);
+    }
+
     public function testAFunctionThisInstallationHasNeverSeenCountsAsTheLowestRole(): void
     {
         $this->buildRoster(['BAL1' => 20, 'LOUV1' => 24]);

--- a/tests/Core/Security/DeactivatedAccountLoginTest.php
+++ b/tests/Core/Security/DeactivatedAccountLoginTest.php
@@ -1,0 +1,346 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security;
+
+use Core\Http\Controller\AuthController;
+use Core\Http\Request;
+use Core\Import\MemberYearRepository;
+use Core\Database\Connection;
+use Core\ScoutYear\ScoutYearResolver;
+use Core\Security\AuthService;
+use Core\Security\AuthSession;
+use Core\Security\CsrfGuard;
+use Core\Security\EncryptionService;
+use Core\Security\LoginThrottler;
+use Core\Security\PasswordAuthMethod;
+use Core\Security\PendingMagicLink;
+use Core\Security\RoleResolver;
+use Core\Security\UserAccountRepository;
+use Core\Security\VerifiedMagicLink;
+use Core\Security\WebAuthnService;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Twig\Environment;
+
+/**
+ * `is_active = false` has to close every door, not most of them.
+ *
+ * The four ways in all reach the same gate —
+ * RoleResolver::isEmailAuthorizedToLogin(), through
+ * AuthController::isMemberAuthorized() — but "they all go through one
+ * method" is a claim about the code as it is today, and the point of
+ * these tests is that it stays true. So each path is driven end to end
+ * against a real RoleResolver rather than asserted structurally.
+ *
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class DeactivatedAccountLoginTest extends TestCase
+{
+    private \PDO $pdo;
+    private EncryptionService $encryption;
+    private UserAccountRepository $userRepo;
+    private RoleResolver $roleResolver;
+    private ScoutYearResolver $scoutYearResolver;
+    private int $scoutYearId;
+    private string $csrfToken;
+
+    protected function setUp(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            ini_set('session.use_cookies', '0');
+            ini_set('session.cache_limiter', '');
+            session_start();
+        }
+        $_SESSION = [];
+
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        $this->encryption = new EncryptionService(random_bytes(32), random_bytes(32));
+        $this->userRepo = new UserAccountRepository($this->pdo, $this->encryption);
+        $this->roleResolver = new RoleResolver(
+            new MemberYearRepository($this->pdo),
+            $this->encryption,
+            $this->pdo
+        );
+
+        $this->pdo->exec(
+            "INSERT INTO scout_years (label, start_date, end_date, is_current)
+             VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)"
+        );
+        $this->scoutYearId = (int) $this->pdo->lastInsertId();
+
+        $this->scoutYearResolver = $this->createStub(ScoutYearResolver::class);
+        $this->scoutYearResolver->method('getCurrentPublicYear')->willReturn([
+            'id' => $this->scoutYearId,
+            'label' => '2025-2026',
+            'start_date' => '2025-09-01',
+            'end_date' => '2026-08-31',
+        ]);
+
+        $this->csrfToken = CsrfGuard::generateToken();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    // ---------------------------------------------------------------
+    // The gate itself
+    // ---------------------------------------------------------------
+
+    public function testAnActiveSuperAdminIsAuthorized(): void
+    {
+        $this->userRepo->create('admin@example.com', true);
+
+        $this->assertTrue(
+            $this->roleResolver->isEmailAuthorizedToLogin('admin@example.com', $this->scoutYearId)
+        );
+    }
+
+    /**
+     * The order trap: `is_super_admin === true → return true` sitting
+     * before the is_active check would leave exactly the account an
+     * operator most wants shut out still able to log in.
+     */
+    public function testADeactivatedSuperAdminIsRefused(): void
+    {
+        $admin = $this->userRepo->create('admin@example.com', true);
+        $this->userRepo->deactivate($admin->id);
+
+        $this->assertFalse(
+            $this->roleResolver->isEmailAuthorizedToLogin('admin@example.com', $this->scoutYearId)
+        );
+    }
+
+    public function testReactivatingRestoresTheAuthorization(): void
+    {
+        $admin = $this->userRepo->create('admin@example.com', true);
+        $this->userRepo->deactivate($admin->id);
+        $this->userRepo->reactivate($admin->id);
+
+        $this->assertTrue(
+            $this->roleResolver->isEmailAuthorizedToLogin('admin@example.com', $this->scoutYearId)
+        );
+    }
+
+    public function testAnAccountWithNoRowAtAllIsUnaffected(): void
+    {
+        // No user_accounts row: the answer comes from the member match
+        // alone, exactly as before this column existed.
+        $this->assertFalse(
+            $this->roleResolver->isEmailAuthorizedToLogin('nobody@example.com', $this->scoutYearId)
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Path 1 — magic link, GET /auth/verify
+    // ---------------------------------------------------------------
+
+    public function testMagicLinkVerifyRefusesADeactivatedAccount(): void
+    {
+        $account = $this->deactivatedSuperAdmin();
+
+        $authService = $this->createStub(AuthService::class);
+        $authService->method('verifyMagicLink')
+            ->willReturn(new VerifiedMagicLink($account->email, $account->id));
+
+        $controller = $this->controllerWith($authService);
+        PendingMagicLink::remember(1);
+
+        $controller->verifyMagicLink($this->getRequest('/auth/verify', ['token' => 'tok', 'id' => '1']), []);
+
+        $this->assertFalse(AuthSession::isAuthenticated());
+    }
+
+    public function testMagicLinkVerifyStillAdmitsAnActiveAccount(): void
+    {
+        $account = $this->userRepo->create('admin@example.com', true);
+
+        $authService = $this->createStub(AuthService::class);
+        $authService->method('verifyMagicLink')
+            ->willReturn(new VerifiedMagicLink($account->email, $account->id));
+
+        $controller = $this->controllerWith($authService);
+        PendingMagicLink::remember(1);
+
+        $controller->verifyMagicLink($this->getRequest('/auth/verify', ['token' => 'tok', 'id' => '1']), []);
+
+        $this->assertTrue(AuthSession::isAuthenticated());
+    }
+
+    // ---------------------------------------------------------------
+    // Path 2 — magic link polling, GET /auth/poll/{id}
+    // ---------------------------------------------------------------
+
+    public function testMagicLinkPollRefusesADeactivatedAccount(): void
+    {
+        $account = $this->deactivatedSuperAdmin();
+
+        $authService = $this->createStub(AuthService::class);
+        $authService->method('isMagicLinkConfirmed')->willReturn(true);
+        $authService->method('getUserForConfirmedLink')
+            ->willReturn($this->userRepo->findById($account->id));
+
+        $controller = $this->controllerWith($authService);
+        PendingMagicLink::remember(7);
+
+        $controller->pollMagicLink($this->getRequest('/auth/poll/7', []), ['id' => '7']);
+
+        $this->assertFalse(AuthSession::isAuthenticated());
+    }
+
+    public function testMagicLinkPollStillAdmitsAnActiveAccount(): void
+    {
+        $account = $this->userRepo->create('admin@example.com', true);
+
+        $authService = $this->createStub(AuthService::class);
+        $authService->method('isMagicLinkConfirmed')->willReturn(true);
+        $authService->method('getUserForConfirmedLink')
+            ->willReturn($this->userRepo->findById($account->id));
+
+        $controller = $this->controllerWith($authService);
+        PendingMagicLink::remember(7);
+
+        $controller->pollMagicLink($this->getRequest('/auth/poll/7', []), ['id' => '7']);
+
+        $this->assertTrue(AuthSession::isAuthenticated());
+    }
+
+    // ---------------------------------------------------------------
+    // Path 3 — password, POST /login/password
+    // ---------------------------------------------------------------
+
+    public function testPasswordLoginRefusesADeactivatedAccount(): void
+    {
+        $account = $this->deactivatedSuperAdmin();
+        $this->userRepo->updatePasswordHash($account->id, password_hash('CorrectPassword', PASSWORD_DEFAULT));
+
+        $controller = $this->controllerWith($this->createStub(AuthService::class));
+        $controller->setPasswordAuth($this->passwordAuth());
+
+        $response = $controller->loginWithPassword($this->jsonRequest('/login/password', [
+            'email' => $account->email,
+            'password' => 'CorrectPassword',
+            '_csrf_token' => $this->csrfToken,
+            'rgpd_consent' => true,
+        ]), []);
+
+        $data = json_decode($response->getBody(), true);
+        $this->assertFalse($data['success']);
+        $this->assertFalse(AuthSession::isAuthenticated());
+    }
+
+    public function testPasswordLoginStillAdmitsAnActiveAccount(): void
+    {
+        $account = $this->userRepo->create('admin@example.com', true);
+        $this->userRepo->updatePasswordHash($account->id, password_hash('CorrectPassword', PASSWORD_DEFAULT));
+
+        $controller = $this->controllerWith($this->createStub(AuthService::class));
+        $controller->setPasswordAuth($this->passwordAuth());
+
+        $response = $controller->loginWithPassword($this->jsonRequest('/login/password', [
+            'email' => $account->email,
+            'password' => 'CorrectPassword',
+            '_csrf_token' => $this->csrfToken,
+            'rgpd_consent' => true,
+        ]), []);
+
+        $data = json_decode($response->getBody(), true);
+        $this->assertTrue($data['success']);
+        $this->assertTrue(AuthSession::isAuthenticated());
+    }
+
+    // ---------------------------------------------------------------
+    // Path 4 — passkey, POST /login/passkey/verify
+    // ---------------------------------------------------------------
+
+    public function testPasskeyLoginRefusesADeactivatedAccount(): void
+    {
+        $account = $this->deactivatedSuperAdmin();
+
+        $webAuthn = $this->createStub(WebAuthnService::class);
+        $webAuthn->method('verifyAuthentication')->willReturn($this->userRepo->findById($account->id));
+
+        $controller = $this->controllerWith($this->createStub(AuthService::class));
+        $controller->setWebAuthnService($webAuthn);
+
+        $response = $controller->passkeyVerify($this->jsonRequest('/login/passkey/verify', [
+            'rgpd_consent' => true,
+        ]), []);
+
+        $data = json_decode($response->getBody(), true);
+        $this->assertFalse($data['success']);
+        $this->assertFalse(AuthSession::isAuthenticated());
+    }
+
+    public function testPasskeyLoginStillAdmitsAnActiveAccount(): void
+    {
+        $account = $this->userRepo->create('admin@example.com', true);
+
+        $webAuthn = $this->createStub(WebAuthnService::class);
+        $webAuthn->method('verifyAuthentication')->willReturn($this->userRepo->findById($account->id));
+
+        $controller = $this->controllerWith($this->createStub(AuthService::class));
+        $controller->setWebAuthnService($webAuthn);
+
+        $response = $controller->passkeyVerify($this->jsonRequest('/login/passkey/verify', [
+            'rgpd_consent' => true,
+        ]), []);
+
+        $data = json_decode($response->getBody(), true);
+        $this->assertTrue($data['success']);
+        $this->assertTrue(AuthSession::isAuthenticated());
+    }
+
+    // ---------------------------------------------------------------
+
+    private function deactivatedSuperAdmin(): \Core\Security\UserAccount
+    {
+        $account = $this->userRepo->create('admin@example.com', true);
+        $this->userRepo->deactivate($account->id);
+
+        return $account;
+    }
+
+    private function controllerWith(AuthService $authService): AuthController
+    {
+        $twig = $this->createStub(Environment::class);
+        $twig->method('render')->willReturn('<html></html>');
+
+        return new AuthController($twig, $authService, $this->roleResolver, $this->scoutYearResolver);
+    }
+
+    private function passwordAuth(): PasswordAuthMethod
+    {
+        $connection = $this->createStub(Connection::class);
+        $connection->method('getPdo')->willReturn($this->pdo);
+
+        return new PasswordAuthMethod($this->userRepo, $this->encryption, new LoginThrottler($connection));
+    }
+
+    /**
+     * @param array<string, string> $query
+     */
+    private function getRequest(string $path, array $query): Request
+    {
+        return new Request('GET', $path, $query, [], [], []);
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function jsonRequest(string $path, array $data): Request
+    {
+        $request = $this->getMockBuilder(Request::class)
+            ->setConstructorArgs(['POST', $path, [], [], [], []])
+            ->onlyMethods(['getRawBody'])
+            ->getMock();
+
+        $request->method('getRawBody')->willReturn(json_encode($data));
+
+        return $request;
+    }
+}

--- a/tests/Core/Security/SessionRevalidatorTest.php
+++ b/tests/Core/Security/SessionRevalidatorTest.php
@@ -240,4 +240,49 @@ class SessionRevalidatorTest extends TestCase
         );
         $stmt->execute([$memberYearId, $functionId]);
     }
+
+    /**
+     * A deactivation that only closed the door for the NEXT login would
+     * leave the account fully usable in whatever tab is already open, for
+     * up to the 30 days of the session cookie. deactivate() stamps
+     * sessions_valid_from precisely so it does not.
+     */
+    public function testDeactivatingAnAccountDropsItsLiveSessionOnTheNextRequest(): void
+    {
+        $account = $this->userRepo->create('admin@test.com', true);
+        AuthSession::login($account->id, $account->email, 'superadmin');
+        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+
+        $this->userRepo->deactivate($account->id);
+
+        $this->assertFalse($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertFalse(AuthSession::isAuthenticated());
+    }
+
+    public function testAnActiveAccountsSessionIsUnaffectedByTheNewColumn(): void
+    {
+        $account = $this->userRepo->create('admin@test.com', true);
+        AuthSession::login($account->id, $account->email, 'superadmin');
+
+        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue(AuthSession::isAuthenticated());
+    }
+
+    /**
+     * Reactivation deliberately leaves sessions_valid_from alone, so the
+     * sessions the deactivation revoked stay revoked — but a session
+     * opened afterwards works normally.
+     */
+    public function testASessionOpenedAfterReactivationSurvives(): void
+    {
+        $account = $this->userRepo->create('admin@test.com', true);
+        $this->userRepo->deactivate($account->id);
+        $this->userRepo->reactivate($account->id);
+
+        AuthSession::login($account->id, $account->email, 'superadmin');
+
+        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue(AuthSession::isAuthenticated());
+    }
 }

--- a/tests/Core/Security/SuperAdminServiceTest.php
+++ b/tests/Core/Security/SuperAdminServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security;
+
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Security\EncryptionService;
+use Core\Security\SuperAdminService;
+use Core\Security\UserAccountRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+
+/**
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class SuperAdminServiceTest extends TestCase
+{
+    private \PDO $pdo;
+    private UserAccountRepository $userRepo;
+    private SuperAdminService $service;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->userRepo = new UserAccountRepository($this->pdo, $encryption);
+        $this->service = new SuperAdminService(
+            $this->userRepo,
+            new JournalService(new JournalRepository($this->pdo))
+        );
+    }
+
+    public function testDeactivateWithdrawsAccessAndJournalsIt(): void
+    {
+        $account = $this->userRepo->create('admin@test.com', true);
+        $actor = $this->userRepo->create('actor@test.com', true);
+
+        $this->service->deactivate($account->id, $actor->id);
+
+        $this->assertFalse($this->userRepo->findById($account->id)?->isActive);
+
+        $entry = $this->lastJournalEntry();
+        $this->assertSame('super_admin_deactivated', $entry['event_type']);
+        $this->assertSame('security', $entry['level']);
+        $this->assertSame($actor->id, (int) $entry['user_account_id']);
+    }
+
+    public function testReactivateRestoresAccessAndJournalsIt(): void
+    {
+        $account = $this->userRepo->create('admin@test.com', true);
+        $this->service->deactivate($account->id, null);
+
+        $this->service->reactivate($account->id, null);
+
+        $this->assertTrue($this->userRepo->findById($account->id)?->isActive);
+
+        $entry = $this->lastJournalEntry();
+        $this->assertSame('super_admin_reactivated', $entry['event_type']);
+        $this->assertSame('security', $entry['level']);
+    }
+
+    /**
+     * An email address is personal data, and the journal is not where it
+     * belongs (AGENTS.md § Security checklist #4). The account id is what
+     * makes the entry traceable without storing the address.
+     */
+    public function testTheJournalEntryNamesTheAccountIdAndNeverTheAddress(): void
+    {
+        $account = $this->userRepo->create('admin@test.com', true);
+
+        $this->service->deactivate($account->id, null);
+        $entry = $this->lastJournalEntry();
+
+        $this->assertSame(
+            ['user_account_id' => $account->id],
+            json_decode((string) $entry['context'], true)
+        );
+
+        $wholeRow = implode(' ', array_map(static fn($v): string => (string) $v, $entry));
+        $this->assertStringNotContainsString('admin@test.com', $wholeRow);
+        $this->assertStringNotContainsString('@', $wholeRow);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function lastJournalEntry(): array
+    {
+        $stmt = $this->pdo->query('SELECT * FROM event_log ORDER BY id DESC LIMIT 1');
+        $row = $stmt !== false ? $stmt->fetch(\PDO::FETCH_ASSOC) : false;
+        $this->assertIsArray($row, 'no journal entry was written');
+
+        return $row;
+    }
+}

--- a/tests/Core/Security/UserAccountRepositoryTest.php
+++ b/tests/Core/Security/UserAccountRepositoryTest.php
@@ -30,8 +30,10 @@ class UserAccountRepositoryTest extends TestCase
                 first_name_encrypted BLOB,
                 last_name_encrypted BLOB,
                 password_hash VARCHAR(255),
+                password_changed_at DATETIME,
                 sessions_valid_from DATETIME,
                 is_super_admin BOOLEAN NOT NULL DEFAULT 0,
+                is_active BOOLEAN NOT NULL DEFAULT 1,
                 created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
                 last_login_at DATETIME
             )
@@ -254,5 +256,57 @@ class UserAccountRepositoryTest extends TestCase
 
         $this->assertSame($admin->id, $repaired->id);
         $this->assertNotNull($this->repo->findByEmail('mixed@test.com'));
+    }
+
+    public function testDeactivateClearsIsActiveAndStampsSessionsValidFrom(): void
+    {
+        $account = $this->repo->create('admin@test.com', true);
+        $this->assertTrue($this->repo->findById($account->id)?->isActive);
+
+        $this->repo->deactivate($account->id);
+
+        $reloaded = $this->repo->findById($account->id);
+        $this->assertNotNull($reloaded);
+        $this->assertFalse($reloaded->isActive);
+        // The stamp is what drops a session already open, rather than
+        // waiting out the 30 days of its cookie.
+        $this->assertNotNull($reloaded->sessionsValidFrom);
+        $this->assertTrue($reloaded->isSuperAdmin, 'deactivation withdraws access, not the flag');
+    }
+
+    public function testDeactivateNeverRemovesTheRow(): void
+    {
+        $account = $this->repo->create('admin@test.com', true);
+        $this->repo->updatePasswordHash($account->id, password_hash('x', PASSWORD_DEFAULT));
+
+        $this->repo->deactivate($account->id);
+
+        $this->assertContains($account->id, $this->repo->findAllIds());
+        $this->assertTrue($this->repo->hasPassword($account->id), 'the password survives a deactivation');
+    }
+
+    public function testReactivateRestoresIsActiveAndLeavesTheStampAlone(): void
+    {
+        $account = $this->repo->create('admin@test.com', true);
+        $this->repo->deactivate($account->id);
+        $stamp = $this->repo->findById($account->id)?->sessionsValidFrom;
+        $this->assertNotNull($stamp);
+
+        $this->repo->reactivate($account->id);
+
+        $reloaded = $this->repo->findById($account->id);
+        $this->assertNotNull($reloaded);
+        $this->assertTrue($reloaded->isActive);
+        // Re-stamping on the way back in would revoke sessions issued
+        // since, for no reason.
+        $this->assertEquals($stamp, $reloaded->sessionsValidFrom);
+    }
+
+    public function testAccountsAreActiveByDefault(): void
+    {
+        $account = $this->repo->create('someone@test.com');
+
+        $this->assertTrue($account->isActive);
+        $this->assertTrue($this->repo->findByEmail('someone@test.com')?->isActive);
     }
 }

--- a/tests/DatabaseTestHelper.php
+++ b/tests/DatabaseTestHelper.php
@@ -66,6 +66,7 @@ class DatabaseTestHelper
             password_changed_at TEXT,
             sessions_valid_from TEXT,
             is_super_admin INTEGER NOT NULL DEFAULT 0,
+            is_active INTEGER NOT NULL DEFAULT 1,
             quiet_hours_start TEXT,
             quiet_hours_end TEXT,
             notification_discretion INTEGER NOT NULL DEFAULT 0,


### PR DESCRIPTION
## Description

A deactivated account must not be able to get in by any route, and its live sessions must fall immediately. No UI in this iteration.

### Schema

`user_accounts.is_active BOOLEAN NOT NULL DEFAULT TRUE`, with a column comment in the style of its neighbours. `DEFAULT TRUE` means existing rows are unaffected on deploy. `schema/core.sql` auto-migrates on every request, so there is **no version to bump** — that rule is about module `schema.sql` files.

### The single insertion point

`Core\Security\RoleResolver::isEmailAuthorizedToLogin()`. It is the only place the refusal needs to go: the five ways in all come through it — `AuthController::verifyMagicLink()`, `pollMagicLink()`, `loginWithPassword()` and `passkeyVerify()` (all via `isMemberAuthorized()`), and `SessionRevalidator::revalidate()` on every request of a session already open.

**The `is_active` check sits BEFORE the `is_super_admin === true → return true` shortcut.** The other way round, a deactivated super admin — exactly the account an operator most wants to be able to shut out — would keep logging in. That is the trap this iteration is mostly about, and there is a test on it.

### Revoking live sessions

`UserAccountRepository::deactivate()` clears the flag **and** stamps `sessions_valid_from`, in one write. `SessionRevalidator` re-reads that field on every request, so a session already open falls on the next click instead of lasting out the 30 days of its cookie. `reactivate()` restores the flag and deliberately leaves the stamp alone — re-stamping would revoke sessions issued since, for no reason. Neither deletes anything.

### Journal

`SuperAdminService` carries the entries (`level: 'security'`, `super_admin_deactivated` / `super_admin_reactivated`). A service rather than controller code, since a Controller holds no business logic and the entry has to happen wherever the change does. **The entries carry the `user_account_id` and never the address** — pinned by a test that asserts the whole row contains no `@` at all.

### One coherence fix that came with the column

`Core\Import\RosterComparisonRepository::hasSuperAdminAccount()` now also requires `is_active`. It answers "does this installation keep an administrative access whatever the Desk file says", which `RosterReplacementGuard` uses as the one escape hatch a roster replacement cannot override. A deactivated super admin is refused by every login path, so counting one would report a way out that nobody can open — and let through exactly the import that leaves the unit locked out of its own site.

### Tests

- all four login paths driven **end to end** against a real `RoleResolver`: refused when deactivated, still admitted when active (verified to fail when the `is_active` check is removed);
- a deactivated super admin is refused — the ordering trap;
- a live session is dropped on the next request; a session opened after reactivation survives;
- `deactivate()` writes the stamp, keeps the row, keeps the password; `reactivate()` leaves the stamp alone;
- the journal entry contains the account id and no address;
- the roster guard's invariant is no longer satisfied by a deactivated super admin.

### Verification

- `vendor/bin/phpunit` — 12269 tests, 40249 assertions, no failures (re-run after rebase on `main` with IT-01 merged)
- `vendor/bin/phpstan analyse` — No errors
- `npm run typecheck` — 0 new findings

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French (no UI in this change)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, no JavaScript touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCFZiaeHecfW1shVLNKpM4)_