### PR TITLE
Courrier entrant IT-08 — un justificatif de dépense peut arriver par courriel

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1584,6 +1584,16 @@ What does protect the files is the ordinary mechanism: `File\RentalDocumentOwner
 
 **The polling task is the one module task registered by hand** rather than auto-resolved from its manifest, because it needs the consumer registry and only a composition root can build one — as a lazy factory in `public/scheduler-bootstrap.php`, the single file both entry points call (§8.5), so the graph is only assembled when a sync task is actually due and the registration cannot exist under one trigger and not the other. `Tests\Modules\InboundMail\CompositionRootWiringTest` pins the factory's load-bearing facts, the camps consumer's last position included.
 
+### 8.59bis An invoice arriving by email (`Modules\Finance\Mail`)
+
+**This consumer only ever proposes.** Never an association, on any path: a receipt is an accounting document, and a wrong one is worse than a missing one because it silently balances against the wrong account. What turns a proposition into a receipt is a treasurer confirming it, and nothing else.
+
+**Two signals, both required.** An **attachment** of a type a receipt can be (PDF or image — a spreadsheet is a document and not a receipt), and **exactly one of the unit's own IBANs** in the message's text. The second is what says *which* account, and the module refuses to guess: zero matches is silence, and two matches is silence too, because an email quoting two of the unit's accounts is almost always a transfer between them and a transfer's receipt belongs to neither side. The IBAN is matched through its blind index, so nothing is decrypted to answer the question. A weak signal, and `describeEvidence()` says so out loud — the superadmin reads that sentence before opening a shared mailbox to this module, which is what publishing per-consumer evidence is for.
+
+**A receipt is only ever filed by a person.** `onLinked()` files nothing unless `MessageLink::createdByUserAccountId` names one, and unless the composition root's resolver recognises that id as the CURRENT session: finance's account check is built from the actor, and inventing one would be this module granting itself an account it may not touch. On the scheduled path there is no actor and no file reader, deliberately — a synchronisation has nobody making a request. `onUnlinked()` does nothing at all: detaching the email a receipt arrived in is a statement about the mail, not about the books, and quietly deleting a receipt because somebody tidied a mailbox is the surprise §8.70 exists to prevent.
+
+**Strictly additive to finance.** Nothing in that module changed: the consumer reaches it through `Api\ExpenseReceiptInterface`, which already existed for the federation-invoice flow, and through `Service\AccountVisibility`, which already answers "may this role see this account" — the same answer the finance screens get, deliberately, because a message filed against an account and the account's own movements must not have two different rules. A consumer that needed its provider to change would have been a consumer built at the wrong layer.
+
 ### 8.59 A booking's correspondence (`Modules\Rental\Mail`)
 
 **`rental` claims its own mail; `inbound_mail` has no idea what a booking

--- a/docs/chantiers/courrier-entrant-transversal.md
+++ b/docs/chantiers/courrier-entrant-transversal.md
@@ -547,3 +547,69 @@ mois ». Ni l'un ni l'autre n'est vrai : le message quitte le séjour et
 reste dans le courrier de l'unité. L'écran ne cite d'ailleurs plus de durée
 — citer un nombre dont ce module n'est plus propriétaire est la façon dont
 un écran finit par promettre six mois pendant que le réglage en dit trois.
+
+## IT-08 — le consumer finances
+
+### Strictement additif, et c'était vérifiable
+
+Rien n'a changé dans le module finances. Le consumer l'atteint par
+`Api\ExpenseReceiptInterface` — qui existait déjà pour la facture de
+fédération — et par `Service\AccountVisibility`, qui répond déjà « ce rôle
+voit-il ce compte ». C'est la même réponse que les écrans finances
+obtiennent, volontairement : un message classé sur un compte et les
+mouvements de ce compte ne doivent pas avoir deux règles différentes.
+
+Un consumer qui aurait exigé que son fournisseur change aurait été un
+consumer construit au mauvais étage.
+
+### Il ne fait que proposer
+
+Jamais un rattachement, sur aucun chemin. Un reçu est une pièce comptable,
+et un mauvais reçu est pire qu'un reçu manquant : il s'équilibre en silence
+sur le mauvais compte.
+
+### Deux signaux, tous les deux obligatoires
+
+Une **pièce jointe** d'un type qu'un reçu peut avoir (PDF ou image — un
+tableur est un document, pas un reçu), et **exactement un** des IBAN de
+l'unité dans le texte. Le second dit *quel* compte, et le module refuse de
+deviner : zéro correspondance, silence ; deux correspondances, silence
+aussi, parce qu'un email citant deux comptes de l'unité est presque
+toujours un virement interne et que le reçu d'un virement n'appartient par
+défaut à aucun des deux côtés.
+
+L'IBAN passe par son index aveugle : rien n'est déchiffré pour répondre.
+
+`describeEvidence()` dit « signal faible » en toutes lettres. C'est le prix
+de l'absence de seuil central : chaque consumer publie ce sur quoi il
+propose, et le superadmin lit cette phrase avant d'ouvrir une boîte
+partagée au module.
+
+### Un reçu n'est jamais classé que par une personne
+
+`onLinked()` ne classe rien tant que `MessageLink::createdByUserAccountId`
+ne nomme personne, **et** tant que le résolveur de la racine de composition
+ne reconnaît pas cet identifiant comme la session **en cours**.
+L'autorisation de finances se construit à partir de l'acteur ; en inventer
+un ici reviendrait à ce que ce module s'accorde un compte auquel il n'a pas
+droit.
+
+Sur le chemin planifié, il n'y a ni acteur ni lecteur de fichier, et c'est
+délibéré : une synchronisation n'a personne qui fait une demande.
+
+### `onUnlinked()` ne fait rien
+
+Détacher l'email dans lequel un reçu est arrivé est une affirmation sur le
+courrier, pas sur la comptabilité. Supprimer un reçu en silence parce que
+quelqu'un a rangé une boîte mail est exactement la surprise que §8.70
+existe pour éviter. On retire un reçu depuis l'écran des reçus.
+
+### `Api\CandidateAttachment` (livré en IT-07)
+
+Le contrat disait depuis toujours qu'un candidat porte les **métadonnées**
+des pièces jointes. Jusqu'à IT-07 il n'en portait aucune, et un consumer
+dont le signal est « il y a une pièce jointe » n'avait aucun moyen de
+poser la question. Métadonnées seulement : pas d'octets, et un test le
+vérifie — lire un PDF pendant la synchronisation ferait exploser
+`max_execution_time` sur un hébergement mutualisé, en laissant le curseur
+immobile, donc en rejouant le même run condamné à chaque tick.

--- a/modules/finance/help/courrier-finances.md
+++ b/modules/finance/help/courrier-finances.md
@@ -1,0 +1,47 @@
+---
+id: courrier-finances
+title: Une facture reçue par e-mail
+summary: Quand le site propose de classer une pièce jointe en reçu, et pourquoi il ne le fait jamais tout seul.
+category: Espace animateurs
+role_min: intendant
+paths: /finance/receipts
+related: courrier-entrant, courrier-unite
+---
+
+Si l'unité relève ses e-mails depuis ScoutMagic et que le module Finances
+a été autorisé à lire une boîte, une facture qui arrive peut vous être
+**proposée** comme reçu sur un compte.
+
+## Ce que le site regarde
+
+Deux choses, et il faut les deux :
+
+- **une pièce jointe** qui peut être un reçu — un PDF ou une image. Un
+  tableur est un document, pas un reçu ;
+- **l'IBAN d'un de vos comptes**, cité dans le message.
+
+C'est l'IBAN qui dit *quel* compte. Le site ne devine pas : s'il n'en
+trouve aucun, il ne propose rien ; s'il en trouve deux, il ne propose rien
+non plus — un message qui cite deux de vos comptes est presque toujours un
+virement interne, et le reçu d'un virement n'appartient par défaut à aucun
+des deux côtés.
+
+C'est un **signal faible**, et le site le dit : la proposition est là pour
+être confirmée ou écartée, pas pour être crue.
+
+## Rien n'est jamais classé tout seul
+
+Le site ne rattache jamais une facture à un compte de sa propre initiative,
+et il ne crée jamais un reçu sans qu'une personne ait confirmé. Un reçu est
+une pièce comptable : un mauvais reçu est pire qu'un reçu manquant, parce
+qu'il s'équilibre en silence sur le mauvais compte.
+
+Le reçu est créé **en votre nom**, sur un compte que vous avez le droit
+d'utiliser — la même vérification que sur l'écran des reçus. Si vous
+n'avez pas ce droit, rien n'est enregistré.
+
+## Détacher le message ne supprime pas le reçu
+
+Une fois le reçu créé, il appartient au compte. Retirer le message du
+compte est une décision sur le courrier, pas sur la comptabilité : le reçu
+reste, et se retire depuis l'écran des reçus si vous le souhaitez.

--- a/modules/finance/src/Mail/FinanceMessageConsumer.php
+++ b/modules/finance/src/Mail/FinanceMessageConsumer.php
@@ -1,0 +1,384 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Modules\Finance\Mail;
+
+use Core\Security\EncryptionService;
+use Core\Security\Role;
+use Modules\Finance\Api\ExpenseReceiptInterface;
+use Modules\Finance\Repository\Account;
+use Modules\Finance\Repository\AccountRepository;
+use Modules\Finance\Service\AccountVisibility;
+use Modules\Finance\Service\IbanNormalizer;
+use Modules\Finance\Service\TreasurerScope;
+use Modules\Finance\Service\TreasurerScopeService;
+use Modules\InboundMail\Api\AnalysisResult;
+use Modules\InboundMail\Api\CandidateMessage;
+use Modules\InboundMail\Api\InboundMessage;
+use Modules\InboundMail\Api\MessageCandidate;
+use Modules\InboundMail\Api\MessageConsumerInterface;
+use Modules\InboundMail\Api\MessageLink;
+
+/**
+ * An invoice arriving by email, offered as a receipt on the account it
+ * names (§8.58's consumer contract, §8.70's receipts).
+ *
+ * **This module never associates anything on its own.** Every answer here
+ * is a *proposition*: a treasurer confirms it, and only then does anything
+ * become a receipt. That is not caution for its own sake — a receipt is an
+ * accounting document, and a wrong one is worse than a missing one because
+ * it silently balances against the wrong account.
+ *
+ * **Two signals, and both are required.**
+ *
+ * 1. An **attachment** of a type a receipt can be — a PDF, an image, an
+ *    office document. Without one there is nothing to file, however much
+ *    the message talks about money.
+ * 2. **Exactly one of the unit's own IBANs**, found in the message's text.
+ *    That is what says *which* account, and this module refuses to guess:
+ *    zero matches means silence, two matches means silence. An IBAN is
+ *    matched through its blind index, so nothing is ever decrypted to
+ *    answer the question.
+ *
+ * A weak signal, and the configuration screen says so out loud
+ * (`describeEvidence()`). The superadmin reads that sentence before
+ * opening a shared mailbox to this module, which is the whole point of
+ * making each consumer publish what it proposes on.
+ *
+ * **Strictly additive.** Nothing in the finance module changed for this:
+ * the consumer reaches finance through `Api\ExpenseReceiptInterface`,
+ * which already existed for the federation-invoice flow, and through
+ * `Service\AccountVisibility`, which already answers "may this role see
+ * this account". A consumer that needed finance to change would have been
+ * a consumer built at the wrong layer.
+ */
+class FinanceMessageConsumer implements MessageConsumerInterface
+{
+    public const CONSUMER_ID = 'finance';
+
+    /** `account-{id}` — never a bare id, which would collide with another module's. */
+    public const REFERENCE_PREFIX = 'account-';
+
+    /**
+     * What a receipt can be. Deliberately narrower than what
+     * `inbound_mail` keeps: a spreadsheet is a document, and an accounting
+     * receipt it is not.
+     */
+    public const RECEIPT_MIME_TYPES = [
+        'application/pdf',
+        'image/jpeg',
+        'image/png',
+        'image/heic',
+        'image/webp',
+    ];
+
+    public function __construct(
+        private AccountRepository $accounts,
+        private TreasurerScopeService $treasurerScopeService,
+        private \PDO $pdo,
+        private EncryptionService $encryption,
+        private int $scoutYearId,
+        /**
+         * How a confirmed proposition becomes a receipt. Null — finance's
+         * own receipt surface unavailable — degrades to "the proposition
+         * is made and confirming it associates the message, but files
+         * nothing", which is visible rather than silent.
+         */
+        private ?ExpenseReceiptInterface $receipts = null,
+        /**
+         * Resolves the confirming user into the (role, members) pair
+         * finance's authorisation needs. Null means no receipt is ever
+         * stored: this module refuses to invent an actor, because the
+         * account check is built from one.
+         *
+         * @var (\Closure(int): ?array{role: string, member_ids: int[]})|null
+         */
+        private ?\Closure $resolveActor = null,
+        /**
+         * Reads an attachment's bytes back out of encrypted storage.
+         * Null — no reader wired — means the association is made and no
+         * receipt is filed, which is the same visible degradation as no
+         * actor.
+         *
+         * @var (\Closure(int): ?string)|null
+         */
+        private ?\Closure $readFile = null
+    ) {
+    }
+
+    public function consumerId(): string
+    {
+        return self::CONSUMER_ID;
+    }
+
+    public function displayName(): string
+    {
+        return 'Finances';
+    }
+
+    public static function referenceFor(int $accountId): string
+    {
+        return self::REFERENCE_PREFIX . $accountId;
+    }
+
+    public static function accountIdFromReference(string $reference): ?int
+    {
+        if (!str_starts_with($reference, self::REFERENCE_PREFIX)) {
+            return null;
+        }
+
+        $id = (int) substr($reference, strlen(self::REFERENCE_PREFIX));
+
+        return $id > 0 ? $id : null;
+    }
+
+    /**
+     * Everything this module needs is already on arrival: the attachment
+     * metadata says whether there is a receipt-shaped file, and the IBAN
+     * is in the text.
+     *
+     * Reading the PDF itself would be the obvious next step and is
+     * deliberately not taken: it is `analyzeStored()`'s territory, it
+     * costs an extraction per message, and the account is named in the
+     * covering email far more often than inside the invoice.
+     */
+    public function analyze(CandidateMessage $message): AnalysisResult
+    {
+        if (!$message->hasAttachmentOfType(self::RECEIPT_MIME_TYPES)) {
+            return AnalysisResult::nothing();
+        }
+
+        $account = $this->theOneAccountNamed($message->subject . "\n" . $message->bodyText);
+        if ($account === null) {
+            return AnalysisResult::nothing();
+        }
+
+        return AnalysisResult::proposing(new MessageCandidate(
+            businessReference: self::referenceFor($account->id),
+            label: $account->name,
+            evidenceType: 'iban_in_body',
+            explanation: 'Le message porte une pièce jointe et cite l\'IBAN de ce compte. '
+                . 'C\'est un signal faible : rien n\'est enregistré tant qu\'un trésorier ne l\'a pas confirmé.'
+        ));
+    }
+
+    /**
+     * Nothing on the deferred pass.
+     *
+     * Reading an invoice's own text would need an extraction per message
+     * and would answer a question the covering email usually answers
+     * already. Adding it later is a change to this class alone.
+     */
+    public function analyzeStored(InboundMessage $message): AnalysisResult
+    {
+        return AnalysisResult::nothing();
+    }
+
+    /**
+     * A treasurer confirmed: the attachments become receipts on that
+     * account.
+     *
+     * **Only when there is an actor.** `$link->createdByUserAccountId` is
+     * set when a person made the association and null when a machine did;
+     * finance's authorisation is built from the actor, and inventing one
+     * here would be this module granting itself an account it may not
+     * touch. No actor therefore means the association is made and no
+     * receipt is filed — visible on the screen, rather than silent.
+     */
+    public function onLinked(InboundMessage $message, MessageLink $link): void
+    {
+        $accountId = self::accountIdFromReference($link->businessReference);
+        if ($accountId === null
+            || $this->receipts === null
+            || $this->resolveActor === null
+            || $this->readFile === null
+        ) {
+            return;
+        }
+
+        if ($link->createdByUserAccountId === null) {
+            return;
+        }
+
+        $actor = ($this->resolveActor)($link->createdByUserAccountId);
+        if ($actor === null) {
+            return;
+        }
+
+        foreach ($message->attachments as $attachment) {
+            if (!in_array($attachment->mimeType, self::RECEIPT_MIME_TYPES, true)) {
+                continue;
+            }
+
+            // Scoped to one attachment when the association is
+            // attachment-level, which is what a proposition about a single
+            // invoice in a message carrying three files means.
+            if ($link->attachmentId !== 0 && $link->attachmentId !== $attachment->id) {
+                continue;
+            }
+
+            $content = ($this->readFile)($attachment->fileId);
+            if ($content === null || $content === '') {
+                continue;
+            }
+
+            try {
+                $this->receipts->storeReceipt(
+                    $content,
+                    $attachment->mimeType,
+                    $attachment->filename,
+                    $accountId,
+                    null,
+                    null,
+                    $actor['role'],
+                    $actor['member_ids'],
+                    $link->createdByUserAccountId
+                );
+            } catch (\Throwable) {
+                // Finance refused the account, or the bytes could not be
+                // read. Neither is worth failing the association over: the
+                // message is on the account either way, and a treasurer
+                // can attach the file by hand from the receipts screen.
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Nothing to take back.
+     *
+     * A receipt is an accounting document. Once a treasurer has filed one,
+     * detaching the email it arrived in is a statement about the mail, not
+     * about the books — and quietly deleting a receipt because somebody
+     * tidied a mailbox is exactly the kind of surprise §8.70 exists to
+     * prevent. The receipts screen is where a receipt is removed.
+     */
+    public function onUnlinked(InboundMessage $message, MessageLink $link): void
+    {
+    }
+
+    /**
+     * @param array<int, int> $linkedMemberIds
+     */
+    public function canRead(string $businessReference, array $linkedMemberIds, string $role): bool
+    {
+        $accountId = self::accountIdFromReference($businessReference);
+        if ($accountId === null) {
+            return false;
+        }
+
+        // The same question the finance screens ask about that account —
+        // deliberately, because a message filed against an account and the
+        // account's own movements must not have two different rules.
+        return (new AccountVisibility(
+            TreasurerScope::forSession($this->treasurerScopeService, $linkedMemberIds, $this->scoutYearId)
+        ))->isVisibleTo($this->accounts->findById($accountId), Role::fromString($role));
+    }
+
+    /**
+     * @return string[]
+     */
+    public function describeEvidence(): array
+    {
+        return [
+            'pièce jointe de type reçu (PDF, image) ET IBAN d\'un compte de l\'unité cité dans le message '
+                . '— signal faible, toujours une proposition',
+        ];
+    }
+
+    public function triageAudienceLabel(): string
+    {
+        return 'la trésorerie et le staff d\'unité';
+    }
+
+    /**
+     * Who would actually see this module's mail: whoever may see at least
+     * one account, which the treasurer scope already answers.
+     *
+     * Exact rather than estimated — the warning that shows this figure is
+     * the only guard-rail on opening a shared mailbox to a module.
+     */
+    public function triageAudienceCount(): int
+    {
+        // Staff d'unité and above. A section treasurer holds a chief or
+        // admin function too (`TreasurerScopeService` requires it before
+        // the badge even counts), so they are already in this figure —
+        // counting them again through the badge would inflate the number
+        // the superadmin is asked to weigh.
+        $stmt = $this->pdo->query(
+            'SELECT COUNT(DISTINCT my.member_id)
+               FROM member_years my
+               JOIN member_functions mf ON mf.member_year_id = my.id
+               JOIN functions f ON mf.function_id = f.id
+               JOIN scout_years sy ON sy.id = my.scout_year_id
+              WHERE sy.is_current = 1 AND my.is_active = 1
+                AND f.role IN (\'chief\', \'admin\', \'superadmin\')'
+        );
+
+        return $stmt === false ? 0 : (int) $stmt->fetchColumn();
+    }
+
+    /**
+     * The single account whose IBAN the text names — or null, which covers
+     * both "none" and "more than one".
+     *
+     * Two matches is silence rather than two propositions: an email
+     * quoting two of the unit's accounts is almost always a transfer
+     * between them, and a transfer's receipt belongs to neither side by
+     * default.
+     */
+    private function theOneAccountNamed(string $text): ?Account
+    {
+        $found = [];
+
+        foreach ($this->ibansIn($text) as $iban) {
+            // Through the blind index, so an IBAN is never decrypted to
+            // answer the question — the same route the statement import
+            // takes to verify a source IBAN (§8.69).
+            $account = $this->accounts->findByIbanBlindIndex(
+                $this->encryption->blindIndex($iban, 'finance_iban')
+            );
+            if ($account !== null && $account->status === Account::STATUS_ACTIVE) {
+                $found[$account->id] = $account;
+            }
+        }
+
+        return count($found) === 1 ? array_values($found)[0] : null;
+    }
+
+    /**
+     * Every IBAN-shaped run in the text, normalised.
+     *
+     * A pattern rather than a parser: what comes back is checked against
+     * the unit's own accounts, so a false positive costs a lookup that
+     * finds nothing rather than a wrong answer.
+     *
+     * @return string[]
+     */
+    private function ibansIn(string $text): array
+    {
+        // Single spaces only, and never a newline: a character class that
+        // included `\s` would run past the end of the IBAN and swallow the
+        // start of the next line, turning a perfectly good match into an
+        // invalid one. Groups of two to four are how an IBAN is written
+        // when it is written for a human to read.
+        if (preg_match_all('/\b[A-Z]{2}\d{2}(?:[ ]?[A-Z0-9]{2,4}){2,8}\b/i', $text, $matches) === false) {
+            return [];
+        }
+
+        $ibans = [];
+        foreach ($matches[0] as $raw) {
+            $normalized = IbanNormalizer::normalize($raw);
+            if (IbanNormalizer::isValidFullIban($normalized)) {
+                $ibans[$normalized] = $normalized;
+            }
+        }
+
+        return array_values($ibans);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -3099,6 +3099,57 @@ if ($isEnabled('finance')) {
         $financeAccountRepo, $financeTreasurerScopeService, $financeReceiptService, $effectiveScoutYear->id
     );
 
+    // An invoice arriving by email, offered as a receipt on the account it
+    // names (§8.58). A FACTORY, like every other consumer here: the
+    // question "who may open this attachment" builds exactly one consumer,
+    // and an ordinary page view — which never asks — builds none.
+    //
+    // Unlike the scheduled path, this one supplies an actor and a file
+    // reader, because here there IS somebody making the request: a
+    // treasurer confirming a proposition. Finance's account check is built
+    // from that actor, and the consumer refuses to invent one.
+    if (isset($inboundReadConsumers)) {
+        $inboundReadConsumers->registerFactory(
+            \Modules\Finance\Mail\FinanceMessageConsumer::CONSUMER_ID,
+            static fn(): \Modules\InboundMail\Api\MessageConsumerInterface =>
+                new \Modules\Finance\Mail\FinanceMessageConsumer(
+                    $financeAccountRepo,
+                    $financeTreasurerScopeService,
+                    $pdo,
+                    $encryptionService,
+                    $effectiveScoutYear->id,
+                    $expenseReceiptProvider,
+                    // The confirming user, resolved into the (role,
+                    // members) pair finance's authorisation needs. Only
+                    // ever the CURRENT session: a stored account id from
+                    // some other request is not somebody making a request
+                    // now, and finance must not be handed one.
+                    static function (int $userAccountId) use ($linkedMemberIds): ?array {
+                        if (!AuthSession::isAuthenticated()
+                            || AuthSession::getUserAccountId() !== $userAccountId
+                        ) {
+                            return null;
+                        }
+
+                        return [
+                            'role' => AuthSession::getRole(),
+                            'member_ids' => $linkedMemberIds,
+                        ];
+                    },
+                    static function (int $fileId) use ($encryptedFileStorageService): ?string {
+                        try {
+                            return $encryptedFileStorageService->retrieve($fileId);
+                        } catch (\Throwable) {
+                            // The bytes are gone or unreadable. The
+                            // association still stands; a treasurer can
+                            // attach the file by hand.
+                            return null;
+                        }
+                    }
+                )
+        );
+    }
+
     // A receipt's FILE follows its account's rule too (ARCHITECTURE.md
     // §8.70): role_min alone is a hierarchical floor and cannot say "the
     // Louveteaux section", so without this the screen would be narrowed

--- a/public/scheduler-bootstrap.php
+++ b/public/scheduler-bootstrap.php
@@ -237,6 +237,30 @@ function scoutmagic_bootstrap_scheduler(
                     ));
                 }
 
+                // Finance only ever PROPOSES, so it needs no place in any
+                // ordering: a proposition costs nobody else anything. On
+                // this path it also has no actor and no file reader, which
+                // is deliberate — a synchronisation has nobody making a
+                // request, and finance's account check is built from the
+                // actor. Nothing is ever filed as a receipt from here.
+                if ($inboundMail !== null && in_array('finance', $enabledModuleIds, true)) {
+                    $registry->register(new \Modules\Finance\Mail\FinanceMessageConsumer(
+                        new \Modules\Finance\Repository\AccountRepository($pdo, $encryptionService),
+                        new \Modules\Finance\Service\TreasurerScopeService(
+                            \Core\Database\Connection::withPdo($pdo),
+                            new \Core\Badge\BadgeRepository($pdo),
+                            new \Core\Badge\MemberBadgeRepository($pdo)
+                        ),
+                        $pdo,
+                        $encryptionService,
+                        // The current year, resolved here rather than
+                        // carried on the context: the scheduled path has no
+                        // session and no "effective" year, and the treasurer
+                        // rule is about who holds the badge THIS year.
+                        (new \Core\Config\ScoutYearService($pdo))->getCurrentYear()['id']
+                    ));
+                }
+
                 // The camps consumer is registered LAST, and that ordering
                 // is load-bearing: MessageConsumerRegistry is
                 // first-claim-wins in registration order, and a dedicated

--- a/tests/Modules/Finance/Mail/FinanceMessageConsumerTest.php
+++ b/tests/Modules/Finance/Mail/FinanceMessageConsumerTest.php
@@ -1,0 +1,442 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Modules\Finance\Mail;
+
+use Core\Security\EncryptionService;
+use Modules\Finance\Mail\FinanceMessageConsumer;
+use Modules\Finance\Repository\Account;
+use Modules\Finance\Repository\AccountRepository;
+use Modules\Finance\Service\TreasurerScopeService;
+use Modules\InboundMail\Api\CandidateAttachment;
+use Modules\InboundMail\Api\CandidateMessage;
+use Modules\InboundMail\Api\InboundAttachment;
+use Modules\InboundMail\Api\InboundMessage;
+use Modules\InboundMail\Api\LinkOrigin;
+use Modules\InboundMail\Api\MessageLink;
+use PHPUnit\Framework\TestCase;
+use Tests\DatabaseTestHelper;
+use Tests\Modules\Finance\FinanceTestHelper;
+
+/**
+ * An invoice arriving by email, offered as a receipt on the account it
+ * names.
+ *
+ * This consumer **never associates anything on its own**: every answer is
+ * a proposition, and only a treasurer's confirmation turns one into a
+ * receipt. A receipt is an accounting document, and a wrong one is worse
+ * than a missing one because it silently balances against the wrong
+ * account.
+ *
+ * @group database
+ */
+#[\PHPUnit\Framework\Attributes\Group('database')]
+class FinanceMessageConsumerTest extends TestCase
+{
+    private const IBAN = 'BE92001511757023';
+    private const OTHER_IBAN = 'BE71096123456769';
+
+    private \PDO $pdo;
+    private EncryptionService $encryption;
+    private AccountRepository $accounts;
+    private int $accountId;
+
+    protected function setUp(): void
+    {
+        $this->pdo = DatabaseTestHelper::createTestDatabase();
+        FinanceTestHelper::createTables($this->pdo);
+        $this->encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $this->accounts = new AccountRepository($this->pdo, $this->encryption);
+
+        $this->accountId = $this->activeAccount('Compte courant', self::IBAN);
+    }
+
+    // ── Both signals are required ───────────────────────────────────────
+
+    public function testAnAttachmentAndTheAccountsIbanTogetherProduceOneProposition(): void
+    {
+        $result = $this->consumer()->analyze($this->message(
+            'Facture de la fédération',
+            'Merci de virer sur le compte BE92 0015 1175 7023.',
+            [$this->pdfAttachment()]
+        ));
+
+        $this->assertSame([], $result->links, 'this module never associates on its own');
+        $this->assertCount(1, $result->candidates);
+        $this->assertSame(
+            FinanceMessageConsumer::referenceFor($this->accountId),
+            $result->candidates[0]->businessReference
+        );
+        $this->assertSame('Compte courant', $result->candidates[0]->label);
+        $this->assertStringContainsString('signal faible', $result->candidates[0]->explanation);
+    }
+
+    public function testAnIbanWithNoAttachmentIsNothingToFile(): void
+    {
+        $result = $this->consumer()->analyze($this->message(
+            'Nos coordonnées',
+            'Notre IBAN est BE92 0015 1175 7023.',
+            []
+        ));
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testAnAttachmentWithNoIbanSaysNothingAboutWhichAccount(): void
+    {
+        $result = $this->consumer()->analyze($this->message(
+            'Facture',
+            'Voici la facture en pièce jointe.',
+            [$this->pdfAttachment()]
+        ));
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testASpreadsheetIsADocumentAndNotAReceipt(): void
+    {
+        $result = $this->consumer()->analyze($this->message(
+            'Tableau',
+            'Compte BE92 0015 1175 7023.',
+            [new CandidateAttachment(
+                'budget.xlsx',
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+                4096
+            )]
+        ));
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testTheIbanIsFoundInTheSubjectToo(): void
+    {
+        $result = $this->consumer()->analyze($this->message(
+            'Virement BE92 0015 1175 7023',
+            'Voir pièce jointe.',
+            [$this->pdfAttachment()]
+        ));
+
+        $this->assertCount(1, $result->candidates);
+    }
+
+    // ── It refuses to guess ─────────────────────────────────────────────
+
+    public function testTwoOfTheUnitsOwnIbansMeanSilence(): void
+    {
+        // Almost always a transfer between two of the unit's accounts, and
+        // a transfer's receipt belongs to neither side by default.
+        $this->activeAccount('Louveteaux', self::OTHER_IBAN);
+
+        $result = $this->consumer()->analyze($this->message(
+            'Virement interne',
+            'De BE92 0015 1175 7023 vers BE71 0961 2345 6769.',
+            [$this->pdfAttachment()]
+        ));
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testAnIbanThatIsNotTheUnitsIsIgnored(): void
+    {
+        $result = $this->consumer()->analyze($this->message(
+            'Facture',
+            'Virez sur BE71 0961 2345 6769, merci.',
+            [$this->pdfAttachment()]
+        ));
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testAnArchivedAccountIsNotProposedOn(): void
+    {
+        $archived = $this->accounts->create('Ancien', Account::TYPE_BANK, null, self::OTHER_IBAN, 'T', 'intendant');
+        $this->accounts->updateStatus($archived, Account::STATUS_INACTIVE);
+
+        $result = $this->consumer()->analyze($this->message(
+            'Facture',
+            'Compte BE71 0961 2345 6769.',
+            [$this->pdfAttachment()]
+        ));
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testTextThatMerelyLooksLikeAnIbanCostsNothing(): void
+    {
+        // The pattern is deliberately loose; what makes it safe is that
+        // whatever it finds is checked against the unit's own accounts.
+        $result = $this->consumer()->analyze($this->message(
+            'Référence',
+            'Votre dossier XX99 ABCD EFGH IJKL est ouvert.',
+            [$this->pdfAttachment()]
+        ));
+
+        $this->assertTrue($result->isEmpty());
+    }
+
+    public function testTheDeferredPassAddsNothing(): void
+    {
+        $this->assertTrue($this->consumer()->analyzeStored($this->storedMessage())->isEmpty());
+    }
+
+    // ── A receipt is only ever filed by a person ────────────────────────
+
+    public function testNothingIsFiledWhenAMachineMadeTheAssociation(): void
+    {
+        // `createdByUserAccountId` is null when a machine associated.
+        // Finance's account check is built from the actor, and inventing
+        // one here would be this module granting itself an account.
+        $filed = [];
+        $consumer = $this->consumer($filed, actorFor: 7);
+
+        $consumer->onLinked($this->storedMessage(), new MessageLink(
+            FinanceMessageConsumer::CONSUMER_ID,
+            FinanceMessageConsumer::referenceFor($this->accountId),
+            LinkOrigin::MANUAL
+        ));
+
+        $this->assertSame([], $filed);
+    }
+
+    public function testAConfirmedPropositionFilesTheAttachmentAsAReceipt(): void
+    {
+        $filed = [];
+        $consumer = $this->consumer($filed, actorFor: 7);
+
+        $consumer->onLinked($this->storedMessage(), new MessageLink(
+            FinanceMessageConsumer::CONSUMER_ID,
+            FinanceMessageConsumer::referenceFor($this->accountId),
+            LinkOrigin::MANUAL,
+            0,
+            7
+        ));
+
+        $this->assertCount(1, $filed);
+        $this->assertSame('facture.pdf', $filed[0]['filename']);
+        $this->assertSame($this->accountId, $filed[0]['account_id']);
+        $this->assertSame('admin', $filed[0]['role']);
+    }
+
+    public function testAnActorTheSessionDoesNotRecogniseFilesNothing(): void
+    {
+        $filed = [];
+        // The resolver answers for user 7 only; the link names user 42.
+        $consumer = $this->consumer($filed, actorFor: 7);
+
+        $consumer->onLinked($this->storedMessage(), new MessageLink(
+            FinanceMessageConsumer::CONSUMER_ID,
+            FinanceMessageConsumer::referenceFor($this->accountId),
+            LinkOrigin::MANUAL,
+            0,
+            42
+        ));
+
+        $this->assertSame([], $filed);
+    }
+
+    public function testAnAttachmentLevelAssociationFilesThatAttachmentAndNoOther(): void
+    {
+        $filed = [];
+        $consumer = $this->consumer($filed, actorFor: 7);
+
+        $consumer->onLinked($this->storedMessage(twoAttachments: true), new MessageLink(
+            FinanceMessageConsumer::CONSUMER_ID,
+            FinanceMessageConsumer::referenceFor($this->accountId),
+            LinkOrigin::MANUAL,
+            88,
+            7
+        ));
+
+        $this->assertCount(1, $filed);
+        $this->assertSame('facture.pdf', $filed[0]['filename']);
+    }
+
+    public function testAnAssociationOnAnotherModulesReferenceFilesNothing(): void
+    {
+        $filed = [];
+        $consumer = $this->consumer($filed, actorFor: 7);
+
+        $consumer->onLinked($this->storedMessage(), new MessageLink('camps', 'camp-1', LinkOrigin::MANUAL, 0, 7));
+
+        $this->assertSame([], $filed);
+    }
+
+    public function testDetachingNeverDeletesAReceipt(): void
+    {
+        // A receipt is an accounting document. Detaching the email it
+        // arrived in is a statement about the mail, not about the books.
+        $filed = [];
+        $consumer = $this->consumer($filed, actorFor: 7);
+
+        $consumer->onUnlinked($this->storedMessage(), new MessageLink(
+            FinanceMessageConsumer::CONSUMER_ID,
+            FinanceMessageConsumer::referenceFor($this->accountId),
+            LinkOrigin::MANUAL,
+            0,
+            7
+        ));
+
+        $this->assertSame([], $filed, 'nothing is undone, and nothing throws');
+    }
+
+    // ── References ──────────────────────────────────────────────────────
+
+    public function testOnlyAnAccountReferenceReadsBackAsAnAccount(): void
+    {
+        $this->assertSame('account-42', FinanceMessageConsumer::referenceFor(42));
+        $this->assertSame(42, FinanceMessageConsumer::accountIdFromReference('account-42'));
+        $this->assertNull(FinanceMessageConsumer::accountIdFromReference('camp-42'));
+        $this->assertNull(FinanceMessageConsumer::accountIdFromReference('account-0'));
+        $this->assertNull(FinanceMessageConsumer::accountIdFromReference('42'));
+    }
+
+    public function testTheModulePublishesWhatItProposesOn(): void
+    {
+        // The superadmin reads this sentence before opening a shared
+        // mailbox to this module. Saying « signal faible » out loud is the
+        // price of there being no central threshold.
+        $evidence = implode(' ', $this->consumer()->describeEvidence());
+
+        $this->assertStringContainsString('signal faible', $evidence);
+        $this->assertStringContainsString('IBAN', $evidence);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * @param array<int, array{filename: string, account_id: int, role: string}> $filed
+     */
+    private function consumer(array &$filed = [], ?int $actorFor = null): FinanceMessageConsumer
+    {
+        $receipts = new RecordingExpenseReceipts($filed);
+
+        return new FinanceMessageConsumer(
+            $this->accounts,
+            new TreasurerScopeService(
+                \Core\Database\Connection::withPdo($this->pdo),
+                new \Core\Badge\BadgeRepository($this->pdo),
+                new \Core\Badge\MemberBadgeRepository($this->pdo)
+            ),
+            $this->pdo,
+            $this->encryption,
+            1,
+            $receipts,
+            $actorFor === null
+                ? null
+                : static fn(int $id): ?array => $id === $actorFor
+                    ? ['role' => 'admin', 'member_ids' => []]
+                    : null,
+            static fn(int $fileId): ?string => 'des octets'
+        );
+    }
+
+    /**
+     * @param CandidateAttachment[] $attachments
+     */
+    private function message(string $subject, string $body, array $attachments): CandidateMessage
+    {
+        return new CandidateMessage(
+            mailboxId: 1,
+            subject: $subject,
+            fromEmail: 'fournisseur@example.be',
+            fromName: null,
+            messageId: 'a@b',
+            inReplyTo: null,
+            references: [],
+            toEmails: [],
+            sentAt: new \DateTimeImmutable('2027-07-12 09:30:00'),
+            bodyText: $body,
+            bodyHtml: '',
+            attachments: $attachments
+        );
+    }
+
+    private function pdfAttachment(): CandidateAttachment
+    {
+        return new CandidateAttachment('facture.pdf', 'application/pdf', 8192);
+    }
+
+    private function storedMessage(bool $twoAttachments = false): InboundMessage
+    {
+        $attachments = [
+            new InboundAttachment(88, 55, 900, 'facture.pdf', 'application/pdf', 8192, 'hash-a'),
+        ];
+        if ($twoAttachments) {
+            $attachments[] = new InboundAttachment(89, 55, 901, 'photo.jpg', 'image/jpeg', 4096, 'hash-b');
+        }
+
+        return new InboundMessage(
+            id: 55,
+            mailboxId: 1,
+            consumerId: FinanceMessageConsumer::CONSUMER_ID,
+            businessReference: FinanceMessageConsumer::referenceFor($this->accountId),
+            linkOrigin: LinkOrigin::MANUAL,
+            subject: 'Facture',
+            fromEmail: 'fournisseur@example.be',
+            fromName: null,
+            messageId: 'a@b',
+            inReplyTo: null,
+            sentAt: new \DateTimeImmutable('2027-07-12 09:30:00'),
+            bodyText: 'Compte BE92 0015 1175 7023.',
+            bodyHtml: '',
+            toEmails: [],
+            attachments: $attachments
+        );
+    }
+
+    private function activeAccount(string $name, string $iban): int
+    {
+        $id = $this->accounts->create($name, Account::TYPE_BANK, null, $iban, 'Titulaire', 'intendant');
+        $this->accounts->updateStatus($id, Account::STATUS_ACTIVE);
+
+        return $id;
+    }
+}
+
+/**
+ * Records what would have been filed, so a test can assert on the DECISION
+ * rather than on finance's own storage — which has its own tests and would
+ * only make this file slower and less specific.
+ *
+ * @internal
+ */
+class RecordingExpenseReceipts implements \Modules\Finance\Api\ExpenseReceiptInterface
+{
+    /** @param array<int, array{filename: string, account_id: int, role: string}> $filed */
+    public function __construct(private array &$filed)
+    {
+    }
+
+    /**
+     * @param int[] $actorLinkedMemberIds
+     * @return array<int, string>
+     */
+    public function receiptAccounts(string $actorRole, array $actorLinkedMemberIds): array
+    {
+        return [];
+    }
+
+    /**
+     * @param int[] $actorLinkedMemberIds
+     */
+    public function storeReceipt(
+        string $content,
+        string $mimeType,
+        string $originalFilename,
+        int $accountId,
+        ?float $suggestedAmount,
+        ?string $suggestedDate,
+        string $actorRole,
+        array $actorLinkedMemberIds,
+        ?int $uploadedBy
+    ): int {
+        $this->filed[] = [
+            'filename' => $originalFilename,
+            'account_id' => $accountId,
+            'role' => $actorRole,
+        ];
+
+        return 1;
+    }
+}

--- a/tests/Modules/Finance/Mail/FinanceMessageConsumerTest.php
+++ b/tests/Modules/Finance/Mail/FinanceMessageConsumerTest.php
@@ -307,6 +307,49 @@ class FinanceMessageConsumerTest extends TestCase
     /**
      * @param array<int, array{filename: string, account_id: int, role: string}> $filed
      */
+    // ── Who may open a message filed against an account ─────────────────
+
+    public function testAReferenceThatNamesNoAccountOpensToNobody(): void
+    {
+        // Fail closed. A reference this module does not recognise is a
+        // corrupted row or another module's, and neither is a reason to
+        // open an accounting document.
+        $consumer = $this->consumer();
+
+        $this->assertFalse($consumer->canRead('pas-un-compte', [], 'superadmin'));
+        $this->assertFalse($consumer->canRead('', [], 'superadmin'));
+        $this->assertFalse($consumer->canRead(
+            FinanceMessageConsumer::REFERENCE_PREFIX . '99999',
+            [],
+            'superadmin'
+        ));
+    }
+
+    // ── What the triage screen asks every consumer ──────────────────────
+
+    public function testTheModuleSaysWhatItRecognisesAndWhoWouldSeeIt(): void
+    {
+        // Shown to a superadmin before a shared mailbox is opened to this
+        // module. The evidence line says outright that the signal is weak
+        // and always a proposition, because that is the whole shape of what
+        // this module does.
+        $consumer = $this->consumer();
+
+        $this->assertSame(FinanceMessageConsumer::CONSUMER_ID, $consumer->consumerId());
+        $this->assertNotSame('', $consumer->displayName());
+        $this->assertNotSame([], $consumer->describeEvidence());
+        $this->assertStringContainsString('proposition', implode(' ', $consumer->describeEvidence()));
+        $this->assertNotSame('', $consumer->triageAudienceLabel());
+    }
+
+    public function testTheAudienceIsCountedOnTheYearInEffect(): void
+    {
+        // A section treasurer already holds a chief function, so they are
+        // in this figure once — counting the badge again would inflate the
+        // number the superadmin is asked to weigh.
+        $this->assertGreaterThanOrEqual(0, $this->consumer()->triageAudienceCount());
+    }
+
     private function consumer(array &$filed = [], ?int $actorFor = null): FinanceMessageConsumer
     {
         $receipts = new RecordingExpenseReceipts($filed);

--- a/tests/Modules/Finance/Mail/FinanceMessageConsumerTest.php
+++ b/tests/Modules/Finance/Mail/FinanceMessageConsumerTest.php
@@ -350,9 +350,64 @@ class FinanceMessageConsumerTest extends TestCase
         $this->assertGreaterThanOrEqual(0, $this->consumer()->triageAudienceCount());
     }
 
-    private function consumer(array &$filed = [], ?int $actorFor = null): FinanceMessageConsumer
+    // ── Filing: the three ways it declines, none of them loud ──────────
+
+    public function testAnAttachmentThatIsNotAReceiptIsNeverFiled(): void
     {
-        $receipts = new RecordingExpenseReceipts($filed);
+        // A signature logo or a calendar invite travels with plenty of
+        // messages. Filing one as a receipt would put a picture nobody
+        // chose into the books.
+        $filed = [];
+        $consumer = $this->consumer($filed, 7);
+
+        $consumer->onLinked($this->storedMessage(mimeType: 'text/calendar'), $this->manualLink(7));
+
+        $this->assertSame([], $filed);
+    }
+
+    public function testAnAttachmentWhoseBytesCannotBeReadIsSkippedRatherThanFiledEmpty(): void
+    {
+        // The row may point at a file the storage no longer holds. An
+        // empty receipt in the books is worse than no receipt at all.
+        $filed = [];
+        $consumer = $this->consumer($filed, 7, static fn(int $fileId): ?string => null);
+
+        $consumer->onLinked($this->storedMessage(), $this->manualLink(7));
+
+        $this->assertSame([], $filed);
+    }
+
+    public function testFinanceRefusingTheReceiptDoesNotUndoTheAssociation(): void
+    {
+        // The message belongs on the account either way, and a treasurer
+        // can attach the file by hand from the receipts screen. Failing the
+        // association here would take away the part that did work.
+        $filed = [];
+        $consumer = $this->consumer($filed, 7, null, new RefusingExpenseReceipts());
+
+        $consumer->onLinked($this->storedMessage(), $this->manualLink(7));
+
+        $this->assertSame([], $filed, 'nothing was filed');
+    }
+
+    private function manualLink(int $byUserAccountId): MessageLink
+    {
+        return new MessageLink(
+            FinanceMessageConsumer::CONSUMER_ID,
+            FinanceMessageConsumer::referenceFor($this->accountId),
+            LinkOrigin::MANUAL,
+            0,
+            $byUserAccountId
+        );
+    }
+
+    private function consumer(
+        array &$filed = [],
+        ?int $actorFor = null,
+        ?\Closure $readFile = null,
+        ?\Modules\Finance\Api\ExpenseReceiptInterface $receipts = null
+    ): FinanceMessageConsumer {
+        $receipts ??= new RecordingExpenseReceipts($filed);
 
         return new FinanceMessageConsumer(
             $this->accounts,
@@ -370,7 +425,7 @@ class FinanceMessageConsumerTest extends TestCase
                 : static fn(int $id): ?array => $id === $actorFor
                     ? ['role' => 'admin', 'member_ids' => []]
                     : null,
-            static fn(int $fileId): ?string => 'des octets'
+            $readFile ?? static fn(int $fileId): ?string => 'des octets'
         );
     }
 
@@ -400,10 +455,13 @@ class FinanceMessageConsumerTest extends TestCase
         return new CandidateAttachment('facture.pdf', 'application/pdf', 8192);
     }
 
-    private function storedMessage(bool $twoAttachments = false): InboundMessage
+    private function storedMessage(
+        bool $twoAttachments = false,
+        string $mimeType = 'application/pdf'
+    ): InboundMessage
     {
         $attachments = [
-            new InboundAttachment(88, 55, 900, 'facture.pdf', 'application/pdf', 8192, 'hash-a'),
+            new InboundAttachment(88, 55, 900, 'facture.pdf', $mimeType, 8192, 'hash-a'),
         ];
         if ($twoAttachments) {
             $attachments[] = new InboundAttachment(89, 55, 901, 'photo.jpg', 'image/jpeg', 4096, 'hash-b');
@@ -481,5 +539,38 @@ class RecordingExpenseReceipts implements \Modules\Finance\Api\ExpenseReceiptInt
         ];
 
         return 1;
+    }
+}
+
+/**
+ * Finance refusing the account, as it does when the actor may not post to
+ * it. The consumer must let the association stand regardless.
+ */
+class RefusingExpenseReceipts implements \Modules\Finance\Api\ExpenseReceiptInterface
+{
+    /**
+     * @param int[] $actorLinkedMemberIds
+     * @return array<int, string>
+     */
+    public function receiptAccounts(string $actorRole, array $actorLinkedMemberIds): array
+    {
+        return [];
+    }
+
+    /**
+     * @param int[] $actorLinkedMemberIds
+     */
+    public function storeReceipt(
+        string $content,
+        string $mimeType,
+        string $originalFilename,
+        int $accountId,
+        ?float $suggestedAmount,
+        ?string $suggestedDate,
+        string $actorRole,
+        array $actorLinkedMemberIds,
+        ?int $uploadedBy
+    ): int {
+        throw new \RuntimeException('ce compte ne vous est pas ouvert');
     }
 }


### PR DESCRIPTION
## Description

Huitième et dernière itération du chantier « Courrier entrant transversal ». Le module `finance` devient à son tour un consommateur de courrier.

### Deux signaux, jamais un seul

Une proposition n'est émise que si **les deux** conditions sont réunies :

- le message porte une pièce jointe **de forme reçu** — PDF, JPEG, PNG, HEIC ou WebP, d'après le type reniflé et non le type déclaré ;
- **exactement un** IBAN actif de l'unité apparaît dans le sujet ou le corps.

Deux IBAN reconnus ne produisent rien. C'est délibérément strict : une mauvaise proposition sur une pièce comptable coûte plus cher qu'une proposition manquée, et ce module ne crée **jamais** d'association de lui-même — il ne fait que proposer.

### L'IBAN n'est jamais comparé en clair

L'expression régulière extrait un candidat du sujet et du corps, et la comparaison se fait à travers l'**index aveugle** (`blindIndex`). Les numéros de compte restent chiffrés au repos, et la recherche reste une recherche d'égalité, conformément à la règle générale sur les données personnelles.

### Classer est plus étroit que proposer

Un justificatif n'est réellement classé que si l'association a été créée par un **compte utilisateur connu** : un justificatif de dépense a besoin d'un auteur, et une synchronisation planifiée n'en a pas. C'est pourquoi la racine de composition web câble un résolveur d'acteur et un lecteur de fichier, tous deux paresseusement, tandis que le bootstrap du planificateur n'en câble aucun. Une association posée automatiquement propose donc sans classer.

Si le classement échoue — finance refuse le compte, ou les octets sont illisibles — l'association n'est pas défaite pour autant : le message est sur le compte de toute façon, et un trésorier peut joindre le fichier à la main depuis l'écran des reçus.

### Lecture

`canRead()` pose exactement la même question que les écrans de finance sur ce compte, délibérément : un message classé sur un compte et les mouvements de ce compte ne doivent pas obéir à deux règles différentes. Et une référence que le module ne reconnaît pas n'ouvre rien du tout.

### Tests

`tests/Modules/Finance/Mail/FinanceMessageConsumerTest.php` (21 cas) — la règle des deux signaux, l'unicité de l'IBAN, la garde sur l'acteur, les formes de pièces jointes acceptées, le refus par défaut sur une référence inconnue, et les déclarations de triage — dont la ligne qui annonce franchement que le signal est faible et toujours une proposition.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 13 118 tests, 0 échec)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: aucun fichier JS touché

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuVmgMA3vDpZn6PfcRJw8F)_