### PR TITLE
Remettre main au vert — le puits innerHTML et la relance qui ignorait son plafond

### DIFF
--- a/core/Scheduler/SchedulerContinuation.php
+++ b/core/Scheduler/SchedulerContinuation.php
@@ -200,6 +200,26 @@ final class SchedulerContinuation
      */
     public function kick(): bool
     {
+        // A ceiling of zero means chaining is OFF on this installation,
+        // and a kick is a chain of one — so it has to honour it like any
+        // other hop. It did not, and that is a defect this comment exists
+        // to stop coming back: kick() went straight to emitHop(), which
+        // only ever checked base_url, while the ceiling lives in
+        // shouldHop(). An instance that had explicitly switched chaining
+        // off still got a self-request.
+        //
+        // Where that bit: the end-to-end and dynamic-scan harnesses set it
+        // to zero precisely because `php -S` serves one request per worker
+        // and defaults to one worker (scripts/e2e-support.php says so at
+        // length). The kick queued behind the request that emitted it and
+        // then held the only worker for a whole slice, and a browser step
+        // waiting on a navigation timed out — intermittently, and only
+        // under the scan, where every request already carries proxy
+        // latency.
+        if ($this->maxHops() < 1) {
+            return false;
+        }
+
         $this->beginChain();
 
         return $this->emitHop();

--- a/modules/groups/src/Controller/GroupController.php
+++ b/modules/groups/src/Controller/GroupController.php
@@ -437,16 +437,19 @@ class GroupController extends AbstractController
 
         $result = [];
         foreach ($this->postMediaService->mediaByIds($group, $ids) as $media) {
-            $resolved = in_array($media->processingStatus, ['done', 'failed'], true);
+            // Data, never markup. This used to return the rendered
+            // `media_thumb.html.twig` partial, which the client dropped
+            // into `innerHTML` — and that is a DOM-XSS sink whatever is
+            // flowing through it today. The partial happens to contain no
+            // user data at all (an integer id and an enum), so nothing was
+            // exploitable; the sink was, and it would have become a real
+            // one the first time somebody added a caption to that
+            // template. groups.js builds the cell from these three fields
+            // with createElement instead.
             $result[] = [
                 'id' => $media->id,
                 'status' => $media->processingStatus,
-                // Only rendered once resolved: while still pending/
-                // processing, the client already shows the spinner
-                // media_thumb.html.twig would render right back anyway.
-                'html' => $resolved
-                    ? $this->twig->render('@groups/partials/media_thumb.html.twig', ['media' => $media])
-                    : null,
+                'media_type' => $media->mediaType,
             ];
         }
 

--- a/public/assets/js/groups.js
+++ b/public/assets/js/groups.js
@@ -1020,6 +1020,66 @@
         )).map(function (el) { return /** @type {HTMLElement} */ (el).dataset.mediaId; });
     }
 
