### PR TITLE
Hotfix — unwedge self-update, journal the real error, fix the pin dialog

### DIFF
--- a/core/Database/MigrationResult.php
+++ b/core/Database/MigrationResult.php
@@ -27,11 +27,42 @@ class MigrationResult
      *   progress page (Core\Http\Controller\SystemController) across
      *   repeated short migrate() calls.
      */
+    /**
+     * @param array<string> $executedStatements
+     * @param array<string> $warnings
+     * @param bool $backupCreated **Upgrade shim. Nothing reads it.**
+     *
+     * Removing this parameter took production down, and the mechanism is
+     * worth understanding because it will happen again otherwise. During a
+     * self-update, `Task\InstallUpdateHandler` replaces the files on disk
+     * and then runs the migration IN THE SAME PHP PROCESS. Classes already
+     * loaded are the old ones; a class not yet loaded is autoloaded from
+     * the NEW files. `MigrationResult` is only ever constructed by
+     * `MigrationRunner::migrate()`, which nothing calls on an ordinary
+     * request — so it is reliably *not* loaded when an update begins, and
+     * reliably loaded from the new files a moment later.
+     *
+     * The old runner, still in memory, calls
+     * `new MigrationResult(..., backupCreated: false)`. Against a class
+     * that no longer declared it, PHP threw
+     * `Error: Unknown named parameter $backupCreated`, the handler caught
+     * it, and the update rolled back. Every time, for good: the retry runs
+     * the same old code, so the site can never reach the version that
+     * would fix it. Six consecutive rollbacks on scoutmagic.be, all
+     * identical, all around 32 seconds.
+     *
+     * Kept as a real (if inert) property rather than a discarded argument
+     * so the compatibility promise is visible in the type rather than
+     * hidden in a signature nobody reads. Removable once no installation
+     * predates the version that reintroduced it — a decision about the
+     * field, not about the code.
+     */
     public function __construct(
         public readonly array $executedStatements,
         public readonly array $warnings,
         public readonly bool $complete = true,
-        public readonly float $progressFraction = 1.0
+        public readonly float $progressFraction = 1.0,
+        public readonly bool $backupCreated = false
     ) {
     }
 

--- a/core/Http/Controller/MaintenanceController.php
+++ b/core/Http/Controller/MaintenanceController.php
@@ -47,6 +47,9 @@ class MaintenanceController extends AbstractController
 
     private const KEEP_BACKUPS = 5;
 
