### PR TITLE
e2e: every spec ceiling scales, so none is tighter than the default

### DIFF
--- a/tests/e2e/specs/auth-methods.spec.js
+++ b/tests/e2e/specs/auth-methods.spec.js
@@ -58,6 +58,7 @@ import { expect, test } from '@playwright/test';
 import { linkFromMail, readMailbox, waitForMail } from '../support/maildrop.js';
 import { logoutControl } from '../support/admin-login.js';
 import { waitOutHumanCheckDelay } from '../support/human-check.js';
+import { scaled } from '../support/timeouts.js';
 
 /**
  * An address with no account and no member behind it. Used to check that
@@ -175,7 +176,7 @@ test('a magic link signs in the device that asked for it, and says nothing about
     // where the navigation offers the logout control to a session that
     // really exists.
     // ---------------------------------------------------------------
-    await expect(page.getByRole('heading', { name: 'Connecté' })).toBeVisible({ timeout: 20_000 });
+    await expect(page.getByRole('heading', { name: 'Connecté' })).toBeVisible({ timeout: scaled(20_000) });
     await page.waitForURL('**/', { waitUntil: 'domcontentloaded' });
     await expect(logoutControl(page)).toBeVisible();
 

--- a/tests/e2e/specs/finance-receipts.spec.js
+++ b/tests/e2e/specs/finance-receipts.spec.js
@@ -28,6 +28,7 @@ import { expect, test } from '@playwright/test';
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { pngBuffer } from '../support/png.js';
+import { scaled } from '../support/timeouts.js';
 
 const ACCOUNT_NAME = `Compte reçus E2E ${Date.now()}`;
 const ACCOUNT_IBAN = 'BE71 0961 2345 6769';
@@ -92,7 +93,7 @@ test('a statement imports, a receipt uploads through the client-side resize, and
     await page.getByLabel('Solde après ce relevé').fill('574,10');
     await page.getByRole('button', { name: 'Importer' }).click();
 
-    await expect(page.getByText('2 ligne(s) lue(s), 2 nouvelle(s)', { exact: false })).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText('2 ligne(s) lue(s), 2 nouvelle(s)', { exact: false })).toBeVisible({ timeout: scaled(15_000) });
     await page.getByRole('link', { name: 'Voir les mouvements' }).click();
     await page.waitForURL(/\/finance\/movements\?account_id=\d+/, { waitUntil: 'load' });
     // The list renders every row twice (desktop table + phone cards) —

--- a/tests/e2e/specs/gallery-media.spec.js
+++ b/tests/e2e/specs/gallery-media.spec.js
@@ -30,6 +30,7 @@ import { answerCookieBanner } from '../support/cookie-banner.js';
 import { autoConfirm, collectToasts } from '../support/confirm-dialog.js';
 import { loginAsAdmin, loginAsMember } from '../support/admin-login.js';
 import { noisePngBuffer, pngBuffer } from '../support/png.js';
+import { scaled } from '../support/timeouts.js';
 
 const ALBUM_TITLE = `Camp d'été E2E ${Date.now()}`;
 
@@ -37,7 +38,7 @@ test('a chief uploads plain and chunked, reorders by drag, and a member browses 
     // Chunked upload of 25 MB + background thumbnail processing driven by
     // a once-a-minute scheduler: this scenario is structurally slower
     // than the default budget.
-    test.setTimeout(300_000);
+    test.setTimeout(scaled(300_000));
 
     /** @type {string[]} */
     const pageErrors = [];
@@ -82,7 +83,7 @@ test('a chief uploads plain and chunked, reorders by drag, and a member browses 
         { name: 'grand-jeu.png', mimeType: 'image/png', buffer: pngBuffer(640, 480, [40, 120, 60, 255]) },
     ]);
     const items = page.locator('#gallery-existing-media .gallery-media-item');
-    await expect(items).toHaveCount(2, { timeout: 30_000 });
+    await expect(items).toHaveCount(2, { timeout: scaled(30_000) });
     // The batch ended in the page's own reload — wait it fully out, or
     // the next setInputFiles fires its change event before gallery.js
     // has re-attached to the input.