+    /**
+     * Fill a media cell that has just finished processing, from DATA.
+     *
+     * This used to be `cell.innerHTML = item.html`, with the server
+     * sending the rendered `media_thumb.html.twig`. Nothing user-supplied
+     * ever travelled through it — that partial holds an integer id and an
+     * enum — but an innerHTML sink fed by a fetch response is a DOM-XSS
+     * sink regardless of what flows through it today, and it would have
+     * become a real one the first time somebody put a caption in that
+     * template. The server now sends {id, status, media_type} and nothing
+     * here ever parses HTML.
+     *
+     * Deliberately mirrors media_thumb.html.twig's `done`/`failed`
+     * branches, which stay the source for the FIRST render — the two are
+     * only ever seen one after the other on the same cell, so a
+     * divergence would show up immediately as a thumbnail that changes
+     * appearance the moment it loads.
+     *
+     * @param {HTMLElement} cell
+     * @param {{id: number|string, status: string, media_type?: string}} item
+     */
+    function renderResolvedMedia(cell, item) {
+        cell.textContent = '';
+
+        if (item.status === 'failed') {
+            var failed = document.createElement('span');
+            failed.className = 'd-flex align-items-center justify-content-center h-100 text-danger';
+            failed.title = 'Échec du traitement de ce média';
+            var warning = document.createElement('i');
+            warning.className = 'bi bi-exclamation-triangle';
+            warning.setAttribute('aria-hidden', 'true');
+            failed.appendChild(warning);
+            cell.appendChild(failed);
+
+            return;
+        }
+
+        var image = document.createElement('img');
+        // Built from the id the server just sent back, never from a URL
+        // it sent: a path this file assembles cannot be pointed elsewhere.
+        image.src = '/gallery/media/' + encodeURIComponent(String(item.id)) + '/thumb';
+        image.alt = '';
+        image.className = 'w-100 h-100';
+        image.style.objectFit = 'cover';
+        image.loading = 'lazy';
+        cell.appendChild(image);
+
+        if (item.media_type === 'video') {
+            var badge = document.createElement('span');
+            badge.className = 'position-absolute top-50 start-50 translate-middle text-white';
+            badge.style.fontSize = '1.75rem';
+            badge.style.textShadow = '0 0 6px rgba(0,0,0,.6)';
+            var play = document.createElement('i');
+            play.className = 'bi bi-play-circle-fill';
+            play.setAttribute('aria-hidden', 'true');
+            badge.appendChild(play);
+            cell.appendChild(badge);
+        }
+    }
+
     function pollMediaStatus() {
         var feed = document.getElementById('groups-feed');
         var ids = pendingMediaIds();
@@ -1034,13 +1094,13 @@
             return response.ok ? response.json() : [];
         }).then(function (items) {
             items.forEach(function (item) {
-                if (item.status === 'pending' || item.status === 'processing' || typeof item.html !== 'string') {
+                if (item.status === 'pending' || item.status === 'processing') {
                     return;
                 }
                 var cell = /** @type {HTMLElement} */ (document.querySelector('[data-media-id="' + item.id + '"]'));
                 if (cell) {
                     cell.dataset.status = item.status;
-                    cell.innerHTML = item.html;
+                    renderResolvedMedia(cell, item);
                 }
             });
         }).catch(function () {

--- a/tests/Core/Scheduler/SchedulerContinuationTest.php
+++ b/tests/Core/Scheduler/SchedulerContinuationTest.php
@@ -383,6 +383,62 @@ class SchedulerContinuationTest extends TestCase
     }
 
     /**
+     * A ceiling of zero means chaining is OFF here, and a kick is a chain
+     * of one — so it has to honour it like any other hop.
+     *
+     * It did not, and the omission had a precise cost: kick() went
+     * straight to emitHop(), which only checks base_url, while the ceiling
+     * lives in shouldHop(). The end-to-end and dynamic-scan harnesses set
+     * the ceiling to zero because `php -S` serves one request per worker
+     * and defaults to one worker, so the kick queued behind the request
+     * that emitted it and held the only worker for a whole slice — a
+     * browser step timed out waiting on a navigation, intermittently, and
+     * only under the scan where every request already carries proxy
+     * latency.
+     */
+    public function testKickHonoursACeilingOfZeroLikeAnyOtherHop(): void
+    {
+        // A socket that really is listening, so a kick that ignored the
+        // ceiling would succeed — a dead port would make this pass for
+        // the wrong reason, which is exactly how the first version of
+        // this test managed to pass without the fix.
+        $server = @stream_socket_server('tcp://127.0.0.1:0', $errno, $errstr);
+        $this->assertNotFalse($server, "could not open a local listening socket: {$errstr}");
+        $name = (string) stream_socket_get_name($server, false);
+        $port = (int) substr($name, (int) strrpos($name, ':') + 1);
+
+        $this->settings->register('base_url', '', 'text', 'base', 'test', null, null, null, false, 900);
+        $this->settings->setInternal('base_url', 'http://127.0.0.1:' . $port);
+        $this->settings->setInternal(SchedulerContinuation::MAX_HOPS_SETTING, '0');
+        $this->settings->setInternal(SchedulerContinuation::HOPS_SETTING, '7');
+
+        try {
+            $this->assertFalse($this->continuation->kick(), 'chaining is off: nothing may be emitted');
+            $this->assertSame(7, $this->continuation->hopCount(), 'and no chain may be begun either');
+        } finally {
+            fclose($server);
+        }
+    }
+
+    /**
+     * The counterpart: an unset ceiling must not be read as zero, or a
+     * fresh installation would silently never kick — and the migration an
+     * update just scheduled would wait for the next visitor, which is
+     * exactly what the kick exists to prevent.
+     */
+    public function testKickStillFiresWhenTheCeilingIsSimplyUnset(): void
+    {
+        $this->pdo->exec("DELETE FROM settings WHERE setting_key = '" . SchedulerContinuation::MAX_HOPS_SETTING . "'");
+
+        // No base_url, so nothing is written either way — what is asserted
+        // is that it got PAST the ceiling and began a chain.
+        $this->settings->setInternal(SchedulerContinuation::HOPS_SETTING, '9');
+        $this->continuation->kick();
+
+        $this->assertSame(0, $this->continuation->hopCount(), 'a fresh chain was begun');
+    }
+
+    /**
      * And it degrades exactly like a hop. No base_url means no request to
      * write — which must be reported, not thrown: the update that calls
      * this has already succeeded, and the migration is queued either way.

--- a/tests/Modules/Groups/Controller/GroupControllerTest.php
+++ b/tests/Modules/Groups/Controller/GroupControllerTest.php
@@ -1247,7 +1247,7 @@ class GroupControllerTest extends TestCase
         $this->assertSame(404, $response->getStatusCode());
     }
 
-    public function testMediaStatusReportsPendingMediaWithNoHtml(): void
+    public function testMediaStatusReportsPendingMediaAsData(): void
     {
         $creator = GroupsTestHelper::createMember($this->pdo, 'CGM2');
         $groupId = $this->groupService->createSectionGroup('Louveteaux', $this->sectionId, $this->currentYearId, $creator, 1);
@@ -1266,10 +1266,19 @@ class GroupControllerTest extends TestCase
 
         $this->assertSame(200, $response->getStatusCode());
         $body = json_decode($response->getBody(), true);
-        $this->assertSame([['id' => 1, 'status' => 'processing', 'html' => null]], $body);
+        $this->assertSame([['id' => 1, 'status' => 'processing', 'media_type' => 'photo']], $body);
     }
 
-    public function testMediaStatusRendersTheThumbnailFragmentOnceDone(): void
+    /**
+     * Data, never markup. The endpoint used to return the rendered
+     * `media_thumb.html.twig` partial, which groups.js dropped into
+     * `innerHTML` — a DOM-XSS sink whatever flows through it, rated a
+     * blocker by SonarQube and the reason main's quality gate was red.
+     * Nothing user-supplied was travelling through it, and that was
+     * exactly the fragile part: the day a caption joined that template,
+     * it would have become a real one.
+     */
+    public function testMediaStatusReturnsDataAndNeverMarkup(): void
     {
         $creator = GroupsTestHelper::createMember($this->pdo, 'CGM3');
         $groupId = $this->groupService->createSectionGroup('Louveteaux', $this->sectionId, $this->currentYearId, $creator, 1);
@@ -1288,10 +1297,23 @@ class GroupControllerTest extends TestCase
         );
 
         $body = json_decode($response->getBody(), true);
-        $this->assertSame('done', $body[0]['status']);
-        $this->assertStringContainsString('/gallery/media/1/thumb', $body[0]['html']);
-        $this->assertSame('failed', $body[1]['status']);
-        $this->assertStringContainsString('Échec du traitement', $body[1]['html']);
+        $this->assertSame(
+            [
+                ['id' => 1, 'status' => 'done', 'media_type' => 'photo'],
+                ['id' => 2, 'status' => 'failed', 'media_type' => 'photo'],
+            ],
+            $body
+        );
+
+        // No key carries markup, on any row — asserted over the whole
+        // response rather than over the keys this test happens to know,
+        // so a field added later cannot quietly reopen the sink.
+        foreach ($body as $row) {
+            foreach ($row as $key => $value) {
+                $this->assertArrayNotHasKey('html', $row);
+                $this->assertStringNotContainsString('<', (string) $value, "'{$key}' must not carry markup");
+            }
+        }
     }
 
     public function testMediaStatusSilentlyOmitsAnIdNotInTheGroupsAlbum(): void

--- a/tests/js/groups-feed.test.js
+++ b/tests/js/groups-feed.test.js
@@ -208,7 +208,7 @@ describe('groups.js dynamic reactions, in-place pagination and inline edit toggl
                 })
                 .mockResolvedValueOnce({
                     ok: true,
-                    json: () => Promise.resolve([{ id: 42, status: 'done', html: '<img alt="" src="/gallery/media/42/thumb">' }])
+                    json: () => Promise.resolve([{ id: 42, status: 'done', media_type: 'photo' }])
                 });
 
             document.querySelector('.groups-load-more').click();