+    /** How many past installations Configuration > Maintenance lists. */
+    private const UPDATE_HISTORY_SHOWN = 20;
+
     /**
      * How long the `dev` channel may go without installing anything before
      * the page says so. Long enough that an ordinary quiet stretch — a
@@ -126,7 +129,13 @@ class MaintenanceController extends AbstractController
             'update_release_notes' => (string) ($this->settingService->get('update_release_notes') ?: ''),
             'update_release_html_url' => (string) ($this->settingService->get('update_release_html_url') ?: ''),
             'update_dependencies_changed' => (bool) ((int) ($this->settingService->get('update_dependencies_changed') ?: '0')),
-            'update_history' => $this->updateHistoryRepository->findRecent(5),
+            // Twenty, not five. Five showed roughly one evening of dev-mode
+            // auto-updates: the six consecutive rollbacks that wedged
+            // production did not fit on the page at once, so the pattern
+            // — every attempt failing, always at the same point — was
+            // invisible to the person looking at it. A run of failures is
+            // the thing this table exists to make obvious.
+            'update_history' => $this->updateHistoryRepository->findRecent(self::UPDATE_HISTORY_SHOWN),
             'backups' => $this->backupRepository->findRecent(self::KEEP_BACKUPS),
             'gallery_enabled' => in_array('gallery', $this->moduleManager->getEnabledModuleIds(), true),
             'zip_encryption_supported' => $this->backupService->supportsZipEncryption(),

--- a/core/Maintenance/Task/InstallUpdateHandler.php
+++ b/core/Maintenance/Task/InstallUpdateHandler.php
@@ -485,12 +485,27 @@ class InstallUpdateHandler implements TaskHandlerInterface
                 'L\'installation de la mise à jour a échoué — la version précédente a été restaurée '
                 . 'automatiquement. Le détail est dans le journal des événements.'
             ));
+            // The technical detail goes HERE and nowhere else. The
+            // user-facing message above deliberately says only "the detail
+            // is in the event journal" (UserFacingMessage's rule: no class
+            // name, no file path, no library text on a page) — which was a
+            // promise this entry did not keep. Six production rollbacks
+            // were diagnosable only by reasoning about the diff, because
+            // the exception message existed nowhere: not in the journal,
+            // not in update_history, and not in the server log either,
+            // since the handler catches it.
             $context->journal->log(
                 'core',
                 'update_rolled_back',
                 'info',
                 'Restauration automatique effectuée après échec de mise à jour',
-                ['version_from' => $history->versionFrom, 'version_to' => $history->versionTo],
+                [
+                    'version_from' => $history->versionFrom,
+                    'version_to' => $history->versionTo,
+                    'error' => $error->getMessage(),
+                    'error_class' => $error::class,
+                    'error_at' => basename($error->getFile()) . ':' . $error->getLine(),
+                ],
                 $history->requestedBy
             );
             $notifyTitle = 'Échec de la mise à jour';

--- a/public/assets/js/groups.js
+++ b/public/assets/js/groups.js
@@ -2015,24 +2015,53 @@
         var modal = bootstrap.Modal.getOrCreateInstance(modalEl);
 
         return new Promise(function (resolve) {
-            var chosen = false;
+            var settled = false;
 
+            function cleanup() {
+                list.removeEventListener('click', onPick);
+                modalEl.removeEventListener('hidden.bs.modal', onHidden);
+            }
+
+            // Resolved on the CHOICE, never on the closing animation.
+            //
+            // This used to set a flag, call modal.hide(), and resolve from
+            // 'hidden.bs.modal' — so the form was submitted only once the
+            // fade-out had finished. Bootstrap's hide() returns early and
+            // fires nothing while the modal is still transitioning IN
+            // (`_isShown`/`_isTransitioning`), and a click can land inside
+            // that window: the dialog is already at its final position
+            // while its opacity is still animating. The promise then never
+            // settled, the form was never submitted, and the message was
+            // simply never pinned — with no error and no feedback. Rare by
+            // hand, reliable under load: it is how the end-to-end suite
+            // came to poll for « Désépingler » 122 times over a full
+            // minute and never see it.
             function onPick(event) {
                 var button = /** @type {HTMLElement|null} */ (
                     /** @type {HTMLElement} */ (event.target).closest('[data-duration]')
                 );
-                if (!button) {
+                if (!button || settled) {
                     return;
                 }
-                chosen = true;
+                settled = true;
                 field.value = button.dataset.duration || '';
+                cleanup();
+                // Best-effort tidying: the form submit below navigates
+                // away, so whether the fade-out completes is immaterial.
                 modal.hide();
+                resolve(true);
             }
 
+            // Dismissal keeps hanging off 'hidden.bs.modal', which is the
+            // right signal for it: closing without choosing must do
+            // nothing, so an event that never arrives costs nothing.
             function onHidden() {
-                list.removeEventListener('click', onPick);
-                modalEl.removeEventListener('hidden.bs.modal', onHidden);
-                resolve(chosen);
+                if (settled) {
+                    return;
+                }
+                settled = true;
+                cleanup();
+                resolve(false);
             }
 
             list.addEventListener('click', onPick);