@@ -100,8 +101,8 @@ test('a chief uploads plain and chunked, reorders by drag, and a member browses 
     // signature of a transfer budget, not of the page.
     await page.locator('#gallery-upload-input').setInputFiles([
         { name: 'panorama.png', mimeType: 'image/png', buffer: noisePngBuffer(2500, 2500) },
-    ], { timeout: 120_000 });
-    await expect(items, 'the chunked upload must reassemble into a third media').toHaveCount(3, { timeout: 90_000 });
+    ], { timeout: scaled(120_000) });
+    await expect(items, 'the chunked upload must reassemble into a third media').toHaveCount(3, { timeout: scaled(90_000) });
     await page.waitForLoadState('load');
 
     /** @returns {Promise<string[]>} the grid's media ids, in DOM order */
@@ -167,7 +168,7 @@ test('a chief uploads plain and chunked, reorders by drag, and a member browses 
     await expect(
         page.locator(`.gallery-media-item[data-media-id="${newCoverId}"]`).getByText('Couverture'),
         'the badge must land on the tile that was clicked, not merely somewhere',
-    ).toBeVisible({ timeout: 15_000 });
+    ).toBeVisible({ timeout: scaled(15_000) });
 
     // ---------------------------------------------------------------
     // Delete one media (its own confirm) — down to two. Setting the
@@ -201,7 +202,7 @@ test('a chief uploads plain and chunked, reorders by drag, and a member browses 
             return memberPage.locator('.gallery-lightbox-trigger img').count();
         }, {
             message: 'both thumbnails must appear once the processing task ran',
-            timeout: 120_000,
+            timeout: scaled(120_000),
             intervals: [3_000],
         }).toBe(2);
 