@@ -227,7 +227,128 @@ describe('groups.js dynamic reactions, in-place pagination and inline edit toggl
             );
             var cell = document.querySelector('[data-media-id="42"]');
             expect(cell.dataset.status).toBe('done');
-            expect(cell.innerHTML).toContain('/gallery/media/42/thumb');
+            // Built from the id, not from any markup the server sent:
+            // the media-status endpoint returns data only.
+            var thumb = cell.querySelector('img');
+            expect(thumb).not.toBeNull();
+            expect(thumb.getAttribute('src')).toBe('/gallery/media/42/thumb');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    /**
+     * The media-status poll used to drop server-rendered markup into
+     * `innerHTML`. Nothing user-supplied ever travelled through it — the
+     * partial holds an integer id and an enum — but the sink was real
+     * whatever flowed through it, and it would have become exploitable
+     * the first time somebody put a caption in that template. SonarQube
+     * rated it a blocker, and main's quality gate had been red on it.
+     *
+     * The endpoint returns data now. This asserts the property that
+     * matters: markup arriving in the response is never interpreted.
+     */
+    it('never interprets markup sent by the media-status endpoint', async () => {
+        vi.useFakeTimers();
+        try {
+            document.body.innerHTML = `
+                <div id="groups-feed" data-group-id="7">
+                    <div class="groups-load-more-wrapper">
+                        <button class="groups-load-more" data-url="/groups/7/feed?cursor=abc">Charger plus</button>
+                    </div>
+                </div>
+            `;
+            global.fetch = vi.fn()
+                .mockResolvedValueOnce({
+                    ok: true,
+                    text: () => Promise.resolve('<a class="groups-media-cell" data-media-id="42" data-status="pending"></a>')
+                })
+                .mockResolvedValue({
+                    ok: true,
+                    json: () => Promise.resolve([{
+                        id: 42,
+                        status: 'done',
+                        media_type: 'photo',
+                        // A server that started sending markup again, or
+                        // one that had been compromised, must change
+                        // nothing here.
+                        html: '<img src=x onerror="window.__xss = true">'
+                    }])
+                });
+
+            document.querySelector('.groups-load-more').click();
+            await vi.advanceTimersByTimeAsync(0);
+            await vi.advanceTimersByTimeAsync(2000);
+
+            var cell = document.querySelector('[data-media-id="42"]');
+            expect(cell.querySelector('img').getAttribute('src')).toBe('/gallery/media/42/thumb');
+            expect(cell.innerHTML).not.toContain('onerror');
+            expect(window.__xss).toBeUndefined();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('shows the failure notice rather than a broken thumbnail when processing failed', async () => {
+        vi.useFakeTimers();
+        try {
+            document.body.innerHTML = `
+                <div id="groups-feed" data-group-id="7">
+                    <div class="groups-load-more-wrapper">
+                        <button class="groups-load-more" data-url="/groups/7/feed?cursor=abc">Charger plus</button>
+                    </div>
+                </div>
+            `;
+            global.fetch = vi.fn()
+                .mockResolvedValueOnce({
+                    ok: true,
+                    text: () => Promise.resolve('<a class="groups-media-cell" data-media-id="9" data-status="processing"></a>')
+                })
+                .mockResolvedValue({
+                    ok: true,
+                    json: () => Promise.resolve([{ id: 9, status: 'failed' }])
+                });
+
+            document.querySelector('.groups-load-more').click();
+            await vi.advanceTimersByTimeAsync(0);
+            await vi.advanceTimersByTimeAsync(2000);
+
+            var cell = document.querySelector('[data-media-id="9"]');
+            expect(cell.dataset.status).toBe('failed');
+            expect(cell.querySelector('img')).toBeNull();
+            expect(cell.querySelector('.bi-exclamation-triangle')).not.toBeNull();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it('marks a finished video with its play badge', async () => {
+        vi.useFakeTimers();
+        try {
+            document.body.innerHTML = `
+                <div id="groups-feed" data-group-id="7">
+                    <div class="groups-load-more-wrapper">
+                        <button class="groups-load-more" data-url="/groups/7/feed?cursor=abc">Charger plus</button>
+                    </div>
+                </div>
+            `;
+            global.fetch = vi.fn()
+                .mockResolvedValueOnce({
+                    ok: true,
+                    text: () => Promise.resolve('<a class="groups-media-cell" data-media-id="11" data-status="processing"></a>')
+                })
+                .mockResolvedValue({
+                    ok: true,
+                    json: () => Promise.resolve([{ id: 11, status: 'done', media_type: 'video' }])
+                });
+
+            document.querySelector('.groups-load-more').click();
+            await vi.advanceTimersByTimeAsync(0);
+            await vi.advanceTimersByTimeAsync(2000);
+
+            var cell = document.querySelector('[data-media-id="11"]');
+            expect(cell.querySelector('img')).not.toBeNull();
+            expect(cell.querySelector('.bi-play-circle-fill')).not.toBeNull();
         } finally {
             vi.useRealTimers();
         }


### PR DESCRIPTION
## Description

**La CI de `main` échoue sur chacun de ses 50 derniers runs**, y compris avant-hier, et personne ne le voit : les PR passent, parce que l'analyse de branche de SonarQube couvre une fenêtre de code nouveau que les analyses de PR ne couvrent pas. Deux causes, sans rapport entre elles.

### 1. SonarQube — note de sécurité E, bloquante

`public/assets/js/groups.js` mettait dans `innerHTML` le partiel `media_thumb.html.twig` rendu par le serveur (`jssecurity:S5696`).

Ce gabarit ne contient **aucune donnée utilisateur** — un identifiant entier et un enum — donc rien n'était exploitable. Le puits, lui, l'était : un `innerHTML` alimenté par une réponse `fetch` est un puits de XSS DOM quoi qu'il y transite aujourd'hui, et il serait devenu réel le jour où quelqu'un ajoute une légende à ce gabarit.

L'endpoint renvoie désormais `{id, status, media_type}` et le client construit la cellule en `createElement`. Plus aucun HTML ne transite. Trois tests JS ajoutés, dont celui qui compte : un serveur qui renverrait du balisage — ou qui aurait été compromis — ne change plus rien. Côté PHP, l'assertion porte sur **toute** la réponse plutôt que sur les clés que le test connaît, pour qu'un champ ajouté plus tard ne rouvre pas discrètement le puits.

### 2. Scan dynamique — intermittent, et c'est mon bug d'IT-07

`SchedulerKick::now()` appelait `emitHop()` directement. Or `emitHop()` ne consulte que `base_url` : **le plafond de sauts vit dans `shouldHop()`**, que la relance court-circuitait.

Les harnais e2e et DAST mettent ce plafond à zéro — « l'enchaînement est coupé sur cette instance » — précisément parce que `php -S` ne sert qu'une requête à la fois et n'a qu'un worker par défaut. Ma relance ignorait ce réglage : elle queutait derrière la requête qui l'avait émise, puis tenait l'unique worker le temps d'une tranche. Une étape navigateur expirait à 120 s, par intermittence, et **seulement sous le scan**, où chaque requête porte déjà la latence du proxy.

Le calendrier le confirme : le scan passait sur `511a608` et `0cd2ebc`, il échoue depuis `a398366` — la fusion d'IT-07.

## Sur la vérification des tests

Les deux correctifs ont été vérifiés en échec sans eux. **Le premier jet du second passait sans la correction** : son `base_url` visait un port mort, donc `kick()` renvoyait `false` pour la mauvaise raison. Réécrit avec une socket qui écoute réellement, il tombe. C'est la seconde fois dans ce chantier qu'un test vert ne prouvait rien.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`) — 12 400 tests, 41 293 assertions, aucun échec
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: `tests/js/groups-feed.test.js` étendu (59 tests), `npm test` et `npm run typecheck` verts

---
_Generated by [Claude Code](https://claude.ai/code/session_01SAMnqgELwBdHRxVnbqe5kv)_