--- a/tests/Core/Database/SelfUpdateCompatibilityTest.php
+++ b/tests/Core/Database/SelfUpdateCompatibilityTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Core\Database;
+
+use Core\Database\MigrationResult;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A self-update runs OLD code against NEW classes, and this is the test
+ * that was missing when that took production down.
+ *
+ * Task\InstallUpdateHandler replaces the files on disk and then runs the
+ * migration in the same PHP process. Classes already loaded stay old; a
+ * class not yet loaded is autoloaded from the new files. MigrationResult
+ * is only ever constructed by MigrationRunner::migrate(), which nothing
+ * calls on an ordinary request — so it is reliably not loaded when an
+ * update begins, and reliably loaded from the new files moments later.
+ *
+ * Removing a constructor parameter therefore breaks the update itself, not
+ * merely the code that reads it: the old runner's named argument hits a
+ * class that no longer declares it, PHP throws "Unknown named parameter",
+ * the handler catches it, and the update rolls back. Every retry runs the
+ * same old code, so the site can never install the version that would fix
+ * it. Six identical rollbacks on scoutmagic.be before this was understood.
+ *
+ * These are the exact call sites of the last version that shipped the old
+ * shape (dev-8e3b6c1). They must keep working until no installation
+ * predates it.
+ */
+class SelfUpdateCompatibilityTest extends TestCase
+{
+    public function testTheOldRunnersShortCircuitCallStillConstructs(): void
+    {
+        $result = new MigrationResult(executedStatements: [], warnings: [], backupCreated: false);
+
+        $this->assertTrue($result->complete);
+        $this->assertFalse($result->hasChanges());
+    }
+
+    public function testTheOldRunnersLockRefusedCallStillConstructs(): void
+    {
+        $result = new MigrationResult(
+            executedStatements: [],
+            warnings: [],
+            backupCreated: false,
+            complete: false,
+            progressFraction: 0.0
+        );
+
+        $this->assertFalse($result->complete);
+        $this->assertSame(0.0, $result->progressFraction);
+    }
+
+    /**
+     * The shim is inert: it must not change what any current field means.
+     * Kept as a real property rather than a discarded argument so the
+     * compatibility promise is visible in the type — but nothing reads it,
+     * and its presence must not disturb the values that are read.
+     */
+    public function testTheShimIsInertForCurrentCallers(): void
+    {
+        $withShim = new MigrationResult(
+            executedStatements: ['ALTER TABLE x ADD COLUMN y INT'],
+            warnings: ['w'],
+            complete: false,
+            progressFraction: 0.5,
+            backupCreated: true
+        );
+        $without = new MigrationResult(
+            executedStatements: ['ALTER TABLE x ADD COLUMN y INT'],
+            warnings: ['w'],
+            complete: false,
+            progressFraction: 0.5
+        );
+
+        $this->assertSame($without->complete, $withShim->complete);
+        $this->assertSame($without->progressFraction, $withShim->progressFraction);
+        $this->assertSame($without->executedStatements, $withShim->executedStatements);
+        $this->assertSame($without->hasChanges(), $withShim->hasChanges());
+        $this->assertFalse($without->backupCreated, 'the shim must default to a value nothing depends on');
+    }
+}

