### PR TITLE
e2e: the pin assertion stops waiting for nothing, and its ceiling scales

### DIFF
--- a/tests/e2e/playwright.config.js
+++ b/tests/e2e/playwright.config.js
@@ -28,6 +28,12 @@
 // and fails loudly rather than silently testing something else.
 import { defineConfig, devices } from '@playwright/test';
 
+// Scaled ceilings (E2E_TIMEOUT_FACTOR, set by scripts/dast.sh). Moved out
+// of this file so specs needing a ceiling of their own use the same
+// definition instead of writing a bare number that cannot scale — see
+// support/timeouts.js for what that cost.
+import { scaled } from './support/timeouts.js';
+
 const baseURL = process.env.E2E_BASE_URL;
 
 if (!baseURL) {
@@ -35,30 +41,6 @@ if (!baseURL) {
         'E2E_BASE_URL is not set. Run the end-to-end tests via `npm run e2e` '
         + '(scripts/e2e.sh), which provisions the application instance and sets it.',
     );
-}
-
-/**
- * How much slower than a plain `npm run e2e` this run is expected to be.
- *
- * scripts/dast.sh sets E2E_TIMEOUT_FACTOR because a security scan drives
- * every request through OWASP ZAP and a TLS terminator, and serves it
- * from a single-worker PHP built-in server: the same scenarios do the
- * same work, they just take a few times longer to do it (about 12
- * minutes against about 8). Scaling the ceilings is the honest response
- * — leaving them would report the harness's own latency as application
- * failures.
- *
- * Unset, which is every other caller, this is 1 and every timeout below
- * is the value it has always been.
- *
- * @param {number} milliseconds
- * @returns {number}
- */
-function scaled(milliseconds) {
-    const raw = Number(process.env.E2E_TIMEOUT_FACTOR);
-    const factor = Number.isFinite(raw) && raw >= 1 ? raw : 1;
-
-    return Math.round(milliseconds * factor);
 }
 
 /**

--- a/tests/e2e/specs/groups-mentions.spec.js
+++ b/tests/e2e/specs/groups-mentions.spec.js
@@ -29,6 +29,7 @@ import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin, loginAsMember } from '../support/admin-login.js';
 import { openCreateGroupForm, waitForGroupsJsReady } from '../support/groups.js';
 import { pngBuffer } from '../support/png.js';
+import { scaled } from '../support/timeouts.js';
 
 const GROUP_NAME = `Intendance camp ${Date.now()}`;
 const MESSAGE_PREFIX = 'Bienvenue dans le groupe ';
@@ -37,7 +38,7 @@ const PHOTO_MESSAGE = 'La photo du terrain pour le camp.';
 test('a mention travels to a notification, a pin asks its duration, "Vu par" names the reader, and the group gallery serves the photo', async ({ page, browser }) => {
     // Two sessions, a media-processing pipeline, and the once-a-minute
     // scheduler behind it.
-    test.setTimeout(240_000);
+    test.setTimeout(scaled(240_000));
 
     /** @type {string[]} */
     const pageErrors = [];