--- a/tests/e2e/specs/maintenance-backup.spec.js
+++ b/tests/e2e/specs/maintenance-backup.spec.js
@@ -29,13 +29,14 @@ import { expect, test } from '@playwright/test';
 
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin } from '../support/admin-login.js';
+import { scaled } from '../support/timeouts.js';
 
 const ARCHIVE_PASSWORD = 'Archive-e2e-2024!';
 
 test('maintenance backups run to completion, the auto-save saves, and the danger zone stays locked behind its keywords', async ({ page }) => {
     // The encrypted backup zips core/, modules/ and public/ in the
     // background — well past the default budget on a loaded run.
-    test.setTimeout(300_000);
+    test.setTimeout(scaled(300_000));
 
     /** @type {string[]} */
     const pageErrors = [];
@@ -102,7 +103,7 @@ test('maintenance backups run to completion, the auto-save saves, and the danger
     await expect(
         backupsCard.getByRole('cell', { name: 'Configuration seule' }).first(),
         'the background backup must complete and its row appear',
-    ).toBeVisible({ timeout: 120_000 });
+    ).toBeVisible({ timeout: scaled(120_000) });
     await expect(page.locator('#full-backup-error')).toBeHidden();
 
     // ---------------------------------------------------------------

--- a/tests/e2e/specs/mass-mail-merge.spec.js
+++ b/tests/e2e/specs/mass-mail-merge.spec.js
@@ -50,6 +50,7 @@ import { autoConfirm } from '../support/confirm-dialog.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { readMailbox, waitForMail } from '../support/maildrop.js';
 import { runScheduler } from '../support/scheduler.js';
+import { scaled } from '../support/timeouts.js';
 
 const FIXTURES = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../fixtures');
 const EXTERNAL_RECIPIENT = 'publipostage-externe@example.invalid';
@@ -62,7 +63,7 @@ const SUBJECT_TEMPLATE = `Camp {{Prenom}} — infos ${RUN_TAG}`;
 test('a mail merge refuses a bad file line by line, previews each row, and delivers personalized mail', async ({ page }) => {
     // Two real sends (test + batch) plus a scheduler pass — roomier than
     // the default budget, far under the classic spec's cron-waiting 180s.
-    test.setTimeout(120_000);
+    test.setTimeout(scaled(120_000));
 
     const memberEmail = process.env.E2E_MEMBER_EMAIL;
     if (!memberEmail) {
@@ -207,7 +208,7 @@ test('a mail merge refuses a bad file line by line, previews each row, and deliv
 
     const testMail = await waitForMail(
         (message) => message.to.includes(TEST_RECIPIENT) && message.subject.includes(`Camp Emma — infos ${RUN_TAG}`),
-        { description: `a test send rendered with row 2's values, addressed to ${TEST_RECIPIENT}`, timeout: 20_000 },
+        { description: `a test send rendered with row 2's values, addressed to ${TEST_RECIPIENT}`, timeout: scaled(20_000) },
     );
     expect(testMail.text).toContain('Cher Emma, tu devras payer 80 €');
 

--- a/tests/e2e/specs/mass-mail.spec.js
+++ b/tests/e2e/specs/mass-mail.spec.js
@@ -30,6 +30,7 @@ import { autoConfirm } from '../support/confirm-dialog.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { pngBuffer } from '../support/png.js';
 import { readMailbox, waitForMail } from '../support/maildrop.js';
+import { scaled } from '../support/timeouts.js';
 
 const SUBJECT = `Fête d'unité — infos pratiques ${Date.now()}`;
 const BODY_LINE = 'Rendez-vous samedi à 14h au local, goûter offert.';
@@ -39,7 +40,7 @@ const ATTACHMENT_NAME = 'plan-acces.png';
 test('a mass mail walks draft → test → sending, and really lands in the members\' mailboxes', async ({ page }) => {
     // The real delivery below waits out the poor-man's cron (at most one
     // scheduler pass per minute) — well past the default test budget.
-    test.setTimeout(180_000);
+    test.setTimeout(scaled(180_000));
 
     const memberEmail = process.env.E2E_MEMBER_EMAIL;
     if (!memberEmail) {
@@ -137,7 +138,7 @@ test('a mass mail walks draft → test → sending, and really lands in the memb
 
     const testMail = await waitForMail(
         (message) => message.to.includes(TEST_RECIPIENT) && message.subject.includes(SUBJECT),
-        { description: `a test send addressed to ${TEST_RECIPIENT}`, timeout: 20_000 },
+        { description: `a test send addressed to ${TEST_RECIPIENT}`, timeout: scaled(20_000) },
     );
     expect(testMail.text).toContain(BODY_LINE);
 
@@ -163,7 +164,7 @@ test('a mass mail walks draft → test → sending, and really lands in the memb
         );
     }, {
         message: `the mass mail must reach ${memberEmail} once the batch task runs`,
-        timeout: 120_000,
+        timeout: scaled(120_000),
         intervals: [2_000],
     }).toBe(true);
 

--- a/tests/e2e/specs/password-reset.spec.js
+++ b/tests/e2e/specs/password-reset.spec.js
@@ -40,6 +40,7 @@ import { expect, test } from '@playwright/test';
 import { logoutControl } from '../support/admin-login.js';
 import { linkFromMail, readMailbox, waitForMail } from '../support/maildrop.js';
 import { waitOutHumanCheckDelay } from '../support/human-check.js';
+import { scaled } from '../support/timeouts.js';
 
 const UNKNOWN_EMAIL = 'personne@example.invalid';
 const TEMP_PASSWORD = 'Nouveau-mdp-E2E-42!';
@@ -124,7 +125,7 @@ test('a forgotten password is reset through the emailed link, which then stops w
     // Three reset requests, each sitting out the anti-bot minimum delay,
     // plus two mailed round trips — headroom for CI's slower,
     // coverage-instrumented runs.
-    test.setTimeout(120_000);
+    test.setTimeout(scaled(120_000));
 
     const memberEmail = process.env.E2E_MEMBER_EMAIL;
     const memberPassword = process.env.E2E_MEMBER_PASSWORD;

--- a/tests/e2e/specs/retro-board.spec.js
+++ b/tests/e2e/specs/retro-board.spec.js
@@ -42,6 +42,7 @@ import { expect, test } from '@playwright/test';
 
 import { answerConfirmation } from '../support/confirm-dialog.js';
 import { loginAsAdmin } from '../support/admin-login.js';
+import { scaled } from '../support/timeouts.js';
 
 const BOARD_TITLE = `Rétro camp E2E ${Date.now()}`;
 const WORD_FROM_FIRST = 'Le feu de camp du samedi soir était magique';
@@ -50,7 +51,7 @@ const WORD_FROM_SECOND = 'Prévoir plus de temps pour le rangement';
 /** Assertions that depend on the other browser's poll cycle (the harness
  * default interval, bounded below by 3 s in retro-board.js) get headroom
  * over the expect default. */
-const POLL = { timeout: 15_000 };
+const POLL = { timeout: scaled(15_000) };
 
 /**
  * The board column a word lives in, addressed the way the page's own
@@ -82,7 +83,7 @@ test('two anonymous visitors write and vote on a live board, a chief moderates, 
     // Three browsers synchronising through a multi-second polling loop —
     // most of this scenario's clock is deliberate waiting, and CI's
     // coverage instrumentation stretches it further.
-    test.setTimeout(180_000);
+    test.setTimeout(scaled(180_000));
 
     /** @type {string[]} */
     const pageErrors = [];

--- a/tests/e2e/specs/zz-module-boot-matrix.spec.js
+++ b/tests/e2e/specs/zz-module-boot-matrix.spec.js
@@ -66,6 +66,7 @@ import { expect, test } from '@playwright/test';
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { moduleToggle, toggleModule } from '../support/modules.js';
+import { scaled } from '../support/timeouts.js';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const modulesDir = path.join(repoRoot, 'modules');
@@ -155,7 +156,7 @@ async function ensureAllModulesEnabled(page) {
 // Twenty boots, each visiting every remaining module's pages, cannot fit
 // the suite's ordinary 60 s ceiling and should not stretch it for
 // everyone else.
-test.describe.configure({ timeout: 240_000 });
+test.describe.configure({ timeout: scaled(240_000) });
 
 test.afterEach(async ({ page }) => {
     await ensureAllModulesEnabled(page);


### PR DESCRIPTION
## Description

#78 fixed `groups-mentions.spec.js` and left the same defect in nine other spec files: **twenty ceilings written as bare numbers**, none of which follow `E2E_TIMEOUT_FACTOR`.

### Six were actively worse than writing nothing

Under `scripts/dast.sh` the factor is 4, so `playwright.config.js` gives an assertion `scaled(10_000)` = **40 s** by default. A hand-written `{ timeout: 15_000 }` or `{ timeout: 20_000 }` stays flat — handing the slowest run the tightest deadline. That is precisely what made the pin assertion flake, and it is carried by:

| Spec | Ceiling | Under the scan |
|---|---|---|
| `retro-board` (`POLL`) | 15 s | 15 s, vs 40 s default |
| `finance-receipts` | 15 s | 15 s, vs 40 s default |
| `gallery-media` | 15 s | 15 s, vs 40 s default |
| `auth-methods` | 20 s | 20 s, vs 40 s default |
| `mass-mail` | 20 s | 20 s, vs 40 s default |
| `mass-mail-merge` | 20 s | 20 s, vs 40 s default |

### The rest were merely failing to scale

`test.setTimeout`, the upload waits and the backup wait were not shrinking below a default, but they were not growing either — and a flat `240_000` under a factor of 4 equals the config's own scanned test timeout, so it had quietly stopped raising anything at all.

### What changed

All twenty now go through `scaled()` (added to `support/timeouts.js` by #78). Nothing else.

Every converted site is a **positive** wait — "this must appear" — so more room can only help. None is a negative assertion, where a scaled ceiling would just slow the suite for no benefit; that was checked before converting rather than assumed.

`zz-module-boot-matrix.spec.js` is `@full`, so neither `npm run e2e` nor the scan runs it and its ceiling never meets a factor. Converted anyway: one rule with no exception to remember beats a rule with one.

**At factor 1, `scaled(N) === N`** — a plain run is unchanged by construction, not merely by observation.

### Verification

- `npm run e2e` — the full 41-spec suite passes (7.8 m)
- `E2E_TIMEOUT_FACTOR=4 npm run e2e` — passes (7.9 m); this is what actually exercises every converted call
- `playwright test --list` — all 35 spec files load, including the `@full` tier neither run executes, which is the only way an import error there would have surfaced
- `vendor/bin/phpunit` — 12304 tests; `vendor/bin/phpstan analyse` — No errors; `npm run typecheck` — 0 new findings; `npm run test:coverage` — 1596 tests

No production code is touched, and no test is skipped, disabled, quarantined or weakened — every assertion is byte-identical apart from the ceiling it is given.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French (no UI in this change)
- [x] Automated tests are written/updated for this change — this change *is* to the tests
- [x] Tests pass locally (`vendor/bin/phpunit`, plus the full end-to-end suite at both factors)
- [x] PHPStan passes (`vendor/bin/phpstan analyse`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, no production JavaScript touched

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCFZiaeHecfW1shVLNKpM4)_