--- a/tests/Core/Http/Controller/MaintenanceControllerTest.php
+++ b/tests/Core/Http/Controller/MaintenanceControllerTest.php
@@ -208,6 +208,31 @@ class MaintenanceControllerTest extends TestCase
     }
 
     /**
+     * Five rows was roughly one evening of dev-mode auto-updates, so the
+     * six consecutive rollbacks that wedged production did not fit on the
+     * page at once — and a run of failures all stopping at the same point
+     * is exactly what this table exists to make obvious.
+     */
+    public function testTheMaintenancePageListsTwentyPastInstallationsNotFive(): void
+    {
+        for ($i = 1; $i <= 25; $i++) {
+            $id = $this->updateHistoryRepository->create('dev-from' . $i, 'dev-vers' . $i, false, null);
+            $this->updateHistoryRepository->markCompleted($id);
+        }
+
+        $body = $this->controller->index(new Request('GET', '/config/maintenance', [], [], [], []), [])->getBody();
+
+        // Counted on the "version de départ" column, which only the
+        // history table renders — the newest target version also appears
+        // in the auto-update health line above it, and counting that one
+        // would silently make 20 look like 21.
+        $this->assertStringContainsString('dev-from25', $body);
+        $this->assertStringContainsString('dev-from6', $body);
+        $this->assertStringNotContainsString('dev-from5<', $body);
+        $this->assertSame(20, substr_count($body, 'dev-from'));
+    }
+
+    /**
      * The auto-update health signal. It exists because everything else
      * about that channel stays green when it stops working — a push
      * webhook answers 200 whether it installed or ignored the push — so a

--- a/tests/Core/Maintenance/Task/InstallUpdateHandlerTest.php
+++ b/tests/Core/Maintenance/Task/InstallUpdateHandlerTest.php
@@ -11,6 +11,7 @@ use Core\Database\Connection;
 use Core\Import\MemberYearRepository;
 use Core\Journal\JournalRepository;
 use Core\Journal\JournalService;
+use Core\Maintenance\BackupService;
 use Core\Maintenance\Task\InstallUpdateHandler;
 use Core\Maintenance\UpdateException;
 use Core\Maintenance\UpdateHistoryRepository;
@@ -205,6 +206,97 @@ class InstallUpdateHandlerTest extends TestCase
      * layer of the H1 self-update integrity fix. Tested via reflection since
      * the guard throws immediately (no network), well before the retry loop.
      */