@@ -109,9 +110,24 @@ test('a mention travels to a notification, a pin asks its duration, "Vu par" nam
     await expect(durationDialog.getByText('Pendant combien de temps ?')).toBeVisible();
     await durationDialog.getByRole('button', { name: '1 semaine' }).click();
 
-    // Pinning reloads the page; the pinned block sits above the feed.
-    await page.waitForURL(`**${groupUrl}`, { waitUntil: 'domcontentloaded' });
-    await expect(page.getByText('Désépingler')).toHaveCount(1, { timeout: 15_000 });
+    // Pinning posts the form and the server redirects back to this same
+    // page, where the card's menu now offers « Désépingler » — rendered by
+    // Twig (partials/post_card.html.twig), so it is in the document the
+    // moment the new page arrives and waits on nothing else.
+    //
+    // There used to be a `waitForURL` for that redirect here. It waited
+    // for nothing: the page is ALREADY on groupUrl when the form posts, so
+    // the pattern matched the current URL and returned at once — the
+    // assertion below then had to cover the whole POST-redirect-render on
+    // its own, from a ceiling written as a bare 15_000. Under the security
+    // scan that number is worse than none at all: everything is four times
+    // slower AND 15 s is below the 40 s the config would otherwise have
+    // given this assertion. Hence the flake, on a spec nothing had
+    // changed.
+    //
+    // The locator re-resolves across the navigation, so waiting on it is
+    // the whole wait — it just needs a ceiling that scales.
+    await expect(page.getByText('Désépingler')).toHaveCount(1, { timeout: scaled(15_000) });
 
     // ---------------------------------------------------------------
     // The other person: notified of the mention, and their visit to the
@@ -170,7 +186,7 @@ test('a mention travels to a notification, a pin asks its duration, "Vu par" nam
             return memberPage.locator('.gallery-lightbox-trigger img').count();
         }, {
             message: 'the group gallery must serve the post\'s photo once processed',
-            timeout: 120_000,
+            timeout: scaled(120_000),
             intervals: [3_000],
         }).toBeGreaterThan(0);
     } finally {

--- a/tests/e2e/support/timeouts.js
+++ b/tests/e2e/support/timeouts.js
@@ -1,0 +1,34 @@
+// The one definition of "how much slower than a plain `npm run e2e` is
+// this run expected to be".
+//
+// scripts/dast.sh sets E2E_TIMEOUT_FACTOR (DAST_TIMEOUT_FACTOR, 4 by
+// default) because a security scan drives every request through OWASP ZAP
+// and a TLS terminator, served by a single-worker PHP built-in server: the
+// same scenarios do the same work, they just take several times longer to
+// do it. playwright.config.js scales every ceiling it sets by this factor,
+// which is the honest response — leaving them would report the harness's
+// own latency as application failures.
+//
+// It lives here, rather than as a private function inside the config,
+// because a SPEC needs it too. A hard-coded `{ timeout: 15_000 }` in a
+// spec does not merely fail to scale: under the scan it becomes SMALLER
+// than the ceiling the config would have given the same assertion by
+// default (expect.timeout is scaled(10_000) — 40 s at factor 4), so
+// writing the number by hand silently tightens the deadline in exactly
+// the run that needs it loosest. That is what made
+// specs/groups-mentions.spec.js's pin assertion flaky.
+//
+// Reach for it whenever a spec needs a ceiling of its own. A bare number
+// is only ever right for a wait that is genuinely independent of how fast
+// the server answers, and there are hardly any of those.
+
+/**
+ * @param {number} milliseconds the value a plain `npm run e2e` should use
+ * @returns {number} that value, multiplied by E2E_TIMEOUT_FACTOR
+ */
+export function scaled(milliseconds) {
+    const raw = Number(process.env.E2E_TIMEOUT_FACTOR);
+    const factor = Number.isFinite(raw) && raw >= 1 ? raw : 1;
+
+    return Math.round(milliseconds * factor);
+}


### PR DESCRIPTION
## Description

`specs/groups-mentions.spec.js`'s pin step went red under `Dynamic scan (passive)` on PR #77 — a PR that changed nothing under `modules/groups/`. `getByText('Désépingler')` found 0 in 15 s. The same spec passed in `End-to-end (browser)` on the same commit, and passed again on a bare re-run of the failed job. Two faults compounded, and neither is in the application.

### 1. The wait waited for nothing

```js
await page.waitForURL(`**${groupUrl}`, { waitUntil: 'domcontentloaded' });
```

The page is **already** on `groupUrl` when the form posts — `page.goto(groupUrl)` happens ~30 lines above and nothing navigates away before the pin click. So the pattern matched the current URL and returned immediately. The assertion below it had to cover the entire POST → redirect → render on its own, starting its clock before the click had even produced a request.

### 2. Its ceiling was a bare number, and that number was *below* the default

`scripts/dast.sh` sets `E2E_TIMEOUT_FACTOR=4` (`DAST_TIMEOUT_FACTOR`), precisely because ZAP plus a TLS terminator plus a single-worker PHP built-in server makes every request several times slower. `playwright.config.js` scales every ceiling it sets by that factor — `expect.timeout` becomes `scaled(10_000)` = **40 s**.

The assertion's hand-written `{ timeout: 15_000 }` did not merely fail to scale: it was **smaller than the ceiling the assertion would have had with no timeout argument at all**. The one run needing the loosest deadline got the tightest one. `Désépingler` is server-rendered by `partials/post_card.html.twig`, so nothing but the navigation itself was ever being waited on.

### The fix

- `scaled()` moves out of `playwright.config.js` into `support/timeouts.js`, so a spec needing a ceiling of its own uses the same definition rather than writing a number that cannot scale. The config imports it; with the factor unset, behaviour is byte-identical to before.
- This spec's three ceilings now scale: the pin assertion (15 s → 60 s under the scan), the media wait, and `test.setTimeout` — which at a flat `240_000` was *exactly* the config's own scanned default, so it had quietly stopped raising anything under DAST.
- The redundant `waitForURL` is gone, with a comment recording why: the locator re-resolves across the navigation, so waiting on it **is** the wait.

No production code is touched. No test is skipped, disabled or quarantined, and no assertion is weakened — the assertion is unchanged, it is only given the deadline the suite already intended it to have.

### Verification

- `npm run e2e -- specs/groups-mentions.spec.js` — passes (59.8 s)
- `E2E_TIMEOUT_FACTOR=4 npm run e2e -- specs/groups-mentions.spec.js` — passes (1.1 m)
- `npm run e2e` — the full 41-spec suite passes (7.8 m), which is what the `playwright.config.js` change needed
- `npm run typecheck` — 0 new findings; `npm run test:coverage` — 94 files, 1596 tests; `vendor/bin/phpstan analyse` — No errors

### Not fixed here

Five other specs carry the same sub-default bare ceilings, and will flake under the scan for the same reason: `retro-board`, `finance-receipts`, `gallery-media` at `15_000`; `auth-methods`, `mass-mail`, `mass-mail-merge` at `20_000`. Same one-line change each, using the helper this PR adds — left out because this PR was asked to stabilise one spec, not six.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French (no UI in this change)
- [x] Automated tests are written/updated for this change — this change *is* to the tests
- [x] Tests pass locally (`vendor/bin/phpunit`, plus the full end-to-end suite)
- [x] PHPStan passes (`vendor/bin/phpstan analyse`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, no production JavaScript touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCFZiaeHecfW1shVLNKpM4)_