### PR TITLE
IT-03 — Comptes superadmin: the page, adding and withdrawing the right

### DIFF
--- a/core/Http/Controller/SuperAdminAccountsController.php
+++ b/core/Http/Controller/SuperAdminAccountsController.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Http\Controller;
+
+use Core\Http\FlashMessage;
+use Core\Http\Request;
+use Core\Http\Response;
+use Core\Security\AuthSession;
+use Core\Security\SuperAdminException;
+use Core\Security\SuperAdminService;
+use Core\Security\UserAccountRepository;
+use Twig\Environment;
+
+/**
+ * Configuration > Comptes superadmin — the accounts that hold
+ * `is_super_admin`, and nothing else.
+ *
+ * No Desk member is managed from here: a Desk member's access comes from
+ * their function in the roster (Core\Security\RoleResolver::resolve()),
+ * which this page does not touch. What it manages is the one access that
+ * exists outside the roster entirely — the site operators.
+ *
+ * The refusals live in SuperAdminService, on the server, and the page's
+ * JavaScript only greys a button out. A POST that arrives anyway is
+ * refused by the service and reported here as a flash message.
+ */
+class SuperAdminAccountsController extends AbstractController
+{
+    private const PAGE_PATH = '/config/superadmins';
+
+    public function __construct(
+        protected Environment $twig,
+        private UserAccountRepository $userAccountRepo,
+        private SuperAdminService $superAdminService
+    ) {
+    }
+
+    /**
+     * GET /config/superadmins
+     *
+     * @param array<string, string> $params
+     */
+    public function index(Request $request, array $params): Response
+    {
+        return $this->render('config/super_admins.html.twig', [
+            'accounts' => $this->userAccountRepo->findSuperAdmins(),
+            'current_account_id' => AuthSession::getUserAccountId(),
+        ]);
+    }
+
+    /**
+     * POST /config/superadmins/add — grant the right to an address,
+     * creating the account when it does not exist yet.
+     *
+     * @param array<string, string> $params
+     */
+    public function add(Request $request, array $params): Response
+    {
+        if (($guard = $this->guardCsrf($request, self::PAGE_PATH)) !== null) {
+            return $guard;
+        }
+
+        $email = (string) $request->getBody('email', '');
+
+        try {
+            $result = $this->superAdminService->grant($email, AuthSession::getUserAccountId());
+        } catch (SuperAdminException $e) {
+            FlashMessage::set('error', $e->getMessage());
+
+            return $this->redirect(self::PAGE_PATH);
+        }
+
+        if ($result['already']) {
+            FlashMessage::set('warning', 'Ce compte est déjà superadmin.');
+        } elseif ($result['created']) {
+            FlashMessage::set(
+                'success',
+                'Le compte a été créé et le droit superadmin lui a été accordé. '
+                . 'La personne se connecte avec un lien magique depuis la page de connexion.'
+            );
+        } else {
+            FlashMessage::set('success', 'Le droit superadmin a été accordé à ce compte.');
+        }
+
+        return $this->redirect(self::PAGE_PATH);
+    }
+
+    /**
+     * POST /config/superadmins/revoke — withdraw the right. The flag
+     * only: the account keeps its password, its passkeys and everything
+     * that references it.
+     *
+     * @param array<string, string> $params
+     */
+    public function revoke(Request $request, array $params): Response
+    {
+        if (($guard = $this->guardCsrf($request, self::PAGE_PATH)) !== null) {
+            return $guard;
+        }
+
+        $accountId = (int) $request->getBody('user_account_id', '0');
+
+        try {
+            $this->superAdminService->revoke($accountId, AuthSession::getUserAccountId());
+        } catch (SuperAdminException $e) {
+            FlashMessage::set('error', $e->getMessage());
+
+            return $this->redirect(self::PAGE_PATH);
+        }
+
+        FlashMessage::set('success', 'Le droit superadmin a été retiré.');
+
+        return $this->redirect(self::PAGE_PATH);
+    }
+}

--- a/core/Security/SuperAdminException.php
+++ b/core/Security/SuperAdminException.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security;
+
+/**
+ * A refused change to the super-admin accounts, stated in French for the
+ * person who attempted it (« Vous ne pouvez pas retirer votre propre
+ * accès superadmin. »).
+ *
+ * Marked {@see \Core\Exception\UserFacingException}: every message this
+ * class is constructed with is a full French sentence naming only what
+ * the visitor can see — an account, their own access, the last remaining
+ * administrator — and never a table, a column or a class. Same "typed
+ * domain exception, caught by the controller, message shown as-is"
+ * convention as Core\Member\SectionException.
+ */
+class SuperAdminException extends \RuntimeException implements \Core\Exception\UserFacingException
+{
+}

--- a/core/Security/SuperAdminService.php
+++ b/core/Security/SuperAdminService.php
@@ -11,8 +11,9 @@ namespace Core\Security;
 use Core\Journal\JournalService;
 
 /**
- * Deactivating and reactivating a super-admin account, with the journal
- * entry each one owes.
+ * Granting, withdrawing, deactivating and reactivating the super-admin
+ * right, with the journal entry each one owes and the refusals none of
+ * them may skip.
  *
  * The repository writes the columns; this is where the act is recorded.
  * It exists as a service rather than as controller code because a
@@ -34,6 +35,84 @@ class SuperAdminService
     }
 
     /**
+     * Give the super-admin right to an address.
+     *
+     * The account is created when it does not exist yet — an address is
+     * all it takes, and the first connection is a magic link like
+     * everybody else's. There is no invitation token and no "pending"
+     * state: clicking the emailed link IS the proof that the address
+     * belongs to the person, so a separate acceptance step would prove
+     * nothing the link does not already prove.
+     *
+     * Setting the flag is idempotent, so an address that is already a
+     * super admin produces no duplicate and no error — it is already in
+     * the state the caller asked for.
+     *
+     * @return array{account: UserAccount, created: bool, already: bool}
+     * @throws SuperAdminException when the address is not usable
+     */
+    public function grant(string $email, ?int $actorId): array
+    {
+        $email = trim($email);
+        if ($email === '' || filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            throw new SuperAdminException("Cette adresse e-mail n'est pas valide.");
+        }
+
+        $existing = $this->userAccountRepo->findByEmail($email);
+
+        if ($existing !== null && $existing->isSuperAdmin) {
+            return ['account' => $existing, 'created' => false, 'already' => true];
+        }
+
+        if ($existing !== null) {
+            $this->userAccountRepo->grantSuperAdmin($existing->id);
+            $account = $this->userAccountRepo->findById($existing->id);
+            \assert($account !== null);
+            $created = false;
+        } else {
+            $account = $this->userAccountRepo->create($email, true);
+            $created = true;
+        }
+
+        $this->journalService->log(
+            'core',
+            'super_admin_granted',
+            'security',
+            'Droit superadmin accordé',
+            ['user_account_id' => $account->id, 'account_created' => $created],
+            $actorId
+        );
+
+        return ['account' => $account, 'created' => $created, 'already' => false];
+    }
+
+    /**
+     * Withdraw the super-admin right — the flag only, never the row.
+     *
+     * Two refusals, both here on the server. The JavaScript on the page
+     * only greys a button out; a POST that arrives anyway has to be
+     * refused by something that actually decides, and this is it.
+     *
+     * @throws SuperAdminException when refused
+     */
+    public function revoke(int $userAccountId, ?int $actorId): void
+    {
+        $this->refuseSelf($userAccountId, $actorId, 'super_admin_revoke_refused');
+        $this->refuseLastOne($userAccountId, $actorId, 'super_admin_revoke_refused');
+
+        $this->userAccountRepo->revokeSuperAdmin($userAccountId);
+
+        $this->journalService->log(
+            'core',
+            'super_admin_revoked',
+            'security',
+            'Droit superadmin retiré',
+            ['user_account_id' => $userAccountId],
+            $actorId
+        );
+    }
+
+    /**
      * Withdraw access. The repository's deactivate() both clears
      * is_active and stamps sessions_valid_from, so a session already open
      * falls on its next request.
@@ -43,6 +122,9 @@ class SuperAdminService
      */
     public function deactivate(int $userAccountId, ?int $actorId): void
     {
+        $this->refuseSelf($userAccountId, $actorId, 'super_admin_deactivate_refused');
+        $this->refuseLastOne($userAccountId, $actorId, 'super_admin_deactivate_refused');
+
         $this->userAccountRepo->deactivate($userAccountId);
 
         $this->journalService->log(
@@ -69,6 +151,61 @@ class SuperAdminService
             'security',
             'Compte superadmin réactivé',
             ['user_account_id' => $userAccountId],
+            $actorId
+        );
+    }
+
+    /**
+     * Nobody withdraws their own access. Compared on the session's
+     * account id rather than on the address: an address is a value that
+     * can be re-typed, re-cased, or belong to a second row after a
+     * re-key, and the identity of the person clicking is the session's,
+     * not the string in the form.
+     */
+    private function refuseSelf(int $userAccountId, ?int $actorId, string $refusalType): void
+    {
+        if ($actorId !== null && $actorId === $userAccountId) {
+            $this->journalRefusal($refusalType, $userAccountId, 'self', $actorId);
+
+            throw new SuperAdminException(
+                'Vous ne pouvez pas retirer ni désactiver votre propre accès superadmin. '
+                . 'Demandez-le à un autre compte superadmin.'
+            );
+        }
+    }
+
+    /**
+     * The site always keeps at least one super admin who can actually get
+     * in. "The last one" is counted on the accounts that are both flagged
+     * AND active, because a deactivated super admin is refused by every
+     * login path — leaving only those behind would lock the unit out of
+     * its own configuration.
+     */
+    private function refuseLastOne(int $userAccountId, ?int $actorId, string $refusalType): void
+    {
+        if ($this->userAccountRepo->countUsableSuperAdminsExcept($userAccountId) === 0) {
+            $this->journalRefusal($refusalType, $userAccountId, 'last_super_admin', $actorId);
+
+            throw new SuperAdminException(
+                "Ce compte est le dernier accès superadmin actif du site. "
+                . "Ajoutez d'abord un autre compte superadmin."
+            );
+        }
+    }
+
+    /**
+     * A refused attempt is journaled too, at the same 'security' level as
+     * the change it was refused. An attempt nobody recorded is one nobody
+     * can notice repeating.
+     */
+    private function journalRefusal(string $type, int $userAccountId, string $reason, ?int $actorId): void
+    {
+        $this->journalService->log(
+            'core',
+            $type,
+            'security',
+            'Modification refusée sur un compte superadmin',
+            ['user_account_id' => $userAccountId, 'reason' => $reason],
             $actorId
         );
     }

--- a/core/Security/UserAccountRepository.php
+++ b/core/Security/UserAccountRepository.php
@@ -210,6 +210,85 @@ class UserAccountRepository
     }
 
     /**
+     * Every account carrying is_super_admin, oldest first — the list
+     * Configuration > Comptes superadmin shows.
+     *
+     * Returns UserAccount objects, so the address is decrypted here in
+     * the Repository like every other encrypted read (SECURITY.md §5),
+     * and the page gets created_at alongside because it is one of the
+     * four things it displays.
+     *
+     * @return array<int, array{account: UserAccount, created_at: ?string}>
+     */
+    public function findSuperAdmins(): array
+    {
+        $stmt = $this->pdo->query(
+            'SELECT * FROM user_accounts WHERE is_super_admin = 1 ORDER BY id ASC'
+        );
+        $rows = $stmt !== false ? $stmt->fetchAll(\PDO::FETCH_ASSOC) : [];
+
+        $accounts = [];
+        foreach ($rows as $row) {
+            $accounts[] = [
+                'account' => $this->hydrate(
+                    $row,
+                    $this->encryption->decrypt($row['email_encrypted'], 'user_accounts.email')
+                ),
+                'created_at' => isset($row['created_at']) ? (string) $row['created_at'] : null,
+            ];
+        }
+
+        return $accounts;
+    }
+
+    /**
+     * How many super admins can actually administer the site right now —
+     * `is_super_admin` AND `is_active` — ignoring $exceptId.
+     *
+     * This is the question behind "you cannot remove the last super
+     * admin": what matters is not how many rows carry the flag but how
+     * many of them can still get in. A deactivated super admin is refused
+     * by every login path, so counting one would let the site be left
+     * with no usable administrative access at all — which is precisely
+     * the situation the refusal exists to prevent.
+     */
+    public function countUsableSuperAdminsExcept(int $exceptId): int
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT COUNT(*) FROM user_accounts WHERE is_super_admin = 1 AND is_active = 1 AND id <> ?'
+        );
+        $stmt->execute([$exceptId]);
+
+        return (int) $stmt->fetchColumn();
+    }
+
+    /**
+     * Set the flag on an existing account. Idempotent: an account that
+     * already carries it is simply left carrying it, which is what makes
+     * "add an address that is already a super admin" produce no duplicate
+     * rather than an error.
+     */
+    public function grantSuperAdmin(int $id): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE user_accounts SET is_super_admin = 1 WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    /**
+     * Clear the flag — the flag ONLY, never the row. user_accounts holds
+     * the password, the passkeys and the notification preferences, and is
+     * referenced by event_log, scheduled_actions and files.created_by
+     * among others: a chef d'unité who keeps a legitimate Desk access
+     * must not lose their credentials because someone withdrew a
+     * superadmin right they also happened to have.
+     */
+    public function revokeSuperAdmin(int $id): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE user_accounts SET is_super_admin = 0 WHERE id = ?');
+        $stmt->execute([$id]);
+    }
+
+    /**
      * Find a user account by email blind index.
      */
     public function findByBlindIndex(string $blindIndex): ?UserAccount

--- a/core/View/templates/config/super_admins.html.twig
+++ b/core/View/templates/config/super_admins.html.twig
@@ -1,0 +1,98 @@
+{% extends "base.html.twig" %}
+
+{% block title %}Comptes superadmin — {{ site_name }}{% endblock %}
+
+{% block content %}
+    {% include 'partials/page_header.html.twig' with { title: 'Comptes superadmin' } only %}
+
+    <p class="text-body-secondary small mb-4">
+        Les comptes qui administrent le site, en dehors du Desk. Un accès superadmin ne
+        dépend d'aucune fonction dans le Desk : il reste valable même si l'import remplace
+        tout le Staff d'Unité. Les animateurs et les chefs d'unité, eux, tiennent leur accès
+        de leur fonction et ne se gèrent pas depuis cette page.
+    </p>
+
+    <div class="card mb-4">
+        <div class="card-body">
+            <h2 class="h6 mb-3">Ajouter un compte superadmin</h2>
+            <form method="post" action="/config/superadmins/add" class="row g-2 align-items-end">
+                {{ csrf_field()|raw }}
+                <div class="col-12 col-md">
+                    {% include 'partials/form_field.html.twig' with {
+                        field_id: 'super-admin-email',
+                        field_name: 'email',
+                        label: 'Adresse e-mail',
+                        type: 'email',
+                        required: true,
+                        autocomplete: 'email',
+                        wrapper_class: '',
+                        help: "Si aucun compte n'existe pour cette adresse, il est créé. La personne se connecte ensuite avec un lien magique, depuis la page de connexion.",
+                    } only %}
+                </div>
+                <div class="col-12 col-md-auto">
+                    <button type="submit" class="btn btn-primary w-100 w-sm-auto">
+                        <i class="bi bi-plus-lg" aria-hidden="true"></i> Ajouter
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    {% if accounts is empty %}
+        {% include 'partials/empty_state.html.twig' with {
+            message: 'Aucun compte superadmin.',
+            icon: 'bi-shield-lock',
+        } only %}
+    {% else %}
+        <div class="table-responsive">
+            <table class="table align-middle">
+                <thead>
+                    <tr>
+                        <th scope="col">Adresse e-mail</th>
+                        <th scope="col">Créé le</th>
+                        <th scope="col">Dernière connexion</th>
+                        <th scope="col">État</th>
+                        <th scope="col"><span class="visually-hidden">Actions</span></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for row in accounts %}
+                        {% set account = row.account %}
+                        {% set is_self = current_account_id is not null and account.id == current_account_id %}
+                        <tr>
+                            <td>
+                                {{ account.email }}
+                                {% if is_self %}
+                                    <span class="badge text-bg-secondary">Vous</span>
+                                {% endif %}
+                            </td>
+                            <td>{{ row.created_at ? row.created_at|date_fr : '—' }}</td>
+                            <td>{{ account.lastLoginAt ? account.lastLoginAt|datetime_fr : 'Jamais' }}</td>
+                            <td>
+                                {% if account.isActive %}
+                                    <span class="badge text-bg-success">Actif</span>
+                                {% else %}
+                                    <span class="badge text-bg-secondary">Désactivé</span>
+                                {% endif %}
+                            </td>
+                            <td class="text-end">
+                                {% if is_self %}
+                                    <span class="text-body-secondary small">Vous ne pouvez pas retirer votre propre accès.</span>
+                                {% else %}
+                                    <form method="post" action="/config/superadmins/revoke"
+                                          data-confirm="Retirer le droit superadmin à {{ account.email }} ? Cette personne perdra l'accès à la configuration du site. Son compte, son mot de passe et ses clés numériques sont conservés.">
+                                        {{ csrf_field()|raw }}
+                                        <input type="hidden" name="user_account_id" value="{{ account.id }}">
+                                        <button type="submit" class="btn btn-sm btn-outline-danger">
+                                            <i class="bi bi-trash" aria-hidden="true"></i> Retirer le droit
+                                        </button>
+                                    </form>
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/docs/help/comptes-superadmin.md
+++ b/docs/help/comptes-superadmin.md
@@ -1,0 +1,61 @@
+---
+id: comptes-superadmin
+title: Gérer les comptes superadmin
+summary: Les comptes qui administrent le site en dehors du Desk : en ajouter un, lui retirer le droit, et pourquoi certains retraits sont refusés.
+category: Configuration
+role_min: superadmin
+paths: /config/superadmins
+related: config-desk, mon-compte, journal
+---
+
+Un compte superadmin administre le site. C'est le seul accès qui ne
+dépend d'aucune fonction dans le Desk : il reste valable même si un
+import remplace tout le Staff d'Unité. Les animateurs et les chefs
+d'unité, eux, tiennent leur accès de leur fonction, et ne se gèrent pas
+depuis cette page.
+
+## Ajouter un compte
+
+Vous n'avez besoin que d'une adresse e-mail. Si aucun compte n'existe
+pour cette adresse, il est créé. Si un compte existe déjà — un chef
+d'unité, par exemple — il reçoit simplement le droit en plus de ce
+qu'il a déjà.
+
+Il n'y a ni mot de passe à choisir, ni invitation à accepter. La
+personne se connecte comme tout le monde : elle demande un lien magique
+depuis la page de connexion, et le clic sur ce lien prouve à lui seul
+que l'adresse est bien la sienne.
+
+Ajouter une adresse qui est déjà superadmin ne crée pas de doublon : le
+site vous le signale et ne change rien.
+
+## Retirer le droit
+
+« Retirer le droit » enlève l'accès d'administration, et rien d'autre.
+Le compte reste : son mot de passe, ses clés numériques et ses
+préférences de notification sont conservés, et un chef d'unité qui
+garde par ailleurs un accès légitime le garde entièrement.
+
+## Deux retraits que le site refuse
+
+- **Votre propre accès.** Vous ne pouvez pas vous retirer vous-même.
+  Demandez-le à un autre compte superadmin.
+- **Le dernier accès actif.** Le site garde toujours au moins un
+  compte superadmin capable de se connecter. Ajoutez d'abord quelqu'un
+  d'autre, puis retirez.
+
+Ces deux refus sont vérifiés par le site lui-même, pas seulement par
+le bouton grisé à l'écran.
+
+## Ce que vous voyez dans la liste
+
+Pour chaque compte : son adresse, la date de création, la dernière
+connexion — « Jamais » tant que la personne ne s'est pas connectée — et
+son état.
+
+> Un accès superadmin ouvre toute la configuration du site, y compris
+> les données personnelles des membres. N'en accordez qu'aux personnes
+> qui en ont réellement besoin.
+
+Chaque ajout et chaque retrait est enregistré dans le journal, ainsi
+que les tentatives refusées.

--- a/public/index.php
+++ b/public/index.php
@@ -86,6 +86,7 @@ use Core\Http\Controller\ScheduledActionsController;
 use Core\Http\Controller\ScoutYearController;
 use Core\Http\Controller\SettingsController;
 use Core\Http\Controller\SetupController;
+use Core\Http\Controller\SuperAdminAccountsController;
 use Core\Http\Controller\SupportController;
 use Core\Http\Controller\ShortUrlController;
 use Core\Http\Controller\StaffsController;
@@ -146,6 +147,7 @@ use Core\Security\PasswordAuthMethod;
 use Core\Security\Role;
 use Core\Security\SecretManager;
 use Core\Security\SessionManager;
+use Core\Security\SuperAdminService;
 use Core\Security\UserAccountRepository;
 use Core\Security\WebAuthnCredentialRepository;
 use Core\Security\WebAuthnService;
@@ -1017,6 +1019,11 @@ $memberRepo = new MemberRepository($pdo);
 $memberYearRepo = new MemberYearRepository($pdo);
 $importJournalRepo = new ImportJournalRepository($pdo);
 $userAccountRepo = new UserAccountRepository($pdo, $encryptionService);
+
+// Configuration > Comptes superadmin (Core\Security\SuperAdminService):
+// granting/withdrawing the flag and deactivating/reactivating an account,
+// with the journal entries and the server-side refusals those changes owe.
+$superAdminService = new SuperAdminService($userAccountRepo, $journalService);
 $mappingResolver = new MappingResolver($functionRepo, $ageBranchRepo, $importSectionRepo, $feeCategoryRepo);
 $csvParser = new DeskCsvParser();
 $unitStaffSectionService = new UnitStaffSectionService($pdo);
@@ -1477,6 +1484,7 @@ $menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'Desk', '/config/function
 $menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'Réglages', '/config/settings', 'superadmin', 30, false, null, MenuBuilder::SORT_GROUP_CORE, 'bi-gear-wide-connected', null, 'site');
 $menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'RGPD', '/config/rgpd', 'superadmin', 35, false, null, MenuBuilder::SORT_GROUP_CORE, 'bi-shield-lock', null, 'unite_donnees');
 $menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'Actions planifiées', '/config/scheduled', 'superadmin', 40, false, null, MenuBuilder::SORT_GROUP_CORE, 'bi-clock-history', null, 'exploitation');
+$menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'Comptes superadmin', '/config/superadmins', 'superadmin', 44, false, null, MenuBuilder::SORT_GROUP_CORE, 'bi-shield-lock', null, 'exploitation');
 $menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'Maintenance', '/config/maintenance', 'admin', 45, false, null, MenuBuilder::SORT_GROUP_CORE, 'bi-tools', null, 'exploitation');
 $menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'Notifications', '/config/notifications', 'superadmin', 46, false, null, MenuBuilder::SORT_GROUP_CORE, 'bi-bell', null, 'exploitation');
 $menuBuilder->addPage(MenuBuilder::MENU_CONFIGURATION, 'Support', '/config/support', 'superadmin', 47, false, null, MenuBuilder::SORT_GROUP_CORE, 'bi-life-preserver', null, 'exploitation');
@@ -1950,6 +1958,12 @@ $router->addRoute('POST', '/config/badges/update', ConfigBadgesController::class
 $router->addRoute('POST', '/config/badges/toggle-active', ConfigBadgesController::class, 'toggleBadgeActive', 'superadmin');
 $router->addRoute('POST', '/config/badges/delete', ConfigBadgesController::class, 'deleteBadge', 'superadmin');
 
+// Configuration > Comptes superadmin — the accounts holding is_super_admin,
+// the one administrative access that exists outside the Desk roster.
+$router->addRoute('GET', '/config/superadmins', SuperAdminAccountsController::class, 'index', 'superadmin', ['label' => 'Comptes superadmin', 'parents' => [MenuBuilder::labelFor(MenuBuilder::MENU_CONFIGURATION)]]);
+$router->addRoute('POST', '/config/superadmins/add', SuperAdminAccountsController::class, 'add', 'superadmin');
+$router->addRoute('POST', '/config/superadmins/revoke', SuperAdminAccountsController::class, 'revoke', 'superadmin');
+
 // RGPD configuration
 $router->addRoute('GET', '/config/rgpd', RgpdConfigController::class, 'index', 'superadmin', ['label' => 'RGPD', 'parents' => [MenuBuilder::labelFor(MenuBuilder::MENU_CONFIGURATION)]]);
 $router->addRoute('POST', '/config/rgpd/save', RgpdConfigController::class, 'save', 'superadmin');
@@ -2322,6 +2336,7 @@ $frontController->registerController(ScheduledActionsController::class, new Sche
 $frontController->registerController(ConfigGeneralController::class, new ConfigGeneralController($twig));
 $frontController->registerController(ConfigModulesController::class, new ConfigModulesController($twig, $moduleManager, $journalService));
 $frontController->registerController(ConfigBadgesController::class, new ConfigBadgesController($twig, $badgeService, $journalService));
+$frontController->registerController(SuperAdminAccountsController::class, new SuperAdminAccountsController($twig, $userAccountRepo, $superAdminService));
 $frontController->registerController(FunctionsController::class, new FunctionsController($twig, $functionRepo, $journalService, $sectionService, $unitStaffSectionService, $scoutYearResolver, $badgeService, $ageBranchRepo, $moduleHooks));
 $frontController->registerController(PlaceholderController::class, new PlaceholderController($twig));
 

--- a/tests/Core/Exception/UserFacingExceptionInventoryTest.php
+++ b/tests/Core/Exception/UserFacingExceptionInventoryTest.php
@@ -54,6 +54,7 @@ final class UserFacingExceptionInventoryTest extends TestCase
         \Core\Member\SectionException::class,
         \Core\Module\ModuleRefusalException::class,
         \Core\Security\SsrfValidationException::class,
+        \Core\Security\SuperAdminException::class,
         \Core\Support\SupportPackageException::class,
         \Core\View\RgpdGenerationException::class,
         \Modules\Banner\Service\BannerException::class,

--- a/tests/Core/Http/Controller/SuperAdminAccountsControllerTest.php
+++ b/tests/Core/Http/Controller/SuperAdminAccountsControllerTest.php
@@ -1,0 +1,319 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Http\Controller;
+
+use Core\Http\Controller\SuperAdminAccountsController;
+use Core\Http\FlashMessage;
+use Core\Http\Request;
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Security\AuthSession;
+use Core\Security\CsrfGuard;
+use Core\Security\EncryptionService;
+use Core\Security\RbacGuard;
+use Core\Security\Role;
+use Core\Security\SuperAdminService;
+use Core\Security\UserAccountRepository;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Twig\Environment;
+
+/**
+ * Configuration > Comptes superadmin.
+ *
+ * The three refusals are the point of this file, and they are asserted
+ * against the controller — not against the JavaScript, which only greys
+ * a button out and is not where a refusal can live.
+ *
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class SuperAdminAccountsControllerTest extends TestCase
+{
+    private \PDO $pdo;
+    private UserAccountRepository $userRepo;
+    private SuperAdminAccountsController $controller;
+    private string $csrfToken;
+
+    protected function setUp(): void
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            ini_set('session.use_cookies', '0');
+            ini_set('session.cache_limiter', '');
+            @session_start();
+        }
+        $_SESSION = [];
+
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->userRepo = new UserAccountRepository($this->pdo, $encryption);
+
+        $twig = $this->createStub(Environment::class);
+        $twig->method('render')->willReturn('<html></html>');
+
+        $this->controller = new SuperAdminAccountsController(
+            $twig,
+            $this->userRepo,
+            new SuperAdminService($this->userRepo, new JournalService(new JournalRepository($this->pdo)))
+        );
+
+        $this->csrfToken = CsrfGuard::generateToken();
+    }
+
+    protected function tearDown(): void
+    {
+        $_SESSION = [];
+    }
+
+    // ---------------------------------------------------------------
+    // RBAC boundary
+    // ---------------------------------------------------------------
+
+    /**
+     * @return array<string, array{string, string, string}>
+     */
+    public static function superAdminRoutes(): array
+    {
+        return [
+            'the page itself' => ['GET', '/config/superadmins', 'index'],
+            'granting the right' => ['POST', '/config/superadmins/add', 'add'],
+            'withdrawing the right' => ['POST', '/config/superadmins/revoke', 'revoke'],
+        ];
+    }
+
+    /**
+     * Read out of public/index.php rather than copied here: the route
+     * table lives in a procedural bootstrap no unit test loads, so a
+     * source-level read is the only way to assert the value the
+     * application actually registers (same technique as
+     * Tests\Core\Http\Controller\EditableContentRbacTest).
+     */
+    private static function registeredRoleMin(string $method, string $path, string $action): string
+    {
+        $contents = file_get_contents(dirname(__DIR__, 4) . '/public/index.php');
+        self::assertNotFalse($contents);
+
+        $matched = preg_match(
+            '/addRoute\s*\(\s*[\'"]' . $method . '[\'"]\s*,\s*[\'"]' . preg_quote($path, '/') . '[\'"]\s*,'
+                . '\s*SuperAdminAccountsController::class\s*,\s*[\'"]' . preg_quote($action, '/') . '[\'"]\s*,'
+                . '\s*[\'"]([a-z_]+)[\'"]/',
+            $contents,
+            $m
+        );
+        self::assertSame(1, $matched, "No addRoute registration found for {$method} {$path}");
+
+        return $m[1];
+    }
+
+    #[DataProvider('superAdminRoutes')]
+    public function testEveryRouteIsRegisteredAtSuperadmin(string $method, string $path, string $action): void
+    {
+        $this->assertSame('superadmin', self::registeredRoleMin($method, $path, $action));
+    }
+
+    #[DataProvider('superAdminRoutes')]
+    public function testASuperAdminReachesIt(string $method, string $path, string $action): void
+    {
+        AuthSession::login(1, 'admin@test.be', 'superadmin');
+
+        $this->assertNull(
+            (new RbacGuard())->enforce(Role::fromString(self::registeredRoleMin($method, $path, $action)))
+        );
+    }
+
+    /**
+     * One level below the floor: a chef d'unité (admin) manages the unit,
+     * not the accounts that administer the site.
+     */
+    #[DataProvider('superAdminRoutes')]
+    public function testAnAdminIsRefused(string $method, string $path, string $action): void
+    {
+        AuthSession::login(2, 'chef-unite@test.be', 'admin');
+
+        $response = (new RbacGuard())->enforce(Role::fromString(self::registeredRoleMin($method, $path, $action)));
+
+        $this->assertNotNull($response, "A chef d'unité must not reach {$method} {$path}.");
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    // ---------------------------------------------------------------
+    // Adding
+    // ---------------------------------------------------------------
+
+    public function testAddingAnUnknownAddressCreatesTheAccount(): void
+    {
+        $this->loginAsExistingSuperAdmin();
+
+        $this->controller->add($this->postRequest(['email' => 'nouveau@example.com']), []);
+
+        $created = $this->userRepo->findByEmail('nouveau@example.com');
+        $this->assertNotNull($created);
+        $this->assertTrue($created->isSuperAdmin);
+        $this->assertTrue($created->isActive);
+        $this->assertSame('success', FlashMessage::get()['type'] ?? null);
+    }
+
+    public function testAddingAnExistingAccountSetsTheFlagWithoutDuplicating(): void
+    {
+        $this->loginAsExistingSuperAdmin();
+        $chief = $this->userRepo->create('chef-unite@example.com', false);
+
+        $this->controller->add($this->postRequest(['email' => 'chef-unite@example.com']), []);
+
+        $this->assertCount(2, $this->userRepo->findAllIds(), 'no second row for the same address');
+        $this->assertTrue($this->userRepo->findById($chief->id)?->isSuperAdmin);
+    }
+
+    public function testAddingAnAddressThatIsAlreadySuperAdminChangesNothing(): void
+    {
+        $this->loginAsExistingSuperAdmin();
+        $other = $this->userRepo->create('deja@example.com', true);
+
+        $this->controller->add($this->postRequest(['email' => 'DEJA@example.com']), []);
+
+        $this->assertCount(2, $this->userRepo->findAllIds());
+        $this->assertTrue($this->userRepo->findById($other->id)?->isSuperAdmin);
+        $this->assertSame('warning', FlashMessage::get()['type'] ?? null);
+    }
+
+    public function testAnInvalidAddressIsRefused(): void
+    {
+        $this->loginAsExistingSuperAdmin();
+
+        $this->controller->add($this->postRequest(['email' => 'pas-une-adresse']), []);
+
+        $this->assertCount(1, $this->userRepo->findAllIds());
+        $this->assertSame('error', FlashMessage::get()['type'] ?? null);
+    }
+
+    // ---------------------------------------------------------------
+    // The three refusals — server-side
+    // ---------------------------------------------------------------
+
+    public function testTheLastSuperAdminCannotBeRevoked(): void
+    {
+        // The only super admin, and someone else is doing the revoking,
+        // so it is the "last one" rule that has to catch this and not the
+        // "not yourself" one.
+        $alone = $this->userRepo->create('seul@example.com', true);
+        AuthSession::login(999, 'quelquun@example.com', 'superadmin');
+
+        $this->controller->revoke($this->postRequest(['user_account_id' => (string) $alone->id]), []);
+
+        $this->assertTrue($this->userRepo->findById($alone->id)?->isSuperAdmin, 'still a super admin');
+        $flash = FlashMessage::get();
+        $this->assertSame('error', $flash['type'] ?? null);
+        $this->assertStringContainsString('dernier', (string) ($flash['message'] ?? ''));
+        $this->assertRefusalJournaled('last_super_admin');
+    }
+
+    /**
+     * Counted on the accounts that can actually log in: a deactivated
+     * super admin is refused by every login path, so leaving only one
+     * behind would lock the unit out of its own configuration.
+     */
+    public function testADeactivatedSuperAdminDoesNotCountAsTheOneThatRemains(): void
+    {
+        $active = $this->userRepo->create('actif@example.com', true);
+        $dormant = $this->userRepo->create('dormant@example.com', true);
+        $this->userRepo->deactivate($dormant->id);
+        AuthSession::login(999, 'quelquun@example.com', 'superadmin');
+
+        $this->controller->revoke($this->postRequest(['user_account_id' => (string) $active->id]), []);
+
+        $this->assertTrue($this->userRepo->findById($active->id)?->isSuperAdmin);
+        $this->assertSame('error', FlashMessage::get()['type'] ?? null);
+    }
+
+    /**
+     * Compared on the session's account id, never on the address: an
+     * address can be re-typed or re-cased, and the identity of the person
+     * clicking is the session's.
+     */
+    public function testYouCannotRevokeYourself(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $this->userRepo->create('autre@example.com', true);
+        AuthSession::login($me->id, $me->email, 'superadmin');
+
+        $this->controller->revoke($this->postRequest(['user_account_id' => (string) $me->id]), []);
+
+        $this->assertTrue($this->userRepo->findById($me->id)?->isSuperAdmin, 'still a super admin');
+        $flash = FlashMessage::get();
+        $this->assertSame('error', $flash['type'] ?? null);
+        $this->assertStringContainsString('propre', (string) ($flash['message'] ?? ''));
+        $this->assertRefusalJournaled('self');
+    }
+
+    public function testRevokingSomebodyElseWorksAndKeepsTheRow(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+        AuthSession::login($me->id, $me->email, 'superadmin');
+
+        $this->controller->revoke($this->postRequest(['user_account_id' => (string) $other->id]), []);
+
+        $reloaded = $this->userRepo->findById($other->id);
+        $this->assertNotNull($reloaded, 'the row is never deleted');
+        $this->assertFalse($reloaded->isSuperAdmin);
+        $this->assertSame('success', FlashMessage::get()['type'] ?? null);
+    }
+
+    // ---------------------------------------------------------------
+    // CSRF
+    // ---------------------------------------------------------------
+
+    public function testARevokeWithoutACsrfTokenChangesNothing(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+        AuthSession::login($me->id, $me->email, 'superadmin');
+
+        $this->controller->revoke(
+            new Request('POST', '/config/superadmins/revoke', [], ['user_account_id' => (string) $other->id], [], []),
+            []
+        );
+
+        $this->assertTrue($this->userRepo->findById($other->id)?->isSuperAdmin);
+    }
+
+    // ---------------------------------------------------------------
+
+    private function loginAsExistingSuperAdmin(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        AuthSession::login($me->id, $me->email, 'superadmin');
+    }
+
+    /**
+     * @param array<string, string> $body
+     */
+    private function postRequest(array $body): Request
+    {
+        return new Request(
+            'POST',
+            '/config/superadmins',
+            [],
+            $body + ['_csrf_token' => $this->csrfToken],
+            [],
+            []
+        );
+    }
+
+    private function assertRefusalJournaled(string $reason): void
+    {
+        $stmt = $this->pdo->query(
+            "SELECT * FROM event_log WHERE event_type = 'super_admin_revoke_refused' ORDER BY id DESC LIMIT 1"
+        );
+        $row = $stmt !== false ? $stmt->fetch(\PDO::FETCH_ASSOC) : false;
+
+        $this->assertIsArray($row, 'a refused attempt is journaled');
+        $this->assertSame('security', $row['level']);
+        $context = json_decode((string) $row['context'], true);
+        $this->assertSame($reason, $context['reason'] ?? null);
+        $this->assertStringNotContainsString('@', (string) $row['context'], 'never the address');
+    }
+}

--- a/tests/Core/Http/MenuRegistrationOrderTest.php
+++ b/tests/Core/Http/MenuRegistrationOrderTest.php
@@ -57,7 +57,7 @@ class MenuRegistrationOrderTest extends TestCase
 
         $this->assertSame('Installation & serveur', $labels[0]);
         $this->assertSame(
-            ['Modules', 'Badges', 'Desk', 'Réglages', 'RGPD', 'Actions planifiées', 'Maintenance', 'Notifications', 'Support'],
+            ['Modules', 'Badges', 'Desk', 'Réglages', 'RGPD', 'Actions planifiées', 'Comptes superadmin', 'Maintenance', 'Notifications', 'Support'],
             array_slice($labels, 1)
         );
     }

--- a/tests/Core/Security/SuperAdminServiceTest.php
+++ b/tests/Core/Security/SuperAdminServiceTest.php
@@ -51,6 +51,7 @@ class SuperAdminServiceTest extends TestCase
     public function testReactivateRestoresAccessAndJournalsIt(): void
     {
         $account = $this->userRepo->create('admin@test.com', true);
+        $this->userRepo->create('other-admin@test.com', true);
         $this->service->deactivate($account->id, null);
 
         $this->service->reactivate($account->id, null);
@@ -70,6 +71,7 @@ class SuperAdminServiceTest extends TestCase
     public function testTheJournalEntryNamesTheAccountIdAndNeverTheAddress(): void
     {
         $account = $this->userRepo->create('admin@test.com', true);
+        $this->userRepo->create('other-admin@test.com', true);
 
         $this->service->deactivate($account->id, null);
         $entry = $this->lastJournalEntry();


### PR DESCRIPTION
## Description

A new Configuration page, `role_min: superadmin`, in the `configuration` menu, named by the task rather than by the layer (design.md §7.1): **« Comptes superadmin »**.

It lists the accounts carrying `is_super_admin` with, for each, the address, the creation date, the last login and whether it is active. No Desk member is managed from here: a Desk member's access comes from their function in the roster, which this page does not touch.

### Adding

One field, the email address (`form_field`, type `email`). The account is created when it does not exist; when it does — a chef d'unité, say — it simply gains the flag, with no second row. An address that is already a super admin produces no duplicate and no error, only a `warning` flash.

No invitation token, no "pending" state: the first connection is a magic link like everybody else's, and clicking it is already the proof that the address belongs to the person.

### Withdrawing

The flag ONLY, never the row. The account keeps its password, its passkeys and its notification preferences, and `event_log`, `scheduled_actions`, `files.created_by` and the rest keep pointing at something. `data-confirm` sits **on the `<form>`** (design.md §7.5 — on a button it is silently inert), with a label naming the action and its consequence.

### The refusals, on the server

Both are decided in `SuperAdminService`, never client-side:

- **the last super admin** cannot lose the right;
- **nobody withdraws their own**, compared on the session's account id rather than on the address, which can be re-typed or re-cased;
- **every refused attempt is journaled** at `level: 'security'`, with the account id and never the address.

"The last one" is counted on the accounts that are both flagged **AND active**, because a deactivated super admin is refused by every login path — leaving only those behind would lock the unit out of its own configuration. That is the same reading `RosterComparisonRepository::hasSuperAdminAccount()` took in IT-02, so the roster-replacement escape hatch and this page agree on what a usable super admin is. `RosterReplacementGuard` is otherwise untouched and stays coherent as the count changes.

An action the server would refuse is **not rendered at all** rather than rendered disabled — a disabled control is something a script can re-enable, and a refusal has to read as a refusal.

### Conventions

`page_header` with a single `<h1>` matching the `<title>`; `empty_state` for the empty list; no « Retour » button (the breadcrumb is the only affordance); buttons per §7.4; flash types limited to `success` / `error` / `warning`.

### Help topic

`docs/help/comptes-superadmin.md` (AGENTS.md checklist #14), written to the design.md §7.11 charter — vouvoiement, under 500 words, the §7.1 lexicon, one `>` callout.

### Tests

- the RBAC boundary on all three routes, with the role read out of the real route table in `public/index.php` and fed to the real `RbacGuard`: superadmin passes, a chef d'unité gets 403;
- the three refusals, each verified to fail when the guard is removed;
- creation of an unknown address; the flag set on an existing account with no duplicate; an address already super admin changing nothing;
- an invalid address refused; a revoke without a CSRF token changing nothing.

### Verification

- `vendor/bin/phpunit` — 12289 tests, 40333 assertions, no failures (re-run after rebase on `main` with IT-02 merged)
- `vendor/bin/phpstan analyse` — No errors
- `npm run typecheck` — 0 new findings

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, no JavaScript in this iteration

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCFZiaeHecfW1shVLNKpM4)_