+    /**
+     * The rollback that actually worked is the one nobody could diagnose.
+     * `markRolledBack()` writes a deliberately vague user-facing string
+     * (UserFacingMessage's rule: no class name, no file path, no library
+     * text on a page) promising the detail is in the event journal — and
+     * the journal entry did not carry it. Six identical production
+     * rollbacks on scoutmagic.be were readable only by reasoning about the
+     * diff, because `Error: Unknown named parameter $backupCreated`
+     * existed in no record at all: not the journal, not update_history,
+     * and not the server log, since the handler catches the throwable.
+     *
+     * So this asserts the promise rather than the wording: the message,
+     * the class and the throw site are all in the entry, and none of them
+     * leaks into what the page shows.
+     */
+    public function testASuccessfulRollbackJournalsTheErrorThatCausedIt(): void
+    {
+        $historyId = $this->updateHistoryRepository->create('dev-8e3b6c1', 'dev-63afd86', false, $this->userId);
+        $history = $this->updateHistoryRepository->findById($historyId);
+        $this->assertNotNull($history);
+
+        // The restore itself must SUCCEED: the entry under test is the one
+        // written after it, and a failing restore takes the other branch.
+        $backupService = $this->createMock(BackupService::class);
+        $backupService->expects($this->once())->method('restoreDatabase');
+        $backupService->expects($this->once())->method('restoreFiles');
+
+        $error = new \Error('Unknown named parameter $backupCreated');
+
+        $method = new \ReflectionMethod(InstallUpdateHandler::class, 'rollbackToSafetyBackup');
+        $method->setAccessible(true);
+        $method->invoke(
+            $this->handler,
+            $historyId,
+            $history,
+            $this->context,
+            $this->updateHistoryRepository,
+            $backupService,
+            $this->storagePath . '/dump.sql',
+            $this->storagePath . '/files.zip',
+            $error
+        );
+
+        $row = $this->pdo->query(
+            "SELECT context FROM event_log WHERE event_type = 'update_rolled_back' ORDER BY id DESC LIMIT 1"
+        )->fetch(\PDO::FETCH_ASSOC);
+        $this->assertNotFalse($row, 'a completed rollback must be journaled');
+
+        $context = json_decode((string) $row['context'], true);
+        $this->assertSame('dev-8e3b6c1', $context['version_from']);
+        $this->assertSame('dev-63afd86', $context['version_to']);
+        $this->assertSame('Unknown named parameter $backupCreated', $context['error']);
+        $this->assertSame('Error', $context['error_class']);
+        $this->assertStringStartsWith('InstallUpdateHandlerTest.php:', $context['error_at']);
+    }
+
+    /**
+     * The counterpart, and the reason the detail goes in the journal and
+     * not in `markRolledBack()`: that string is rendered as a title=""
+     * tooltip on Configuration > Maintenance, so it must stay free of the
+     * exception's own text.
+     */
+    public function testTheDetailStaysOutOfWhatTheMaintenancePageShows(): void
+    {
+        $historyId = $this->updateHistoryRepository->create('dev-8e3b6c1', 'dev-63afd86', false, $this->userId);
+        $history = $this->updateHistoryRepository->findById($historyId);
+        $this->assertNotNull($history);
+
+        $backupService = $this->createMock(BackupService::class);
+
+        $method = new \ReflectionMethod(InstallUpdateHandler::class, 'rollbackToSafetyBackup');
+        $method->setAccessible(true);
+        $method->invoke(
+            $this->handler,
+            $historyId,
+            $history,
+            $this->context,
+            $this->updateHistoryRepository,
+            $backupService,
+            $this->storagePath . '/dump.sql',
+            $this->storagePath . '/files.zip',
+            new \Error('Unknown named parameter $backupCreated')
+        );
+
+        $after = $this->updateHistoryRepository->findById($historyId);
+        $this->assertNotNull($after);
+        $this->assertSame('rolled_back', $after->status);
+        $this->assertStringNotContainsString('backupCreated', (string) $after->errorMessage);
+        $this->assertStringContainsString('journal des événements', (string) $after->errorMessage);
+    }
+
     public function testDownloadRefusesANonGitHubUrlBeforeFetching(): void
     {
         $method = new \ReflectionMethod(InstallUpdateHandler::class, 'download');

--- a/tests/e2e/specs/groups-mentions.spec.js
+++ b/tests/e2e/specs/groups-mentions.spec.js
@@ -115,15 +115,17 @@ test('a mention travels to a notification, a pin asks its duration, "Vu par" nam
     // Twig (partials/post_card.html.twig), so it is in the document the
     // moment the new page arrives and waits on nothing else.
     //
-    // There used to be a `waitForURL` for that redirect here. It waited
-    // for nothing: the page is ALREADY on groupUrl when the form posts, so
-    // the pattern matched the current URL and returned at once — the
-    // assertion below then had to cover the whole POST-redirect-render on
-    // its own, from a ceiling written as a bare 15_000. Under the security
-    // scan that number is worse than none at all: everything is four times
-    // slower AND 15 s is below the 40 s the config would otherwise have
-    // given this assertion. Hence the flake, on a spec nothing had
-    // changed.
+    // This assertion was flaky under the security scan, and the ceiling
+    // was NOT the reason — it failed with 60 s to spend, polling 122 times
+    // and finding nothing. The cause was in the application: the duration
+    // dialog resolved its promise from Bootstrap's 'hidden.bs.modal', so
+    // the form was submitted only after the fade-out finished, and
+    // Bootstrap's hide() does nothing at all when the modal is still
+    // transitioning IN. A click landing in that window left the promise
+    // unsettled forever and the message simply never pinned — for a quick
+    // human on a loaded server exactly as for this test. Fixed in
+    // public/assets/js/groups.js (askPinDuration now resolves on the
+    // choice); tests/js/groups-pin-duration.test.js pins the behaviour.
     //
     // The locator re-resolves across the navigation, so waiting on it is
     // the whole wait — it just needs a ceiling that scales.

--- a/tests/js/groups-pin-duration.test.js
+++ b/tests/js/groups-pin-duration.test.js
@@ -126,4 +126,33 @@ describe('pinning a message: the duration dialog', () => {
 
         expect(form.submit).toHaveBeenCalledTimes(1);
     });
+
+    /**
+     * The list is a click target in its own right — its padding, and the
+     * gaps between the buttons. A click that missed must be ignored, not
+     * read as a choice with an empty duration: `duration=""` is what the
+     * server takes to mean "pin indefinitely", so a mis-click landing one
+     * pixel off would silently pin forever.
+     */
+    it('ignores a click that landed on the list but not on a duration', async () => {
+        stubBootstrapWithADeadHide();
+        const form = buildPinDom();
+        await loadGroups();
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await Promise.resolve();
+
+        document.querySelector('#groups-detail-modal-body .list-group').click();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(form.submit).not.toHaveBeenCalled();
+
+        // And the dialog is still live: the real choice that follows works.
+        document.querySelector('#groups-detail-modal-body [data-duration="week"]').click();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(form.submit).toHaveBeenCalledTimes(1);
+    });
 });

--- a/tests/js/groups-pin-duration.test.js
+++ b/tests/js/groups-pin-duration.test.js
@@ -1,0 +1,129 @@
+// Isolated JavaScript unit test — jsdom only, exercising the REAL
+// public/assets/js/groups.js (imported below, never reimplemented).
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function loadGroups() {
+    vi.resetModules();
+    await import('../../public/assets/js/groups.js');
+}
+
+/**
+ * A Bootstrap modal stand-in whose hide() does NOTHING and fires no
+ * 'hidden.bs.modal' — which is not a caricature but exactly what Bootstrap
+ * 5 does when hide() is called while the modal is still transitioning in:
+ * `if (!this._isShown || this._isTransitioning) { return; }`.
+ *
+ * A click can land in that window. Playwright waits for an element to be
+ * stable in POSITION, and a fading modal is already at its final position
+ * while its opacity is still animating; a quick human on a loaded server
+ * hits the same gap.
+ */
+function stubBootstrapWithADeadHide() {
+    globalThis.bootstrap = {
+        Modal: {
+            getOrCreateInstance: () => ({
+                show: () => {},
+                hide: () => {},
+            }),
+        },
+    };
+}
+
+function buildPinDom() {
+    document.body.innerHTML = `
+        <div id="groups-feed"></div>
+        <form class="groups-pin-form" action="/groups/1/posts/2/pin" method="post">
+            <input type="hidden" name="duration" value="">
+            <button type="submit">Épingler</button>
+        </form>
+        <div id="groups-detail-modal">
+            <h2 id="groups-detail-modal-title"></h2>
+            <div id="groups-detail-modal-body"></div>
+        </div>
+    `;
+
+    const form = /** @type {HTMLFormElement} */ (document.querySelector('.groups-pin-form'));
+    // jsdom does not implement form.submit(); it is also precisely the
+    // effect under test, so it is the thing to observe.
+    form.submit = vi.fn();
+
+    return form;
+}
+
+describe('pinning a message: the duration dialog', () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+        delete globalThis.bootstrap;
+        document.body.innerHTML = '';
+    });
+
+    /**
+     * The regression. The dialog used to resolve its promise from
+     * 'hidden.bs.modal', so the form was submitted only once the fade-out
+     * had finished — and when hide() was a no-op because the modal was
+     * still coming in, the promise never settled at all. The message was
+     * simply never pinned, with no error and no feedback anywhere.
+     */
+    it('submits the form on the choice, even when the modal never reports being hidden', async () => {
+        stubBootstrapWithADeadHide();
+        const form = buildPinDom();
+        await loadGroups();
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await Promise.resolve();
+
+        const weekButton = [...document.querySelectorAll('#groups-detail-modal-body [data-duration]')]
+            .find((b) => b.dataset.duration === 'week');
+        expect(weekButton, 'the dialog must offer a one-week choice').toBeTruthy();
+
+        weekButton.click();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(form.submit).toHaveBeenCalledTimes(1);
+        expect(form.querySelector('input[name="duration"]').value).toBe('week');
+    });
+
+    /**
+     * The counterpart: closing the dialog without choosing must submit
+     * nothing. That path still hangs off 'hidden.bs.modal', which is the
+     * right signal for it — an event that never arrives simply leaves the
+     * message unpinned, which is what dismissing means.
+     */
+    it('submits nothing when the dialog is dismissed without a choice', async () => {
+        stubBootstrapWithADeadHide();
+        const form = buildPinDom();
+        await loadGroups();
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await Promise.resolve();
+
+        document.getElementById('groups-detail-modal')
+            .dispatchEvent(new Event('hidden.bs.modal', { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(form.submit).not.toHaveBeenCalled();
+    });
+
+    /**
+     * And a late 'hidden.bs.modal' arriving after a choice must not
+     * resolve the promise a second time — the form is submitted once.
+     */
+    it('does not submit twice when the modal reports being hidden after a choice', async () => {
+        stubBootstrapWithADeadHide();
+        const form = buildPinDom();
+        await loadGroups();
+
+        form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+        await Promise.resolve();
+
+        document.querySelector('#groups-detail-modal-body [data-duration="week"]').click();
+        document.getElementById('groups-detail-modal')
+            .dispatchEvent(new Event('hidden.bs.modal', { bubbles: true }));
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(form.submit).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Description

**Production has been unable to install any version since `dev-fff8638`.** Six consecutive rollbacks, all identical, all ~32 s; the site is still on `dev-8e3b6c1`. The cause is mine, from IT-01.

### Why it happened

During a self-update, `InstallUpdateHandler` replaces the files on disk and then runs the migration **in the same PHP process**. Classes already loaded are the old ones; a class not yet loaded is autoloaded from the **new** files. `MigrationResult` is only ever constructed by `MigrationRunner::migrate()`, which nothing calls on an ordinary request — so it is reliably *not* loaded when an update begins, and reliably loaded from the new files a moment later.

The old runner, still in memory, calls `new MigrationResult(..., backupCreated: false)`. Against a class that no longer declared it, PHP throws `Error: Unknown named parameter $backupCreated`, the handler catches it, and the update rolls back. **Self-locking**: every retry runs the same old code, so the site can never reach the version that would fix it.

`MigrationResult` carries the parameter again, inert — as a property rather than a discarded argument, so the compatibility promise is visible in the type instead of hidden in a signature nobody reads. Removable once no installation predates this version, which is a decision about the field rather than about the code. `tests/Core/Database/SelfUpdateCompatibilityTest` pins the exact call sites of `dev-8e3b6c1`.

### Why it was invisible

The rollback path journaled the version numbers and **dropped the exception**. `update_history.error_message` says "le détail est dans le journal des événements" — a promise nothing kept: the message existed nowhere. Not in the journal, not in `update_history`, and not in the server log either, since the handler catches it (`errors-resume.txt` in the support package: "Aucune erreur fatale ni exception non rattrapée"). Six rollbacks were diagnosable only by reasoning about the diff.

The entry now carries `error`, `error_class` and `error_at` (file:line). The other failure paths already did this; only the rollback did not.

### Update history: twenty rows, not five

Five was about one evening of dev-mode auto-updates, so the run of six failures did not fit on the page at once — and a run of failures all stopping at the same point is precisely what that table exists to make obvious.

### And the pin dialog — not a flake after all

`askPinDuration()` resolved its promise from Bootstrap's `hidden.bs.modal`, so the form was submitted only once the fade-out had finished. Bootstrap 5's `hide()` returns early and fires nothing while the modal is still transitioning *in* (`if (!this._isShown || this._isTransitioning) return`). A click landing in that window left the promise unsettled **forever**: the message was never pinned, with no error and no feedback anywhere.

Rare by hand, reliable under load — which is why the E2E suite polled for « Désépingler » **122 times over a full minute** and never saw it, with 60 s of ceiling to spend. The ceiling was never the problem, and raising it only made the failure slower. This is a real user-facing bug, not a test artefact: a quick click on a loaded server silently does nothing.

It now resolves on the choice; dismissal still hangs off `hidden.bs.modal`, which is the right signal for a path whose correct outcome is to do nothing. `tests/js/groups-pin-duration.test.js` covers all three cases and was verified to fail (2 of 3) against the old logic.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 12346 tests, 40550 assertions, no errors or failures)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — no errors)
- [x] `public/assets/js/` behavior changed: Vitest spec added (`npx vitest run` — 95 files, 1599 tests, all passing), `npm run typecheck` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAMnqgELwBdHRxVnbqe5kv)_