### PR TITLE
IT-04 — the actif/inactif switch, and the mails a change of access owes

### DIFF
--- a/core/Http/Controller/SuperAdminAccountsController.php
+++ b/core/Http/Controller/SuperAdminAccountsController.php
@@ -48,9 +48,26 @@ class SuperAdminAccountsController extends AbstractController
      */
     public function index(Request $request, array $params): Response
     {
+        $accounts = $this->userAccountRepo->findSuperAdmins();
+        $actorId = AuthSession::getUserAccountId();
+
+        // Whether each row may be offered a switch at all. Drawing one the
+        // server would refuse is dishonest, and a DISABLED one would be
+        // worse: a script can re-enable it, so a refusal has to be absent
+        // rather than merely greyed. The server re-checks on every POST
+        // regardless — this decides rendering, never permission.
+        $canToggle = [];
+        $canRevoke = [];
+        foreach ($accounts as $row) {
+            $canToggle[$row['account']->id] = $this->superAdminService->canToggleActive($row['account'], $actorId);
+            $canRevoke[$row['account']->id] = $this->superAdminService->canRevoke($row['account'], $actorId);
+        }
+
         return $this->render('config/super_admins.html.twig', [
-            'accounts' => $this->userAccountRepo->findSuperAdmins(),
-            'current_account_id' => AuthSession::getUserAccountId(),
+            'accounts' => $accounts,
+            'current_account_id' => $actorId,
+            'can_toggle' => $canToggle,
+            'can_revoke' => $canRevoke,
         ]);
     }
 
@@ -117,5 +134,57 @@ class SuperAdminAccountsController extends AbstractController
         FlashMessage::set('success', 'Le droit superadmin a été retiré.');
 
         return $this->redirect(self::PAGE_PATH);
+    }
+
+    /**
+     * POST /config/superadmins/toggle-active — activate or deactivate one
+     * account (AJAX, JSON).
+     *
+     * An independent control, so it saves on change with a toast and no
+     * button (design.md §7.13) — which is exactly why the two refusals
+     * cannot live in the switch's own JavaScript: it only greys a control
+     * out, and a POST that arrives anyway is decided here.
+     *
+     * @param array<string, string> $params
+     */
+    public function toggleActive(Request $request, array $params): Response
+    {
+        $data = $this->decodeJsonBody($request);
+        if ($data === null) {
+            return $this->json(['success' => false, 'error' => 'Requête invalide.'], 400);
+        }
+
+        if (($guard = $this->guardCsrfJson($request, (string) ($data['_csrf_token'] ?? ''))) !== null) {
+            return $guard;
+        }
+
+        $accountId = isset($data['user_account_id']) ? (int) $data['user_account_id'] : 0;
+        $shouldBeActive = (bool) ($data['is_active'] ?? false);
+        $actorId = AuthSession::getUserAccountId();
+
+        try {
+            if ($shouldBeActive) {
+                $this->superAdminService->reactivate($accountId, $actorId);
+            } else {
+                $this->superAdminService->deactivate($accountId, $actorId);
+            }
+        } catch (SuperAdminException $e) {
+            return $this->json(['success' => false, 'error' => $e->getMessage()], 400);
+        }
+
+        return $this->json([
+            'success' => true,
+            'message' => $shouldBeActive ? 'Le compte a été réactivé.' : 'Le compte a été désactivé.',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function decodeJsonBody(Request $request): ?array
+    {
+        $data = json_decode($request->getRawBody(), true);
+
+        return is_array($data) ? $data : null;
     }
 }

--- a/core/Security/SuperAdminMailer.php
+++ b/core/Security/SuperAdminMailer.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security;
+
+use Core\Mail\MailException;
+use Core\Mail\MailService;
+use Twig\Environment;
+
+/**
+ * The three emails a change to a super-admin access owes the person it
+ * concerns.
+ *
+ * All of them go through MailService::send(), which owns the subject
+ * prefix, the DKIM signature, the multipart body and the delivery mode
+ * (AGENTS.md § Email) — nothing here sends anything itself.
+ *
+ * None of them is a request: the promotion mail is a notification, not
+ * an invitation to accept. There is no acceptance step anywhere in this
+ * feature, because clicking the magic link at the first connection is
+ * already the proof that the address belongs to the person, and a second
+ * ceremony would prove nothing more.
+ *
+ * A send failure never undoes the change, which has already happened by
+ * the time this runs: the site refusing to record a withdrawal because a
+ * mail server was down would be worse than a withdrawal nobody was
+ * emailed about. Failures are swallowed here and left to MailService's
+ * own journaling.
+ *
+ * Why a deactivation mail exists at all (the chantier left the call
+ * open): a deactivation cuts the person off mid-session, at the very
+ * next click. Somebody who is not told reads that as the site being
+ * broken and goes looking for help. A withdrawal of the right, by
+ * contrast, is silent from their side until they try to open a
+ * configuration page — and it still gets its own mail for the same
+ * reason. Reactivation gets none: the access simply works again, which
+ * needs no warning.
+ */
+class SuperAdminMailer
+{
+    public function __construct(
+        private MailService $mailService,
+        private Environment $twig,
+        private string $siteName,
+        private string $baseUrl
+    ) {
+    }
+
+    /**
+     * $grantedByLabel names who did it — an address, or a generic phrase
+     * when the change had no identified author behind it. It is the one
+     * question the recipient actually has ("who gave me this?"), so the
+     * mail answers it rather than arriving anonymously.
+     */
+    public function sendGranted(string $to, ?string $grantedByLabel): void
+    {
+        $this->send($to, 'Vous êtes administrateur du site', 'super_admin_granted', [
+            'granted_by' => $grantedByLabel,
+        ]);
+    }
+
+    public function sendRevoked(string $to): void
+    {
+        $this->send($to, "Votre accès administrateur a été retiré", 'super_admin_revoked', []);
+    }
+
+    public function sendDeactivated(string $to): void
+    {
+        $this->send($to, 'Votre accès au site a été suspendu', 'super_admin_deactivated', []);
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function send(string $to, string $subject, string $template, array $context): void
+    {
+        $context += [
+            'site_name' => $this->siteName,
+            'login_url' => rtrim($this->baseUrl, '/') . '/login',
+        ];
+
+        try {
+            $this->mailService->send(
+                to: $to,
+                subject: $subject,
+                bodyHtml: $this->twig->render("email/{$template}.html.twig", $context),
+                bodyText: $this->twig->render("email/{$template}.text.twig", $context)
+            );
+        } catch (MailException) {
+            // Deliberately swallowed — see the class docblock. The change
+            // itself has already happened, and MailService has already
+            // journaled the technical reason.
+        }
+    }
+}

--- a/core/Security/SuperAdminService.php
+++ b/core/Security/SuperAdminService.php
@@ -30,7 +30,14 @@ class SuperAdminService
 {
     public function __construct(
         private UserAccountRepository $userAccountRepo,
-        private JournalService $journalService
+        private JournalService $journalService,
+        /**
+         * Optional so a caller with no mail transport to hand — a test,
+         * a CLI path — still gets the flag changes and the journal
+         * entries, which are the parts that must never depend on a mail
+         * server being reachable.
+         */
+        private ?SuperAdminMailer $mailer = null
     ) {
     }
 
@@ -83,6 +90,8 @@ class SuperAdminService
             $actorId
         );
 
+        $this->mailer?->sendGranted($account->email, $this->labelFor($actorId));
+
         return ['account' => $account, 'created' => $created, 'already' => false];
     }
 
@@ -100,6 +109,11 @@ class SuperAdminService
         $this->refuseSelf($userAccountId, $actorId, 'super_admin_revoke_refused');
         $this->refuseLastOne($userAccountId, $actorId, 'super_admin_revoke_refused');
 
+        // Read before the change: after it, this is still the same row,
+        // but reading first keeps "who was emailed" and "who was changed"
+        // provably the same account.
+        $target = $this->userAccountRepo->findById($userAccountId);
+
         $this->userAccountRepo->revokeSuperAdmin($userAccountId);
 
         $this->journalService->log(
@@ -110,6 +124,10 @@ class SuperAdminService
             ['user_account_id' => $userAccountId],
             $actorId
         );
+
+        if ($target !== null) {
+            $this->mailer?->sendRevoked($target->email);
+        }
     }
 
     /**
@@ -125,6 +143,8 @@ class SuperAdminService
         $this->refuseSelf($userAccountId, $actorId, 'super_admin_deactivate_refused');
         $this->refuseLastOne($userAccountId, $actorId, 'super_admin_deactivate_refused');
 
+        $target = $this->userAccountRepo->findById($userAccountId);
+
         $this->userAccountRepo->deactivate($userAccountId);
 
         $this->journalService->log(
@@ -135,6 +155,10 @@ class SuperAdminService
             ['user_account_id' => $userAccountId],
             $actorId
         );
+
+        if ($target !== null) {
+            $this->mailer?->sendDeactivated($target->email);
+        }
     }
 
     /**
@@ -153,6 +177,47 @@ class SuperAdminService
             ['user_account_id' => $userAccountId],
             $actorId
         );
+    }
+
+    /**
+     * Whether « Retirer le droit » may be offered for this account — the
+     * render-time twin of revoke()'s two refusals, for the same reason
+     * canToggleActive() is the switch's: offering an action the server
+     * will always refuse is not honest, and the POST re-checks anyway.
+     */
+    public function canRevoke(UserAccount $account, ?int $actorId): bool
+    {
+        if ($actorId !== null && $actorId === $account->id) {
+            return false;
+        }
+
+        return $this->userAccountRepo->countUsableSuperAdminsExcept($account->id) > 0;
+    }
+
+    /**
+     * Whether the actif/inactif switch may be offered for this account —
+     * the render-time twin of the two refusals below, and deliberately
+     * expressed in terms of the same rules rather than beside them.
+     *
+     * Not a substitute for them: deactivate() re-checks on every POST.
+     * This only decides whether drawing a control the server would refuse
+     * is honest, and it is not.
+     *
+     * Reactivation is always allowed — it can lock nobody out — so an
+     * account that is already inactive keeps its switch even when it is
+     * the only super admin left.
+     */
+    public function canToggleActive(UserAccount $account, ?int $actorId): bool
+    {
+        if ($actorId !== null && $actorId === $account->id) {
+            return false;
+        }
+
+        if (!$account->isActive) {
+            return true;
+        }
+
+        return $this->userAccountRepo->countUsableSuperAdminsExcept($account->id) > 0;
     }
 
     /**
@@ -208,5 +273,24 @@ class SuperAdminService
             ['user_account_id' => $userAccountId, 'reason' => $reason],
             $actorId
         );
+    }
+
+    /**
+     * How the promotion mail names whoever granted the right — their
+     * address, or null when nothing identified is behind the change, in
+     * which case the mail falls back to an impersonal wording.
+     *
+     * This address goes into an EMAIL, never into a journal entry: the
+     * journal bars personal data (SECURITY.md §11), a mail is by
+     * definition addressed to someone and telling them who gave them an
+     * administrative access is the one question they will actually have.
+     */
+    private function labelFor(?int $actorId): ?string
+    {
+        if ($actorId === null) {
+            return null;
+        }
+
+        return $this->userAccountRepo->findById($actorId)?->email;
     }
 }

