### PR TITLE
Un choix de cookies refusé par le serveur ne doit pas ressembler à un choix enregistré

### DIFF
--- a/public/assets/js/cookie-consent.js
+++ b/public/assets/js/cookie-consent.js
@@ -12,21 +12,66 @@ document.addEventListener('DOMContentLoaded', function () {
         return meta ? meta.content : '';
     }
 
-    document.getElementById('cookie-accept-all').addEventListener('click', function () {
-        fetch('/cookies/accept-all', {
+    /**
+     * The banner stays, because it is the only control that can record a
+     * choice — taking it away would leave the visitor no way to answer.
+     */
+    function choiceNotRecorded() {
+        var toast = window.ScoutMagicToast;
+        if (toast) {
+            toast.show(
+                "Votre choix n'a pas pu être enregistré. Rechargez la page et réessayez.",
+                { variant: 'error' }
+            );
+        }
+    }
+
+    // A refused POST must not look like a recorded choice.
+    //
+    // Both handlers used to remove the banner from inside
+    // `fetch(...).then(...)`, which runs for EVERY response the server
+    // sends — a 403 exactly as readily as a 200. A decision the server
+    // rejected therefore took the banner away just like an accepted one:
+    // the visitor saw their click land, nothing was stored, and the
+    // banner returned on the next page load with no explanation. For
+    // « Tout refuser » that is worse than cosmetic — a refusal is
+    // reported as registered when it was not, which is precisely the
+    // claim ePrivacy consent rests on.
+    //
+    // Found from the other side, and only because something else was
+    // being chased: a dynamic-security run caught
+    // POST /cookies/reject-all answering 403 while
+    // tests/e2e/support/cookie-banner.js still reporting success — its
+    // own comment claimed that waiting for the banner to go WAS waiting
+    // for the decision to be recorded. That claim is true now, and only
+    // because of this function: resolved is not succeeded.
+    /**
+     * @param {string} endpoint
+     * @param {() => void} [onRecorded] side effects that only become
+     *        true once the server has actually stored the choice
+     */
+    function recordChoice(endpoint, onRecorded) {
+        fetch(endpoint, {
             method: 'POST',
             headers: { 'X-CSRF-Token': getCsrf() }
-        }).then(function () {
+        }).then(function (response) {
+            if (!response.ok) {
+                choiceNotRecorded();
+                return;
+            }
             banner.remove();
-        });
+            if (onRecorded) {
+                onRecorded();
+            }
+        }).catch(choiceNotRecorded);
+    }
+
+    document.getElementById('cookie-accept-all').addEventListener('click', function () {
+        recordChoice('/cookies/accept-all');
     });
 
     document.getElementById('cookie-reject-all').addEventListener('click', function () {
-        fetch('/cookies/reject-all', {
-            method: 'POST',
-            headers: { 'X-CSRF-Token': getCsrf() }
-        }).then(function () {
-            banner.remove();
+        recordChoice('/cookies/reject-all', function () {
             // Withdrawing functional consent also withdraws the stored
             // theme preference (public/assets/js/theme.js — functional
             // category, declared in core/Cookie/CookieRegistry.php): the

--- a/tests/e2e/specs/rental-request.spec.js
+++ b/tests/e2e/specs/rental-request.spec.js
@@ -83,7 +83,7 @@ const PROPOSED_DEPARTURE = isoDaysFromNow(69);
 const PROPOSAL_MESSAGE = 'Ces dates-là nous arrangeraient mieux, le local est pris la semaine avant.';
 
 test.describe('Rentals', () => {
-    test('an admin creates a hall and a visitor asks to rent it', async ({ page }) => {
+    test('an admin creates a hall and a visitor asks to rent it', async ({ page, browser }) => {
         // --- The unit puts a hall online. ---
         await loginAsAdmin(page);
         await page.goto('/admin/locations');
@@ -119,54 +119,72 @@ test.describe('Rentals', () => {
 
 
         // --- A stranger, with no account at all. ---
-        await page.context().clearCookies();
-        await page.goto('/locations');
+        // Their own browser context, not this one with its cookies
+        // cleared. The two identities used to share a context and take
+        // turns in it — clearCookies() to become the stranger,
+        // loginAsAdmin() to become the unit again — and a session is not
+        // something a page can put down and pick back up: a form renders
+        // with the CSRF token of the session that drew it, and by the
+        // time it is submitted the OTHER identity has replaced that
+        // session. The POST is then refused, the page comes back
+        // unchanged, and the failure surfaces several assertions later as
+        // whatever the click was supposed to cause never happening.
+        //
+        // That is a real DAST failure, not a hypothesis: the accept below
+        // answered 302 into « Votre session a expirée » while
+        // POST /cookies/reject-all answered 403, and the trace showed five
+        // renders of the tracking page carrying five different CSRF
+        // tokens — five sessions, for one visitor who never logged in.
+        // Two contexts cannot do that to each other.
+        const renterContext = await browser.newContext();
+        const renter = await renterContext.newPage();
+        await renter.goto('/locations');
 
-        await expect(page.getByRole('heading', { name: 'Locations' })).toBeVisible();
-        const assetLink = page.getByRole('link', { name: ASSET_NAME }).first();
+        await expect(renter.getByRole('heading', { name: 'Locations' })).toBeVisible();
+        const assetLink = renter.getByRole('link', { name: ASSET_NAME }).first();
         await expect(assetLink).toBeVisible();
         await assetLink.click();
 
         // The public page says what the hall is and never who is in it
         // (§6.6) — the calendar shows occupancy, never a renter.
-        await expect(page.getByRole('heading', { name: ASSET_NAME })).toBeVisible();
+        await expect(renter.getByRole('heading', { name: ASSET_NAME })).toBeVisible();
 
         // The availability calendar has to be READABLE, not merely
         // present: see ../support/calendar.js for the failure mode this
         // rules out, which every markup assertion in the PHP suite is
         // blind to.
-        await expectRendersAsACalendar(page.locator('#rental-calendar .daygrid'));
+        await expectRendersAsACalendar(renter.locator('#rental-calendar .daygrid'));
 
         // Paging forward is a plain link — no account, no JavaScript
         // required — and the grid on the next month must render just as
         // well as the first one did.
-        await page.getByRole('link', { name: 'Mois suivant' }).click();
-        await expectRendersAsACalendar(page.locator('#rental-calendar .daygrid'));
+        await renter.getByRole('link', { name: 'Mois suivant' }).click();
+        await expectRendersAsACalendar(renter.locator('#rental-calendar .daygrid'));
 
         // And a visitor can never page into the past (§22.2): the control
         // is disabled rather than hidden, so they are told rather than
         // left wondering where it went.
-        await page.goto(`/locations/${ASSET_SLUG}`);
+        await renter.goto(`/locations/${ASSET_SLUG}`);
         await expect(
-            page.getByRole('button', { name: /Mois précédent/ }),
+            renter.getByRole('button', { name: /Mois précédent/ }),
         ).toBeDisabled();
 
-        await page.getByRole('link', { name: /demande/i }).first().click();
-        await expect(page.getByRole('heading', { name: new RegExp(ASSET_NAME) })).toBeVisible();
+        await renter.getByRole('link', { name: /demande/i }).first().click();
+        await expect(renter.getByRole('heading', { name: new RegExp(ASSET_NAME) })).toBeVisible();
 
         // --- The request itself. ---
-        await page.locator('input[name="arrival"]').fill(ARRIVAL);
-        await page.locator('input[name="departure"]').fill(DEPARTURE);
-        await page.locator('input[name="persons"]').fill('35');
-        await page.locator('input[name="name"]').fill('Jeanne Martin');
-        await page.locator('input[name="email"]').fill('jeanne.martin@example.be');
-        await page.locator('input[name="organisation"]').fill('Les Scouts de Nulle Part');
+        await renter.locator('input[name="arrival"]').fill(ARRIVAL);
+        await renter.locator('input[name="departure"]').fill(DEPARTURE);
+        await renter.locator('input[name="persons"]').fill('35');
+        await renter.locator('input[name="name"]').fill('Jeanne Martin');
+        await renter.locator('input[name="email"]').fill('jeanne.martin@example.be');
+        await renter.locator('input[name="organisation"]').fill('Les Scouts de Nulle Part');
 
         // Both are required, and both are an acknowledgement rather than a
         // consent: the unit cannot handle the request without the data,
         // and the box attests that the visitor was told (§6.13).
-        await page.locator('input[name="accept_conditions"]').check();
-        await page.locator('input[name="accept_privacy"]').check();
+        await renter.locator('input[name="accept_conditions"]').check();
+        await renter.locator('input[name="accept_privacy"]').check();
 
         // Core\Security\HumanCheck refuses a form submitted faster than a
         // human could have filled it — a real barrier, and one this
@@ -174,38 +192,38 @@ test.describe('Rentals', () => {
         // configure away. Waiting here is therefore part of what is being
         // tested: the public form is protected, and a genuine request still
         // gets through.
-        await page.waitForTimeout(4000);
+        await renter.waitForTimeout(4000);
 
-        await page.getByRole('button', { name: 'Envoyer ma demande' }).click();
+        await renter.getByRole('button', { name: 'Envoyer ma demande' }).click();
 
         // --- What the visitor gets back. ---
         // A reference they can quote, which is also what a reply's subject
         // line carries back (§7.6, level 1) — and the tracking page itself,
         // reached with no account and no session at all: the link in their
         // acknowledgement IS the authorisation (§6.26).
-        const heading = page.getByRole('heading', { name: /Votre demande LOC-\d{4}-\d+/ });
+        const heading = renter.getByRole('heading', { name: /Votre demande LOC-\d{4}-\d+/ });
         await expect(heading).toBeVisible();
         const reference = (await heading.textContent()).match(/LOC-\d{4}-\d+/)[0];
 
         // The dates are held while the unit answers, and the page says
         // until when rather than leaving the visitor guessing (§6.14).
-        await expect(page.getByText(/Dates bloquées/)).toBeVisible();
+        await expect(renter.getByText(/Dates bloquées/)).toBeVisible();
 
         // The link IS the authorisation (§6.26): no account, no session,
         // and it still opens on a cold browser. Keeping the URL and
         // clearing everything is the only way to say that honestly.
-        const trackingUrl = page.url();
-        await page.context().clearCookies();
-        await page.goto(trackingUrl);
-        await expect(page.getByRole('heading', { name: new RegExp(reference) })).toBeVisible();
+        const trackingUrl = renter.url();
+        await renter.context().clearCookies();
+        await renter.goto(trackingUrl);
+        await expect(renter.getByRole('heading', { name: new RegExp(reference) })).toBeVisible();
 
         // A neighbouring id with the same token is refused — the id is
         // right there in the URL, so only the token may decide.
-        await page.goto(trackingUrl.replace(/\/(\d+)\//, (_, id) => `/${Number(id) + 1}/`));
-        await expect(page.getByRole('heading', { name: new RegExp(reference) })).toHaveCount(0);
+        await renter.goto(trackingUrl.replace(/\/(\d+)\//, (_, id) => `/${Number(id) + 1}/`));
+        await expect(renter.getByRole('heading', { name: new RegExp(reference) })).toHaveCount(0);
 
         // --- And what the unit sees. ---
-        await loginAsAdmin(page);
+        // Still signed in: nothing dropped this session in the meantime.
         await page.goto('/mes-locations');
 
         await expect(page.getByText(ASSET_NAME).first()).toBeVisible();
@@ -225,18 +243,17 @@ test.describe('Rentals', () => {
         await comment.getByRole('button', { name: 'Enregistrer' }).click();
         await expect(page.getByText(INTERNAL_NOTE)).toBeVisible();
 
-        await page.context().clearCookies();
-        await page.goto(trackingUrl);
+        await renter.context().clearCookies();
+        await renter.goto(trackingUrl);
 
-        await expect(page.getByRole('heading', { name: new RegExp(reference) })).toBeVisible();
-        await expect(page.locator('body')).not.toContainText(INTERNAL_NOTE);
+        await expect(renter.getByRole('heading', { name: new RegExp(reference) })).toBeVisible();
+        await expect(renter.locator('body')).not.toContainText(INTERNAL_NOTE);
 
         // --- The negotiation: the unit proposes, the renter decides. ---
         // Nothing a manager proposes changes the booking on its own —
         // that is the whole rule (§6.16), and it is only observable by
         // crossing the boundary twice: written by an authenticated
         // manager, answered by an anonymous browser holding a link.
-        await loginAsAdmin(page);
         await page.goto(`/mes-locations/${ASSET_SLUG}/reservations`);
         await page.getByRole('link', { name: new RegExp(reference) }).first().click();
 
@@ -252,43 +269,42 @@ test.describe('Rentals', () => {
         await expect(page.getByText(/En attente/).first()).toBeVisible();
 
         // --- The renter, with no account and no session. ---
-        await page.context().clearCookies();
-        await page.goto(trackingUrl);
+        await renter.context().clearCookies();
+        await renter.goto(trackingUrl);
 
         // The proposal is put to them in words, with what it costs to
         // ignore it spelled out.
-        await expect(page.getByText(/L'unité vous propose ces dates/)).toBeVisible();
-        await expect(page.getByText(/votre réservation reste inchangée/i)).toBeVisible();
+        await expect(renter.getByText(/L'unité vous propose ces dates/)).toBeVisible();
+        await expect(renter.getByText(/votre réservation reste inchangée/i)).toBeVisible();
 
         // --- And the booking has NOT moved. ---
         // Asserted on the « Votre séjour » block rather than on the page
         // as a whole, precisely because the proposed dates ARE already on
         // the page — inside the proposal being put to them. What must not
         // have changed is the booking, and the booking is that <dd>.
-        await expect(stayDates(page)).toContainText(frenchDate(DEPARTURE));
-        await expect(stayDates(page)).not.toContainText(frenchDate(PROPOSED_DEPARTURE));
+        await expect(stayDates(renter)).toContainText(frenchDate(DEPARTURE));
+        await expect(stayDates(renter)).not.toContainText(frenchDate(PROPOSED_DEPARTURE));
 
         // `exact` because the cookie banner's « Tout accepter » is a
         // substring match away, and it stands in front of the page anyway
         // — answering it first is not housekeeping (see
         // ../support/cookie-banner.js).
-        await answerCookieBanner(page);
-        await page.getByRole('button', { name: 'Accepter', exact: true }).click();
+        await answerCookieBanner(renter);
+        await renter.getByRole('button', { name: 'Accepter', exact: true }).click();
 
         // --- And now it has. ---
         // The dates in « Votre séjour » are ones this booking never had,
         // the proposal is closed, and the button that closed it is gone —
         // three things that could not have been true a moment ago.
-        await expect(stayDates(page)).toContainText(frenchDate(PROPOSED_DEPARTURE));
-        await expect(stayDates(page)).not.toContainText(frenchDate(DEPARTURE));
-        await expect(page.getByText('Acceptée').first()).toBeVisible();
-        await expect(page.getByRole('button', { name: 'Accepter', exact: true })).toHaveCount(0);
+        await expect(stayDates(renter)).toContainText(frenchDate(PROPOSED_DEPARTURE));
+        await expect(stayDates(renter)).not.toContainText(frenchDate(DEPARTURE));
+        await expect(renter.getByText('Acceptée').first()).toBeVisible();
+        await expect(renter.getByRole('button', { name: 'Accepter', exact: true })).toHaveCount(0);
 
         // --- The unit sees the same booking, moved. ---
         // Which is what says the DECISION reached the database rather
         // than only the page that rendered it: a different session, a
         // different template, the same dates.
-        await loginAsAdmin(page);
         await page.goto(`/mes-locations/${ASSET_SLUG}/reservations`);
         await page.getByRole('link', { name: new RegExp(reference) }).first().click();
 
@@ -299,6 +315,8 @@ test.describe('Rentals', () => {
         // like every other per-entity timeline on the site (§8.66).
         await expect(page.locator('.audit-timeline')).toBeVisible();
         await expect(page.getByText(/Décision sur la modification/).first()).toBeVisible();
+
+        await renterContext.close();
     });
 });
 

--- a/tests/e2e/support/cookie-banner.js
+++ b/tests/e2e/support/cookie-banner.js
@@ -32,8 +32,18 @@ export async function answerCookieBanner(page, options = {}) {
     await expect(banner).toBeVisible();
     await page.getByRole('button', { name: options.accept ? 'Tout accepter' : 'Tout refuser' }).click();
 
-    // cookie-consent.js hides the banner only once its POST has resolved,
-    // so waiting for it to go is waiting for the decision to be recorded —
-    // never a fixed delay.
+    // cookie-consent.js removes the banner only once its POST has come
+    // back OK, so waiting for it to go is waiting for the decision to be
+    // recorded — never a fixed delay.
+    //
+    // That second clause was false until the fix that added this note.
+    // The banner used to be removed from inside `fetch(...).then(...)`,
+    // which runs for every response the server sends: a dynamic-security
+    // run caught POST /cookies/reject-all answering 403 with this helper
+    // reporting success, and the scenario failing forty seconds later on
+    // the unrelated-looking assertion that came next. Resolved is not
+    // succeeded — the banner surviving is now a real signal, so if this
+    // ever times out, read it as "the server refused the choice", not as
+    // "the banner is slow".
     await expect(banner).toBeHidden();
 }

--- a/tests/js/cookie-consent.test.js
+++ b/tests/js/cookie-consent.test.js
@@ -63,6 +63,68 @@ describe('cookie-consent.js', () => {
         expect(fetch).not.toHaveBeenCalled();
     });
 
+    // The banner disappearing is what tells a visitor their choice was
+    // recorded, so it must never outrun the server actually recording it.
+    // Both handlers used to remove it from inside `fetch().then()`, which
+    // runs for a 403 as readily as a 200 — a refused decision looked
+    // exactly like an accepted one. A dynamic-security run caught
+    // POST /cookies/reject-all answering 403 with the banner gone anyway.
+    // Every case below was red against that implementation.
+    describe('when the server refuses the choice', () => {
+        beforeEach(() => {
+            global.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 403 }));
+            window.ScoutMagicToast = { show: vi.fn() };
+        });
+
+        it('keeps the banner when the POST is refused, so the choice can still be made', async () => {
+            renderBanner();
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+
+            document.getElementById('cookie-reject-all').click();
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+
+            expect(document.getElementById('cookie-banner')).not.toBeNull();
+        });
+
+        it('says so rather than failing silently', async () => {
+            renderBanner();
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+
+            document.getElementById('cookie-accept-all').click();
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+
+            expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
+                expect.stringContaining("n'a pas pu être enregistré"),
+                expect.objectContaining({ variant: 'error' })
+            );
+        });
+
+        // Withdrawing consent purges the theme preference and tells the
+        // service worker to stop caching. Doing that on a refused refusal
+        // would act on a decision the server never stored.
+        it('does not withdraw the stored theme preference when the refusal was not recorded', async () => {
+            renderBanner();
+            localStorage.setItem('theme_preference', 'sombre');
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+
+            document.getElementById('cookie-reject-all').click();
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+
+            expect(localStorage.getItem('theme_preference')).toBe('sombre');
+        });
+
+        it('keeps the banner when the network fails outright', async () => {
+            global.fetch = vi.fn(() => Promise.reject(new Error('network down')));
+            renderBanner();
+            document.dispatchEvent(new Event('DOMContentLoaded'));
+
+            document.getElementById('cookie-accept-all').click();
+            await vi.waitFor(() => expect(window.ScoutMagicToast.show).toHaveBeenCalled());
+
+            expect(document.getElementById('cookie-banner')).not.toBeNull();
+        });
+    });
+
     it('sends the CSRF token header from the page meta tag when accepting', async () => {
         renderBanner();
         const meta = document.createElement('meta');


### PR DESCRIPTION
Deux corrections issues de l'analyse du dernier échec restant du job DAST — celui qui subsistait derrière la course d'overlay Bootstrap corrigée par #122.

## Le bug produit : une bannière qui disparaît sans que rien ne soit enregistré

`public/assets/js/cookie-consent.js` retirait la bannière depuis l'intérieur de `fetch(...).then(...)`, qui s'exécute pour **toute** réponse du serveur — un 403 aussi bien qu'un 200. Un choix refusé par le serveur faisait donc disparaître la bannière exactement comme un choix accepté : le visiteur voyait son clic aboutir, rien n'était stocké, et la bannière revenait au chargement suivant sans explication.

Pour « Tout refuser », ce n'est pas cosmétique : un refus est annoncé comme enregistré alors qu'il ne l'est pas, et cette annonce est précisément ce sur quoi repose le consentement ePrivacy. Le retrait du consentement fonctionnel purge par ailleurs la préférence de thème et demande au service worker de cesser de mettre en cache — ces effets s'appliquaient à une décision que le serveur avait refusé d'enregistrer.

Désormais : la bannière ne disparaît que sur une réponse `ok`, elle survit à un refus (c'est le seul contrôle qui permet de faire un choix), et un toast d'erreur le dit au lieu d'échouer en silence.

Les quatre nouveaux cas Vitest sont **rouges** contre l'implémentation précédente.

## Le test : le locataire obtient son propre navigateur

`tests/e2e/specs/rental-request.spec.js` jouait les deux identités dans **un seul** contexte, en alternant `clearCookies()` pour devenir l'inconnu et `loginAsAdmin()` pour redevenir l'unité, cinq fois de suite. Une session n'est pas quelque chose qu'une page peut poser puis reprendre : un formulaire est rendu avec le jeton CSRF de la session qui l'a dessiné, et au moment de l'envoi l'autre identité a remplacé cette session. Le POST est refusé, la page revient inchangée, et l'échec ne se manifeste que plusieurs assertions plus loin.

La trace le montre plutôt qu'elle ne le suggère : l'acceptation répondait 302 vers « Votre session a expirée », `POST /cookies/reject-all` répondait 403, et cinq rendus de la même page de suivi portaient cinq jetons CSRF différents — cinq sessions, pour un visiteur qui ne s'est jamais connecté.

Le locataire a maintenant son propre contexte, créé une fois et fermé à la fin. Deux contextes ne peuvent pas se retirer mutuellement leur session : la forme du bug disparaît au lieu de devenir moins probable. L'administrateur conserve une seule session, ce qui supprime trois reconnexions qui n'existaient que pour réparer les `clearCookies()`.

## Vérifications effectuées

- `npm run typecheck` — propre, `js-typecheck-baseline.json` inchangé (toujours `{}`).
- `npx vitest run` — 1696 tests, 98 fichiers, tous verts.
- `./scripts/e2e.sh specs/rental-request.spec.js` — **quatre exécutions consécutives**, chacune sur une instance fraîchement provisionnée : 13,5 s / 13,7 s / 14,2 s / 13,8 s.
- Aucun changement PHP, donc pas de PHPStan à faire tourner.

Aucun problème de compatibilité ascendante : aucun changement de schéma, de configuration ni de comportement serveur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF