### PR TITLE
Réparer main : le scénario d'accueil ouvre le composeur avant d'écrire

### DIFF
--- a/tests/e2e/specs/public-home-page.spec.js
+++ b/tests/e2e/specs/public-home-page.spec.js
@@ -34,7 +34,7 @@ import { expect, test } from '@playwright/test';
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { autoConfirm } from '../support/confirm-dialog.js';
 import { loginAsAdmin, loginAsMember } from '../support/admin-login.js';
-import { openCreateGroupForm, waitForGroupsJsReady } from '../support/groups.js';
+import { openComposer, openCreateGroupForm, waitForGroupsJsReady } from '../support/groups.js';
 import { xlsxBuffer } from '../support/xlsx.js';
 
 test('the public home page boots through public/index.php and renders in a browser', async ({ page }) => {
@@ -355,8 +355,12 @@ test('with money due and unread group activity at once, the home page shows one 
 
         await memberPage.goto(groupUrl, { waitUntil: 'domcontentloaded' });
         await waitForGroupsJsReady(memberPage);
+        // groups.js folds the composer away behind a one-line bar as soon
+        // as it runs (modules/groups/views/show.html.twig), so writing a
+        // message starts by asking for the form — the same click a member
+        // makes. Without it the form below stays `d-none`.
+        await openComposer(memberPage);
         const composer = memberPage.locator('#groups-post-form');
-        await expect(composer).toBeVisible();
         await composer.getByLabel('Écrire un message').fill(MEMBER_MESSAGE);
         await composer.getByRole('button', { name: 'Publier' }).click();
         // The post's own rendered body, never the edit textarea that


### PR DESCRIPTION
`main` est rouge depuis le merge de la voie C (`8f478249`, run [685](https://github.com/xdubois-57/scoutmagic/actions/runs/33326348730)), sur `End-to-end (browser)` et `Dynamic scan (passive)`. Les six PR ouvertes — #103, #104, #106, #107, #108, #109 — reposent toutes sur ce tip et échouent à l'identique. Ce correctif les débloque toutes.

## La panne

Un seul scénario échoue, 46 passent.

```
1) [chromium] › tests/e2e/specs/public-home-page.spec.js:251:1 › with money due and unread
   group activity at once, the home page shows one band and it is the payment one

    Error: expect(locator).toBeVisible() failed
    Locator:  locator('#groups-post-form')
    Expected: visible   Received: hidden   Timeout: 10000ms
      - 24 × locator resolved to <form … id="groups-post-form" … class="card mb-3 d-none" …>
```

`Dynamic scan (passive)` est la même panne au timeout de 40 s, et n'a pas de défaut propre : le scan a cartographié 436 URL et passé sa propre porte — aucune remontée au niveau Medium ou au-dessus — puis `scripts/dast.sh` sort volontairement avec le code de la suite navigateur qui a produit son trafic, « a scan is only as complete as the traffic it was given ». Un seul correctif éteint les deux jobs.

## La cause

L'application est correcte ; c'est la précondition du scénario qui a vieilli. `show.html.twig` livre `#groups-post-form` sans `d-none` et rend à côté la barre repliée « Écrire un message… » ; `groups.js` replie le formulaire au ready. La voie C a ajouté le helper `openComposer()` et corrigé les huit scénarios qui écrivent un message — discussion, mentions, gestion — tous verts.

Mais `public-home-page.spec.js` appartient à la voie A, mergée **après** le run de CI de la voie C et **avant** que la voie C ne soit mergée. La combinaison n'a jamais été testée ensemble. La voie C avait pourtant écrit l'avertissement dans son propre message de merge : « replier le composeur change une précondition pour tout scénario qui écrit un message ».

## Le correctif

Deux lignes : `openComposer` ajouté à l'import existant, et appelé après `waitForGroupsJsReady()` à la place du `toBeVisible()` nu. Aucune assertion perdue — `openComposer()` attend et vérifie que le textarea « Écrire un message » est visible, ce qui est la même affirmation. Aucun code de production touché, aucun test neutralisé ni affaibli.

La suite a été auditée avant l'édition : quatre specs seulement touchent `/groups/`, et c'était le seul écrivain auquel il manquait l'étape. `groups-discussion.spec.js:707` attend le formulaire visible **volontairement** dans le scénario sans JavaScript — correct, laissé tel quel.

## Portes

| Porte | Résultat |
|---|---|
| `vendor/bin/phpunit` | 12 485 tests, 41 330 assertions, 64 ignorés, 0 échec |
| `vendor/bin/phpstan` | **[OK] No errors** (1 200 fichiers) |
| `npx vitest run` | 95 fichiers, 1 625 tests |
| `npm run typecheck` | 0 nouvelle remontée |

Aucun run Playwright local : le verrou `GET_LOCK('scoutmagic_schema_migration')` est à portée serveur et une autre session travaille sur la même machine. Les quatre portes ci-dessus prouvent seulement que rien d'autre n'a régressé — **la CI de cette PR est le juge des jobs e2e et DAST.**

## Ce que ça dit de la méthode

Le CI vert de la voie C avait été calculé contre une base qui a bougé avant son merge. Un vert n'est valable que pour la base sur laquelle il a été calculé ; c'est ce contrôle qui manquait, pas un test.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEvHt2nVMfwVnipsDK6QgA

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEvHt2nVMfwVnipsDK6QgA)_