--- a/core/View/templates/config/super_admins.html.twig
+++ b/core/View/templates/config/super_admins.html.twig
@@ -38,6 +38,11 @@
         </div>
     </div>
 
+    <p class="text-body-secondary small mb-3">
+        L'enregistrement est automatique — il n'y a pas de bouton « Enregistrer » pour
+        l'état actif ou désactivé d'un compte.
+    </p>
+
     {% if accounts is empty %}
         {% include 'partials/empty_state.html.twig' with {
             message: 'Aucun compte superadmin.',
@@ -51,7 +56,7 @@
                         <th scope="col">Adresse e-mail</th>
                         <th scope="col">Créé le</th>
                         <th scope="col">Dernière connexion</th>
-                        <th scope="col">État</th>
+                        <th scope="col">Actif</th>
                         <th scope="col"><span class="visually-hidden">Actions</span></th>
                     </tr>
                 </thead>
@@ -59,7 +64,7 @@
                     {% for row in accounts %}
                         {% set account = row.account %}
                         {% set is_self = current_account_id is not null and account.id == current_account_id %}
-                        <tr>
+                        <tr class="{{ account.isActive ? '' : 'opacity-50' }}">
                             <td>
                                 {{ account.email }}
                                 {% if is_self %}
@@ -69,15 +74,44 @@
                             <td>{{ row.created_at ? row.created_at|date_fr : '—' }}</td>
                             <td>{{ account.lastLoginAt ? account.lastLoginAt|datetime_fr : 'Jamais' }}</td>
                             <td>
-                                {% if account.isActive %}
-                                    <span class="badge text-bg-success">Actif</span>
+                                {% if not can_toggle[account.id]|default(false) %}
+                                    {# No switch at all where the server would refuse the
+                                       change: a disabled control is something a script can
+                                       re-enable, and the refusal has to read as a refusal
+                                       rather than as a control that does not respond. #}
+                                    <span class="badge super-admin-state-badge {{ account.isActive ? 'text-bg-success' : 'text-bg-secondary' }}">
+                                        {{ account.isActive ? 'Actif' : 'Désactivé' }}
+                                    </span>
                                 {% else %}
-                                    <span class="badge text-bg-secondary">Désactivé</span>
+                                    <div class="d-flex align-items-center gap-2">
+                                        <div class="form-check form-switch mb-0">
+                                            <input type="checkbox" role="switch"
+                                                   class="form-check-input super-admin-active-toggle"
+                                                   id="super-admin-active-{{ account.id }}"
+                                                   data-account-id="{{ account.id }}"
+                                                   {{ account.isActive ? 'checked' : '' }}>
+                                            <label class="form-check-label visually-hidden" for="super-admin-active-{{ account.id }}">
+                                                Compte actif
+                                            </label>
+                                        </div>
+                                        <span class="badge super-admin-state-badge {{ account.isActive ? 'text-bg-success' : 'text-bg-secondary' }}">
+                                            {{ account.isActive ? 'Actif' : 'Désactivé' }}
+                                        </span>
+                                    </div>
                                 {% endif %}
                             </td>
                             <td class="text-end">
-                                {% if is_self %}
-                                    <span class="text-body-secondary small">Vous ne pouvez pas retirer votre propre accès.</span>
+                                {% if not can_revoke[account.id]|default(false) %}
+                                    {# Same rule as the switch: an action the server would
+                                       refuse is not offered at all, and the reason is
+                                       written out instead. #}
+                                    <span class="text-body-secondary small">
+                                        {% if is_self %}
+                                            Vous ne pouvez pas retirer votre propre accès.
+                                        {% else %}
+                                            Dernier accès superadmin actif du site.
+                                        {% endif %}
+                                    </span>
                                 {% else %}
                                     <form method="post" action="/config/superadmins/revoke"
                                           data-confirm="Retirer le droit superadmin à {{ account.email }} ? Cette personne perdra l'accès à la configuration du site. Son compte, son mot de passe et ses clés numériques sont conservés.">
@@ -95,4 +129,8 @@
             </table>
         </div>
     {% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ asset('/assets/js/config-super-admins.js') }}" defer nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/core/View/templates/config/super_admins.html.twig
+++ b/core/View/templates/config/super_admins.html.twig
@@ -89,7 +89,8 @@
                                                    class="form-check-input super-admin-active-toggle"
                                                    id="super-admin-active-{{ account.id }}"
                                                    data-account-id="{{ account.id }}"
-                                                   {{ account.isActive ? 'checked' : '' }}>
+                                                   {{ account.isActive ? 'checked' : '' }}
+                                                   aria-checked="{{ account.isActive ? 'true' : 'false' }}">
                                             <label class="form-check-label visually-hidden" for="super-admin-active-{{ account.id }}">
                                                 Compte actif
                                             </label>

--- a/core/View/templates/email/super_admin_deactivated.html.twig
+++ b/core/View/templates/email/super_admin_deactivated.html.twig
@@ -1,0 +1,7 @@
+{% extends 'email/base.html.twig' %}
+{% block content %}
+    <h2 style="margin:0 0 16px;font-size:20px;">Votre accès au site a été suspendu</h2>
+    <p>Votre compte sur {{ site_name }} a été désactivé. Vous ne pouvez plus vous connecter, et la session que vous aviez éventuellement ouverte a pris fin.</p>
+    <p>Votre compte n'est pas supprimé : il est mis en pause. Tout est conservé, et un administrateur du site peut le réactiver à tout moment — vous retrouverez alors votre accès tel qu'il était.</p>
+    <p style="font-size:13px;color:#666;">Si cette suspension vous surprend, parlez-en à l'équipe de votre unité.</p>
+{% endblock %}

--- a/core/View/templates/email/super_admin_deactivated.text.twig
+++ b/core/View/templates/email/super_admin_deactivated.text.twig
@@ -1,0 +1,7 @@
+Votre accès au site a été suspendu
+
+Votre compte sur {{ site_name }} a été désactivé. Vous ne pouvez plus vous connecter, et la session que vous aviez éventuellement ouverte a pris fin.
+
+Votre compte n'est pas supprimé : il est mis en pause. Tout est conservé, et un administrateur du site peut le réactiver à tout moment — vous retrouverez alors votre accès tel qu'il était.
+
+Si cette suspension vous surprend, parlez-en à l'équipe de votre unité.

--- a/core/View/templates/email/super_admin_granted.html.twig
+++ b/core/View/templates/email/super_admin_granted.html.twig
@@ -1,0 +1,14 @@
+{% extends 'email/base.html.twig' %}
+{% block content %}
+    <h2 style="margin:0 0 16px;font-size:20px;">Vous êtes administrateur du site</h2>
+    <p>{% if granted_by %}{{ granted_by }} vous a accordé{% else %}Le droit administrateur vous a été accordé{% endif %} un accès superadmin sur {{ site_name }}. Vous pouvez désormais ouvrir les pages de configuration du site.</p>
+    <p>Pour vous connecter, rendez-vous sur la page de connexion et demandez un lien magique : vous recevrez un e-mail contenant un lien à usage unique. Il n'y a pas de mot de passe à créer, et rien à accepter — ce message est une information, pas une demande.</p>
+    <p style="text-align:center;margin:24px 0;">
+        <a href="{{ login_url }}"
+           style="display:inline-block;padding:12px 32px;background-color:#0d6efd;color:#ffffff;text-decoration:none;border-radius:6px;font-weight:bold;">
+            Aller à la page de connexion
+        </a>
+    </p>
+    <p style="font-size:13px;color:#666;">Un accès administrateur ouvre toute la configuration du site, y compris les données personnelles des membres. Si vous pensez que cet accès vous a été donné par erreur, signalez-le à l'équipe de votre unité.</p>
+    <p style="font-size:12px;color:#999;word-break:break-all;">{{ login_url }}</p>
+{% endblock %}

--- a/core/View/templates/email/super_admin_granted.text.twig
+++ b/core/View/templates/email/super_admin_granted.text.twig
@@ -1,0 +1,9 @@
+Vous êtes administrateur du site
+
+{% if granted_by %}{{ granted_by }} vous a accordé{% else %}Le droit administrateur vous a été accordé{% endif %} un accès superadmin sur {{ site_name }}. Vous pouvez désormais ouvrir les pages de configuration du site.
+
+Pour vous connecter, rendez-vous sur la page de connexion et demandez un lien magique : vous recevrez un e-mail contenant un lien à usage unique. Il n'y a pas de mot de passe à créer, et rien à accepter — ce message est une information, pas une demande.
+
+{{ login_url }}
+
+Un accès administrateur ouvre toute la configuration du site, y compris les données personnelles des membres. Si vous pensez que cet accès vous a été donné par erreur, signalez-le à l'équipe de votre unité.

--- a/core/View/templates/email/super_admin_revoked.html.twig
+++ b/core/View/templates/email/super_admin_revoked.html.twig
@@ -1,0 +1,7 @@
+{% extends 'email/base.html.twig' %}
+{% block content %}
+    <h2 style="margin:0 0 16px;font-size:20px;">Votre accès administrateur a été retiré</h2>
+    <p>Le droit superadmin qui vous avait été accordé sur {{ site_name }} vous a été retiré. Les pages de configuration du site ne vous sont plus accessibles.</p>
+    <p>Votre compte, lui, est conservé : votre mot de passe, vos clés numériques et vos préférences de notification restent en place. Si vous êtes par ailleurs animateur ou chef d'unité, votre accès habituel n'est pas modifié.</p>
+    <p style="font-size:13px;color:#666;">Si ce retrait vous surprend, parlez-en à l'équipe de votre unité.</p>
+{% endblock %}

--- a/core/View/templates/email/super_admin_revoked.text.twig
+++ b/core/View/templates/email/super_admin_revoked.text.twig
@@ -1,0 +1,7 @@
+Votre accès administrateur a été retiré
+
+Le droit superadmin qui vous avait été accordé sur {{ site_name }} vous a été retiré. Les pages de configuration du site ne vous sont plus accessibles.
+
+Votre compte, lui, est conservé : votre mot de passe, vos clés numériques et vos préférences de notification restent en place. Si vous êtes par ailleurs animateur ou chef d'unité, votre accès habituel n'est pas modifié.
+
+Si ce retrait vous surprend, parlez-en à l'équipe de votre unité.

--- a/docs/help/comptes-superadmin.md
+++ b/docs/help/comptes-superadmin.md
@@ -1,7 +1,7 @@
 ---
 id: comptes-superadmin
 title: Gérer les comptes superadmin
-summary: Les comptes qui administrent le site en dehors du Desk : en ajouter un, lui retirer le droit, et pourquoi certains retraits sont refusés.
+summary: Les comptes qui administrent le site en dehors du Desk : en ajouter un, retirer le droit, suspendre un accès, et les changements que le site refuse.
 category: Configuration
 role_min: superadmin
 paths: /config/superadmins
@@ -11,51 +11,58 @@ related: config-desk, mon-compte, journal
 Un compte superadmin administre le site. C'est le seul accès qui ne
 dépend d'aucune fonction dans le Desk : il reste valable même si un
 import remplace tout le Staff d'Unité. Les animateurs et les chefs
-d'unité, eux, tiennent leur accès de leur fonction, et ne se gèrent pas
+d'unité, eux, tiennent leur accès de leur fonction et ne se gèrent pas
 depuis cette page.
 
 ## Ajouter un compte
 
 Vous n'avez besoin que d'une adresse e-mail. Si aucun compte n'existe
-pour cette adresse, il est créé. Si un compte existe déjà — un chef
-d'unité, par exemple — il reçoit simplement le droit en plus de ce
-qu'il a déjà.
+pour cette adresse, il est créé ; s'il en existe déjà un, il reçoit le
+droit en plus de ce qu'il a. Ajouter une adresse déjà superadmin ne crée
+pas de doublon.
 
 Il n'y a ni mot de passe à choisir, ni invitation à accepter. La
-personne se connecte comme tout le monde : elle demande un lien magique
-depuis la page de connexion, et le clic sur ce lien prouve à lui seul
-que l'adresse est bien la sienne.
-
-Ajouter une adresse qui est déjà superadmin ne crée pas de doublon : le
-site vous le signale et ne change rien.
+personne demande un lien magique depuis la page de connexion, et le clic
+sur ce lien prouve à lui seul que l'adresse est la sienne.
 
 ## Retirer le droit
 
 « Retirer le droit » enlève l'accès d'administration, et rien d'autre.
-Le compte reste : son mot de passe, ses clés numériques et ses
-préférences de notification sont conservés, et un chef d'unité qui
-garde par ailleurs un accès légitime le garde entièrement.
+Le compte reste : mot de passe, clés numériques et préférences de
+notification sont conservés. Un chef d'unité qui garde par ailleurs un
+accès légitime le garde entièrement.
 
-## Deux retraits que le site refuse
+## Suspendre un accès sans le retirer
 
-- **Votre propre accès.** Vous ne pouvez pas vous retirer vous-même.
-  Demandez-le à un autre compte superadmin.
-- **Le dernier accès actif.** Le site garde toujours au moins un
-  compte superadmin capable de se connecter. Ajoutez d'abord quelqu'un
-  d'autre, puis retirez.
+L'interrupteur « Actif » suspend un accès sans toucher au droit. Un
+compte désactivé ne peut plus se connecter, par aucun moyen, et la
+session qu'il avait ouverte prend fin au clic suivant.
 
-Ces deux refus sont vérifiés par le site lui-même, pas seulement par
-le bouton grisé à l'écran.
+C'est ce que vous utilisez pour un départ dont vous n'êtes pas encore
+sûr, ou le temps de tirer au clair un accès suspect. L'enregistrement
+est automatique : il n'y a pas de bouton « Enregistrer ». Le compte
+suspendu reste dans la liste, en grisé.
 
-## Ce que vous voyez dans la liste
+## Deux changements que le site refuse
 
-Pour chaque compte : son adresse, la date de création, la dernière
-connexion — « Jamais » tant que la personne ne s'est pas connectée — et
-son état.
+- **Votre propre accès.** Vous ne pouvez ni vous retirer le droit, ni
+  vous désactiver vous-même. Demandez-le à quelqu'un d'autre.
+- **Le dernier accès actif.** Le site garde toujours au moins un compte
+  superadmin capable de se connecter.
+
+Ces refus valent pour le retrait comme pour la désactivation, et c'est
+le site lui-même qui les applique.
+
+## Les personnes concernées sont prévenues
+
+Un e-mail part automatiquement quand un accès est accordé — il dit qui
+l'a accordé et comment se connecter —, quand il est retiré, et quand un
+compte est désactivé. La réactivation n'envoie rien : l'accès
+refonctionne, simplement.
 
 > Un accès superadmin ouvre toute la configuration du site, y compris
 > les données personnelles des membres. N'en accordez qu'aux personnes
 > qui en ont réellement besoin.
 
-Chaque ajout et chaque retrait est enregistré dans le journal, ainsi
-que les tentatives refusées.
+Chaque changement est enregistré dans le journal, ainsi que les
+tentatives refusées.

--- a/public/assets/js/config-super-admins.js
+++ b/public/assets/js/config-super-admins.js
@@ -17,8 +17,27 @@
 // would be no refusal at all — which is why the row the visitor cannot
 // act on is rendered without a switch server-side, rather than with a
 // disabled one this script could re-enable.
+//
+// The « Actif » control is a role="switch" checkbox. Bootstrap's switch is
+// purely visual, so the aria-checked a screen reader announces is the
+// page's own responsibility: Twig renders it once at load, nav.js's
+// delegated listener keeps it in step with real user interaction, and a
+// revert done in code here fires no 'change' event at all — which is
+// exactly the case a refusal produces. So this file syncs it itself on
+// that path, or a screen reader would keep announcing the state the
+// server just refused (same reason config-badges.js does).
 (function () {
     var api = window.ScoutMagicApi;
+
+    /**
+     * @param {HTMLInputElement} control
+     * @returns {void}
+     */
+    function syncAriaChecked(control) {
+        if (window.ScoutMagicNav && window.ScoutMagicNav.syncSwitchAriaChecked) {
+            window.ScoutMagicNav.syncSwitchAriaChecked(control);
+        }
+    }
 
     /** @type {NodeListOf<HTMLInputElement>} */
     var switches = document.querySelectorAll('.super-admin-active-toggle');
@@ -62,10 +81,10 @@
                     is_active: wanted
                 });
             }).then(function (res) {
-                if (res.data && res.data.success) {
+                if (res.data?.success) {
                     paintRow(control, wanted);
                     window.ScoutMagicToast.show(
-                        (res.data && res.data.message) || 'Modification enregistrée.',
+                        res.data?.message || 'Modification enregistrée.',
                         { variant: 'success' }
                     );
                     return;
@@ -75,11 +94,12 @@
                 // switch goes back to what it was, because the screen
                 // must not keep claiming a change that did not happen.
                 control.checked = !wanted;
+                syncAriaChecked(control);
                 paintRow(control, !wanted);
                 window.ScoutMagicToast.show(
                     res.status === 0
                         ? 'Erreur réseau.'
-                        : (res.data && res.data.error) || "Le compte n'a pas pu être modifié.",
+                        : res.data?.error || "Le compte n'a pas pu être modifié.",
                     { variant: 'error' }
                 );
             });

--- a/public/assets/js/config-super-admins.js
+++ b/public/assets/js/config-super-admins.js
@@ -1,0 +1,88 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+// Configuration > Comptes superadmin (core/View/templates/config/
+// super_admins.html.twig): the actif/inactif switch on each row.
+//
+// One independent control, so it saves on change with a toast and no
+// button (design.md §7.13) — the page says so once, next to the list,
+// because a visitor cannot tell the two saving shapes apart by looking.
+//
+// The switch does NOT decide anything. The server refuses deactivating
+// the last usable super admin, and refuses anyone deactivating
+// themselves; this file only reports what came back and puts the switch
+// where the server left it. A refusal that only greyed a control out
+// would be no refusal at all — which is why the row the visitor cannot
+// act on is rendered without a switch server-side, rather than with a
+// disabled one this script could re-enable.
+(function () {
+    var api = window.ScoutMagicApi;
+
+    /** @type {NodeListOf<HTMLInputElement>} */
+    var switches = document.querySelectorAll('.super-admin-active-toggle');
+
+    // A no-op on every other page of the site.
+    if (!switches.length) {
+        return;
+    }
+
+    /**
+     * Reflects the row's state in the badge beside the switch, so the
+     * written state and the control never disagree after a save.
+     *
+     * @param {HTMLInputElement} control
+     * @param {boolean} isActive
+     * @returns {void}
+     */
+    function paintRow(control, isActive) {
+        var row = control.closest('tr');
+        if (!row) {
+            return;
+        }
+
+        row.classList.toggle('opacity-50', !isActive);
+
+        var badge = row.querySelector('.super-admin-state-badge');
+        if (badge) {
+            badge.textContent = isActive ? 'Actif' : 'Désactivé';
+            badge.classList.toggle('text-bg-success', isActive);
+            badge.classList.toggle('text-bg-secondary', !isActive);
+        }
+    }
+
+    switches.forEach(function (control) {
+        control.addEventListener('change', function () {
+            var wanted = control.checked;
+
+            api.withDisabled(control, function () {
+                return api.postJson('/config/superadmins/toggle-active', {
+                    user_account_id: control.dataset.accountId,
+                    is_active: wanted
+                });
+            }).then(function (res) {
+                if (res.data && res.data.success) {
+                    paintRow(control, wanted);
+                    window.ScoutMagicToast.show(
+                        (res.data && res.data.message) || 'Modification enregistrée.',
+                        { variant: 'success' }
+                    );
+                    return;
+                }
+
+                // The server said no — or never answered. Either way the
+                // switch goes back to what it was, because the screen
+                // must not keep claiming a change that did not happen.
+                control.checked = !wanted;
+                paintRow(control, !wanted);
+                window.ScoutMagicToast.show(
+                    res.status === 0
+                        ? 'Erreur réseau.'
+                        : (res.data && res.data.error) || "Le compte n'a pas pu être modifié.",
+                    { variant: 'error' }
+                );
+            });
+        });
+    });
+})();

--- a/public/index.php
+++ b/public/index.php
@@ -147,6 +147,7 @@ use Core\Security\PasswordAuthMethod;
 use Core\Security\Role;
 use Core\Security\SecretManager;
 use Core\Security\SessionManager;
+use Core\Security\SuperAdminMailer;
 use Core\Security\SuperAdminService;
 use Core\Security\UserAccountRepository;
 use Core\Security\WebAuthnCredentialRepository;
@@ -1023,7 +1024,16 @@ $userAccountRepo = new UserAccountRepository($pdo, $encryptionService);
 // Configuration > Comptes superadmin (Core\Security\SuperAdminService):
 // granting/withdrawing the flag and deactivating/reactivating an account,
 // with the journal entries and the server-side refusals those changes owe.
-$superAdminService = new SuperAdminService($userAccountRepo, $journalService);
+$superAdminService = new SuperAdminService(
+    $userAccountRepo,
+    $journalService,
+    new SuperAdminMailer(
+        $mailService,
+        $twig,
+        (string) $settingService->get('site_name'),
+        (string) $settingService->get('base_url')
+    )
+);
 $mappingResolver = new MappingResolver($functionRepo, $ageBranchRepo, $importSectionRepo, $feeCategoryRepo);
 $csvParser = new DeskCsvParser();
 $unitStaffSectionService = new UnitStaffSectionService($pdo);
@@ -1963,6 +1973,7 @@ $router->addRoute('POST', '/config/badges/delete', ConfigBadgesController::class
 $router->addRoute('GET', '/config/superadmins', SuperAdminAccountsController::class, 'index', 'superadmin', ['label' => 'Comptes superadmin', 'parents' => [MenuBuilder::labelFor(MenuBuilder::MENU_CONFIGURATION)]]);
 $router->addRoute('POST', '/config/superadmins/add', SuperAdminAccountsController::class, 'add', 'superadmin');
 $router->addRoute('POST', '/config/superadmins/revoke', SuperAdminAccountsController::class, 'revoke', 'superadmin');
+$router->addRoute('POST', '/config/superadmins/toggle-active', SuperAdminAccountsController::class, 'toggleActive', 'superadmin');
 
 // RGPD configuration
 $router->addRoute('GET', '/config/rgpd', RgpdConfigController::class, 'index', 'superadmin', ['label' => 'RGPD', 'parents' => [MenuBuilder::labelFor(MenuBuilder::MENU_CONFIGURATION)]]);

--- a/tests/Core/Http/Controller/SuperAdminAccountsControllerTest.php
+++ b/tests/Core/Http/Controller/SuperAdminAccountsControllerTest.php
@@ -266,6 +266,91 @@ class SuperAdminAccountsControllerTest extends TestCase
     // CSRF
     // ---------------------------------------------------------------
 
+    public function testAToggleWithoutACsrfTokenChangesNothing(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+        AuthSession::login($me->id, $me->email, 'superadmin');
+
+        $response = $this->controller->toggleActive(
+            $this->jsonRequest(['user_account_id' => $other->id, 'is_active' => false]),
+            []
+        );
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertTrue($this->userRepo->findById($other->id)?->isActive);
+    }
+
+    // ---------------------------------------------------------------
+    // The actif/inactif switch — same two refusals, same server
+    // ---------------------------------------------------------------
+
+    public function testTheSwitchDeactivatesAndReactivates(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+        AuthSession::login($me->id, $me->email, 'superadmin');
+
+        $this->controller->toggleActive($this->jsonRequest([
+            'user_account_id' => $other->id, 'is_active' => false, '_csrf_token' => $this->csrfToken,
+        ]), []);
+        $this->assertFalse($this->userRepo->findById($other->id)?->isActive);
+
+        $this->controller->toggleActive($this->jsonRequest([
+            'user_account_id' => $other->id, 'is_active' => true, '_csrf_token' => $this->csrfToken,
+        ]), []);
+        $this->assertTrue($this->userRepo->findById($other->id)?->isActive);
+    }
+
+    public function testYouCannotDeactivateYourself(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $this->userRepo->create('autre@example.com', true);
+        AuthSession::login($me->id, $me->email, 'superadmin');
+
+        $response = $this->controller->toggleActive($this->jsonRequest([
+            'user_account_id' => $me->id, 'is_active' => false, '_csrf_token' => $this->csrfToken,
+        ]), []);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertTrue($this->userRepo->findById($me->id)?->isActive, 'still active');
+        $this->assertRefusalJournaled('self', 'super_admin_deactivate_refused');
+    }
+
+    public function testTheLastUsableSuperAdminCannotBeDeactivated(): void
+    {
+        $alone = $this->userRepo->create('seul@example.com', true);
+        AuthSession::login(999, 'quelquun@example.com', 'superadmin');
+
+        $response = $this->controller->toggleActive($this->jsonRequest([
+            'user_account_id' => $alone->id, 'is_active' => false, '_csrf_token' => $this->csrfToken,
+        ]), []);
+
+        $this->assertSame(400, $response->getStatusCode());
+        $this->assertTrue($this->userRepo->findById($alone->id)?->isActive);
+        $this->assertRefusalJournaled('last_super_admin', 'super_admin_deactivate_refused');
+    }
+
+    /**
+     * Reactivation can lock nobody out, so it is allowed even when the
+     * account is the only super admin there is — otherwise a site whose
+     * single administrator got deactivated could never be recovered from
+     * this page.
+     */
+    public function testTheOnlySuperAdminCanStillBeReactivated(): void
+    {
+        $alone = $this->userRepo->create('seul@example.com', true);
+        $this->userRepo->deactivate($alone->id);
+        AuthSession::login(999, 'quelquun@example.com', 'superadmin');
+
+        $response = $this->controller->toggleActive($this->jsonRequest([
+            'user_account_id' => $alone->id, 'is_active' => true, '_csrf_token' => $this->csrfToken,
+        ]), []);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertTrue($this->userRepo->findById($alone->id)?->isActive);
+    }
+
     public function testARevokeWithoutACsrfTokenChangesNothing(): void
     {
         $me = $this->userRepo->create('moi@example.com', true);
@@ -303,10 +388,25 @@ class SuperAdminAccountsControllerTest extends TestCase
         );
     }
 
-    private function assertRefusalJournaled(string $reason): void
+    /**
+     * @param array<string, mixed> $body
+     */
+    private function jsonRequest(array $body): Request
+    {
+        $request = $this->getMockBuilder(Request::class)
+            ->setConstructorArgs(['POST', '/config/superadmins/toggle-active', [], [], [], []])
+            ->onlyMethods(['getRawBody'])
+            ->getMock();
+
+        $request->method('getRawBody')->willReturn(json_encode($body));
+
+        return $request;
+    }
+
+    private function assertRefusalJournaled(string $reason, string $type = 'super_admin_revoke_refused'): void
     {
         $stmt = $this->pdo->query(
-            "SELECT * FROM event_log WHERE event_type = 'super_admin_revoke_refused' ORDER BY id DESC LIMIT 1"
+            "SELECT * FROM event_log WHERE event_type = '{$type}' ORDER BY id DESC LIMIT 1"
         );
         $row = $stmt !== false ? $stmt->fetch(\PDO::FETCH_ASSOC) : false;
 

--- a/tests/Core/Security/SuperAdminMailerTest.php
+++ b/tests/Core/Security/SuperAdminMailerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security;
+
+use Core\Journal\JournalRepository;
+use Core\Journal\JournalService;
+use Core\Mail\MailException;
+use Core\Mail\MailService;
+use Core\Security\EncryptionService;
+use Core\Security\SuperAdminException;
+use Core\Security\SuperAdminMailer;
+use Core\Security\SuperAdminService;
+use Core\Security\UserAccountRepository;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Twig\Environment;
+
+/**
+ * Which changes send a mail, which do not, and what happens when the mail
+ * transport is down.
+ *
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class SuperAdminMailerTest extends TestCase
+{
+    private \PDO $pdo;
+    private UserAccountRepository $userRepo;
+    private MailService&\PHPUnit\Framework\MockObject\MockObject $mailService;
+    private SuperAdminService $service;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->userRepo = new UserAccountRepository($this->pdo, $encryption);
+
+        $this->mailService = $this->createMock(MailService::class);
+
+        $twig = $this->createStub(Environment::class);
+        $twig->method('render')->willReturn('corps du message');
+
+        $this->service = new SuperAdminService(
+            $this->userRepo,
+            new JournalService(new JournalRepository($this->pdo)),
+            new SuperAdminMailer($this->mailService, $twig, 'Unité Test', 'https://unite.example')
+        );
+    }
+
+    public function testGrantingTheRightSendsTheNotification(): void
+    {
+        $actor = $this->userRepo->create('celui-qui-donne@example.com', true);
+
+        $this->mailService->expects($this->once())
+            ->method('send')
+            ->with(
+                $this->equalTo('nouveau@example.com'),
+                $this->stringContains('administrateur')
+            );
+
+        $this->service->grant('nouveau@example.com', $actor->id);
+    }
+
+    public function testWithdrawingTheRightSendsTheNotification(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+
+        $this->mailService->expects($this->once())
+            ->method('send')
+            ->with($this->equalTo('autre@example.com'));
+
+        $this->service->revoke($other->id, $me->id);
+    }
+
+    public function testDeactivatingSendsTheNotification(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+
+        $this->mailService->expects($this->once())
+            ->method('send')
+            ->with($this->equalTo('autre@example.com'), $this->stringContains('suspendu'));
+
+        $this->service->deactivate($other->id, $me->id);
+    }
+
+    /**
+     * The access simply works again — nothing to warn anybody about.
+     */
+    public function testReactivatingSendsNothing(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+        $this->userRepo->deactivate($other->id);
+
+        $this->mailService->expects($this->never())->method('send');
+
+        $this->service->reactivate($other->id, $me->id);
+    }
+
+    /**
+     * A refused operation changed nothing, so there is nothing to
+     * announce — and mailing somebody that their access was withdrawn
+     * when it was not would be worse than saying nothing.
+     */
+    public function testARefusedWithdrawalSendsNothing(): void
+    {
+        $alone = $this->userRepo->create('seul@example.com', true);
+
+        $this->mailService->expects($this->never())->method('send');
+
+        $this->expectException(SuperAdminException::class);
+        $this->service->revoke($alone->id, 999);
+    }
+
+    public function testARefusedSelfWithdrawalSendsNothing(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $this->userRepo->create('autre@example.com', true);
+
+        $this->mailService->expects($this->never())->method('send');
+
+        $this->expectException(SuperAdminException::class);
+        $this->service->revoke($me->id, $me->id);
+    }
+
+    public function testARefusedDeactivationSendsNothing(): void
+    {
+        $alone = $this->userRepo->create('seul@example.com', true);
+
+        $this->mailService->expects($this->never())->method('send');
+
+        $this->expectException(SuperAdminException::class);
+        $this->service->deactivate($alone->id, 999);
+    }
+
+    /**
+     * Adding an address that is already a super admin changes nothing, so
+     * it announces nothing either — otherwise clicking « Ajouter » twice
+     * would mail the same person twice about a right they already had.
+     */
+    public function testGrantingARightSomebodyAlreadyHasSendsNothing(): void
+    {
+        $actor = $this->userRepo->create('moi@example.com', true);
+        $this->userRepo->create('deja@example.com', true);
+
+        $this->mailService->expects($this->never())->method('send');
+
+        $this->service->grant('deja@example.com', $actor->id);
+    }
+
+    /**
+     * The change has already happened by the time the mail is attempted.
+     * A mail server being down must not undo it, or leave the caller with
+     * an exception for something that did succeed.
+     */
+    public function testAMailFailureDoesNotUndoTheChange(): void
+    {
+        $me = $this->userRepo->create('moi@example.com', true);
+        $other = $this->userRepo->create('autre@example.com', true);
+
+        $this->mailService->method('send')
+            ->willThrowException(new MailException('SMTP connect() failed'));
+
+        $this->service->revoke($other->id, $me->id);
+
+        $this->assertFalse($this->userRepo->findById($other->id)?->isSuperAdmin);
+    }
+}

--- a/tests/js/config-super-admins.test.js
+++ b/tests/js/config-super-admins.test.js
@@ -1,0 +1,161 @@
+// Isolated JavaScript unit test — jsdom-simulated DOM only. No PHP
+// server, no MySQL, no real network: fetch is mocked, and so is the toast
+// toolbox. Exercises the REAL implementation in
+// public/assets/js/config-super-admins.js (imported below, never
+// reimplemented here). That file is an IIFE that reads the DOM at import
+// time, so each test builds its fixture first and then imports the module
+// via vi.resetModules() + await import().
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PAGE = `
+    <table><tbody>
+        <tr id="row-7">
+            <td>sept@example.com</td>
+            <td>
+                <input class="form-check-input super-admin-active-toggle" type="checkbox"
+                       role="switch" id="super-admin-active-7" data-account-id="7" checked>
+                <span class="badge super-admin-state-badge text-bg-success">Actif</span>
+            </td>
+        </tr>
+        <tr id="row-9" class="opacity-50">
+            <td>neuf@example.com</td>
+            <td>
+                <input class="form-check-input super-admin-active-toggle" type="checkbox"
+                       role="switch" id="super-admin-active-9" data-account-id="9">
+                <span class="badge super-admin-state-badge text-bg-secondary">Désactivé</span>
+            </td>
+        </tr>
+    </tbody></table>`;
+
+function jsonResponse(body, status = 200) {
+    return Promise.resolve({ ok: status < 400, status, json: () => Promise.resolve(body) });
+}
+
+describe('config-super-admins.js', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        document.head.innerHTML = '<meta name="csrf-token" content="tok-123">';
+        document.body.innerHTML = PAGE;
+        global.fetch = vi.fn(() => jsonResponse({ success: true, message: 'Le compte a été désactivé.' }));
+        window.ScoutMagicToast = { show: vi.fn() };
+    });
+
+    async function boot() {
+        await import('../../public/assets/js/api.js');
+        await import('../../public/assets/js/config-super-admins.js');
+    }
+
+    const control = (id) => document.getElementById('super-admin-active-' + id);
+    const row = (id) => document.getElementById('row-' + id);
+    const badge = (id) => row(id).querySelector('.super-admin-state-badge');
+
+    function flip(id, to) {
+        control(id).checked = to;
+        control(id).dispatchEvent(new Event('change'));
+    }
+
+    const lastBody = () => JSON.parse(fetch.mock.calls[0][1].body);
+
+    describe('entry guard', () => {
+        it('does nothing at all on a page with no switches', async () => {
+            document.body.innerHTML = '<p>Une autre page</p>';
+            await expect(boot()).resolves.not.toThrow();
+            expect(fetch).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('deactivating', () => {
+        it('POSTs the account id, the new state and the CSRF token', async () => {
+            await boot();
+            flip(7, false);
+
+            await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+            expect(fetch.mock.calls[0][0]).toBe('/config/superadmins/toggle-active');
+            expect(lastBody()).toEqual({
+                user_account_id: '7', is_active: false, _csrf_token: 'tok-123',
+            });
+        });
+
+        it('confirms with a toast — there is no save button to press', async () => {
+            await boot();
+            flip(7, false);
+
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+            expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
+                'Le compte a été désactivé.',
+                { variant: 'success' }
+            );
+        });
+
+        it('greys the row and repaints the badge', async () => {
+            await boot();
+            flip(7, false);
+
+            await vi.waitFor(() => expect(badge(7).textContent).toBe('Désactivé'));
+            expect(row(7).classList.contains('opacity-50')).toBe(true);
+            expect(badge(7).classList.contains('text-bg-secondary')).toBe(true);
+            expect(badge(7).classList.contains('text-bg-success')).toBe(false);
+        });
+    });
+
+    describe('reactivating', () => {
+        it('ungreys the row and repaints the badge', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ success: true, message: 'Le compte a été réactivé.' }));
+            await boot();
+            flip(9, true);
+
+            await vi.waitFor(() => expect(badge(9).textContent).toBe('Actif'));
+            expect(row(9).classList.contains('opacity-50')).toBe(false);
+            expect(badge(9).classList.contains('text-bg-success')).toBe(true);
+        });
+    });
+
+    describe('a refusal from the server', () => {
+        // The two refusals are decided server-side. This script's whole
+        // job on a refusal is to stop the screen claiming a change that
+        // did not happen.
+        it('puts the switch back and shows the reason', async () => {
+            global.fetch = vi.fn(() => jsonResponse(
+                { success: false, error: 'Ce compte est le dernier accès superadmin actif du site.' },
+                400
+            ));
+            await boot();
+            flip(7, false);
+
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+            expect(control(7).checked).toBe(true);
+            expect(badge(7).textContent).toBe('Actif');
+            expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
+                'Ce compte est le dernier accès superadmin actif du site.',
+                { variant: 'error' }
+            );
+        });
+
+        it('falls back to a sentence of its own when the refusal carries no message', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ success: false }, 400));
+            await boot();
+            flip(7, false);
+
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+            expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
+                "Le compte n'a pas pu être modifié.",
+                { variant: 'error' }
+            );
+        });
+    });
+
+    describe('a network failure', () => {
+        it('puts the switch back and says so', async () => {
+            global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+            await boot();
+            flip(7, false);
+
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+            expect(control(7).checked).toBe(true);
+            expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
+                'Erreur réseau.',
+                { variant: 'error' }
+            );
+        });
+    });
+});

--- a/tests/js/config-super-admins.test.js
+++ b/tests/js/config-super-admins.test.js
@@ -13,7 +13,8 @@ const PAGE = `
             <td>sept@example.com</td>
             <td>
                 <input class="form-check-input super-admin-active-toggle" type="checkbox"
-                       role="switch" id="super-admin-active-7" data-account-id="7" checked>
+                       role="switch" id="super-admin-active-7" data-account-id="7" checked
+                       aria-checked="true">
                 <span class="badge super-admin-state-badge text-bg-success">Actif</span>
             </td>
         </tr>
@@ -21,7 +22,8 @@ const PAGE = `
             <td>neuf@example.com</td>
             <td>
                 <input class="form-check-input super-admin-active-toggle" type="checkbox"
-                       role="switch" id="super-admin-active-9" data-account-id="9">
+                       role="switch" id="super-admin-active-9" data-account-id="9"
+                       aria-checked="false">
                 <span class="badge super-admin-state-badge text-bg-secondary">Désactivé</span>
             </td>
         </tr>
@@ -38,6 +40,24 @@ describe('config-super-admins.js', () => {
         document.body.innerHTML = PAGE;
         global.fetch = vi.fn(() => jsonResponse({ success: true, message: 'Le compte a été désactivé.' }));
         window.ScoutMagicToast = { show: vi.fn() };
+        // nav.js, reproduced: the same delegated listener that keeps every
+        // role="switch" on the site in step on a REAL user change, plus the
+        // helper it exposes for the programmatic case that fires no event.
+        // Without the listener here the fixture's aria-checked would never
+        // move at all, and these assertions would pass no matter what the
+        // production file does.
+        const syncSwitchAriaChecked = (input) => {
+            input.setAttribute('aria-checked', input.checked ? 'true' : 'false');
+        };
+        window.ScoutMagicNav = { syncSwitchAriaChecked };
+        document.addEventListener('change', (e) => {
+            const target = e.target;
+            if (target instanceof window.HTMLInputElement
+                && target.type === 'checkbox'
+                && target.getAttribute('role') === 'switch') {
+                syncSwitchAriaChecked(target);
+            }
+        });
     });
 
     async function boot() {
@@ -49,9 +69,11 @@ describe('config-super-admins.js', () => {
     const row = (id) => document.getElementById('row-' + id);
     const badge = (id) => row(id).querySelector('.super-admin-state-badge');
 
+    // `bubbles: true` because a real user change does bubble — that is how
+    // nav.js's delegated aria-checked listener ever sees it at all.
     function flip(id, to) {
         control(id).checked = to;
-        control(id).dispatchEvent(new Event('change'));
+        control(id).dispatchEvent(new Event('change', { bubbles: true }));
     }
 
     const lastBody = () => JSON.parse(fetch.mock.calls[0][1].body);
@@ -92,6 +114,7 @@ describe('config-super-admins.js', () => {
             flip(7, false);
 
             await vi.waitFor(() => expect(badge(7).textContent).toBe('Désactivé'));
+            expect(control(7).getAttribute('aria-checked')).toBe('false');
             expect(row(7).classList.contains('opacity-50')).toBe(true);
             expect(badge(7).classList.contains('text-bg-secondary')).toBe(true);
             expect(badge(7).classList.contains('text-bg-success')).toBe(false);
@@ -125,6 +148,10 @@ describe('config-super-admins.js', () => {
             await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
             expect(control(7).checked).toBe(true);
             expect(badge(7).textContent).toBe('Actif');
+            // A revert done in code fires no 'change', so nav.js's delegated
+            // listener never runs — without an explicit sync a screen reader
+            // would keep announcing the state the server just refused.
+            expect(control(7).getAttribute('aria-checked')).toBe('true');
             expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
                 'Ce compte est le dernier accès superadmin actif du site.',
                 { variant: 'error' }
@@ -152,6 +179,7 @@ describe('config-super-admins.js', () => {
 
             await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
             expect(control(7).checked).toBe(true);
+            expect(control(7).getAttribute('aria-checked')).toBe('true');
             expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
                 'Erreur réseau.',
                 { variant: 'error' }


### PR DESCRIPTION
## Description

### The switch

An actif/inactif control per account on the Comptes superadmin page. One independent control, so it **saves on change** with a `ScoutMagicToast` and no button (design.md §7.13) — and the page says so once, next to the list, because a visitor cannot tell the two saving shapes apart by looking. A deactivated account stays in the list, greyed.

The two refusals of IT-02 apply to it, decided on the server in `SuperAdminService` exactly as the withdrawal's are: not the last usable super admin, and never yourself.

**A row the server would refuse is rendered without a switch, not with a disabled one.** A disabled control is something a script can re-enable, so the refusal has to read as a refusal rather than as a control that does not respond. `canToggleActive()` / `canRevoke()` are the render-time twins of those rules, expressed in terms of them rather than beside them; the POST re-checks regardless. « Retirer le droit » now follows the same rule as the switch, for consistency.

**Reactivation is always allowed**, including for the only super admin there is: it can lock nobody out, and refusing it would leave a site whose single administrator got deactivated with no way back from this page.

### The mails

All through `MailService::send()` — nothing sends anything directly. French, vouvoiement, multipart handled by the service.

- **Promotion** — who granted the right and how to connect (a magic link from the login page). A notification, not a request for acceptance; the mail says so.
- **Withdrawal** — the right is gone, the account is not.
- **Deactivation** — the call the chantier left open, and the answer is **yes**: a deactivation cuts the person off mid-session at the very next click, and somebody who is not told reads that as the site being broken. Reactivation deliberately sends nothing — the access simply works again, which needs no warning.

A refused operation changed nothing and so announces nothing: mailing somebody that their access was withdrawn when it was not would be worse than silence. Granting a right somebody already holds is silent too, so clicking « Ajouter » twice does not mail them twice. A mail failure never undoes the change, which has already happened by then — it is swallowed and left to `MailService`'s own journaling.

The promotion mail names the granting account's address. That is an email, not a journal entry — the journal still carries the account id and nothing else — and "who gave me this?" is the one question its recipient actually has.

### Help topic

`docs/help/comptes-superadmin.md` updated to cover the suspension, still within the §7.11 charter and under the 500-word limit.

### Tests

- the mail is sent on promotion, withdrawal and deactivation;
- nothing is sent on reactivation, on a right somebody already holds, or on any of the three refused operations;
- the change survives a mail transport failure;
- the switch's two refusals through the controller, each journaled at `level: 'security'` with no address;
- the only super admin is still reactivable;
- a toggle without a CSRF token changes nothing;
- `tests/js/config-super-admins.test.js` exercises the real script — the POST it sends, the toast, the row repaint, and the switch going back on a refusal or a network failure.

### Verification

- `vendor/bin/phpunit` — 12304 tests, 40431 assertions, no failures (re-run after rebase on `main` with IT-03 merged)
- `vendor/bin/phpunit --group=database` — 6120 tests, no failures
- `vendor/bin/phpstan analyse` — No errors
- `npm run typecheck` — 0 new findings
- `npm run test:coverage` — 94 files, 1596 tests, all passing

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] This PR changes `public/assets/js/`: a Vitest spec was added in `tests/js/config-super-admins.test.js`, and `npm run test:coverage` passes locally

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCFZiaeHecfW1shVLNKpM4)_