### PR TITLE
Maintenance : borner l'historique à cinq lignes et les notes de version à un écran

### DIFF
--- a/core/View/templates/config/maintenance.html.twig
+++ b/core/View/templates/config/maintenance.html.twig
@@ -129,7 +129,11 @@
                 {% endif %}
             </p>
             {% if installed_version_notes %}
-                <div class="small text-body-secondary mb-1">{{ installed_version_notes|markdown }}</div>
+                {% include 'partials/clampable_notes.html.twig' with {
+                    id: 'installed-version-notes',
+                    notes: installed_version_notes,
+                    classes: 'small text-body-secondary mb-1'
+                } only %}
             {% endif %}
             <p class="small text-body-secondary">
                 Dernière vérification :
@@ -174,7 +178,11 @@
                         {% endif %}
                     </p>
                     {% if update_release_notes %}
-                        <div class="small mb-2">{{ update_release_notes|markdown }}</div>
+                        {% include 'partials/clampable_notes.html.twig' with {
+                            id: 'update-release-notes',
+                            notes: update_release_notes,
+                            classes: 'small mb-2'
+                        } only %}
                     {% endif %}
                     {% if update_dependencies_changed %}
                         <div class="alert alert-warning small mb-2">
@@ -211,28 +219,35 @@
                                 <th>Statut</th>
                             </tr>
                         </thead>
+                        {# Five, then the rest on demand. The page's job is
+                           "install the update in front of me"; twenty rows of
+                           history pushed that below the fold. The rows beyond
+                           the fifth are rendered all the same — the controller
+                           already fetched them, and a reader who opens the list
+                           should not wait for a round trip. #}
                         <tbody>
-                            {% for entry in update_history %}
-                                <tr>
-                                    <td class="small text-nowrap">{{ entry.versionFrom }} → {{ entry.versionTo }}</td>
-                                    <td class="small text-nowrap">{{ entry.startedAt }}</td>
-                                    <td class="small">
-                                        {% if entry.status == 'completed' %}
-                                            {% include 'partials/status_badge.html.twig' with { status: 'done', label: 'Réussie' } only %}
-                                        {% elseif entry.status == 'failed' %}
-                                            {# title tooltips (error detail) — kept out of the shared partial, which carries none #}
-                                            <span class="badge text-bg-danger" title="{{ entry.errorMessage }}">Échouée</span>
-                                        {% elseif entry.status == 'rolled_back' %}
-                                            <span class="badge text-bg-warning" title="{{ entry.errorMessage }}">Échouée — restaurée automatiquement</span>
-                                        {% else %}
-                                            {% include 'partials/status_badge.html.twig' with { status: 'in_progress', label: 'En cours (' ~ entry.status ~ ')' } only %}
-                                        {% endif %}
-                                    </td>
-                                </tr>
+                            {% for entry in update_history|slice(0, 5) %}
+                                {% include 'partials/update_history_row.html.twig' with { entry: entry } only %}
                             {% endfor %}
                         </tbody>
+                        {% if update_history|length > 5 %}
+                            <tbody class="collapse" id="update-history-more">
+                                {% for entry in update_history|slice(5) %}
+                                    {% include 'partials/update_history_row.html.twig' with { entry: entry } only %}
+                                {% endfor %}
+                            </tbody>
+                        {% endif %}
                     </table>
                 </div>
+                {% if update_history|length > 5 %}
+                    <button type="button" class="btn btn-outline-secondary btn-sm mt-2 collapsed"
+                            data-bs-toggle="collapse" data-bs-target="#update-history-more"
+                            aria-expanded="false" aria-controls="update-history-more">
+                        <span class="show-when-collapsed">Afficher les {{ update_history|length - 5 }} précédentes</span>
+                        <span class="show-when-expanded">Afficher moins</span>
+                        <i class="bi bi-chevron-down ms-1" aria-hidden="true"></i>
+                    </button>
+                {% endif %}
             {% endif %}
         </div>
     </div>
@@ -683,4 +698,5 @@
 {% block scripts %}
     <script src="{{ asset('/assets/js/chunked-upload.js') }}" defer nonce="{{ csp_nonce }}"></script>
     <script src="{{ asset('/assets/js/maintenance.js') }}" defer nonce="{{ csp_nonce }}"></script>
+    <script src="{{ asset('/assets/js/notes-clamp.js') }}" defer nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/core/View/templates/partials/clampable_notes.html.twig
+++ b/core/View/templates/partials/clampable_notes.html.twig
@@ -1,0 +1,33 @@
+{# Release notes, bounded to about twenty lines with « voir plus ».
+
+   Author-written Markdown of no fixed length: a patch ships two lines, a
+   release that lands a module ships several screens. Configuration >
+   Maintenance renders two of these at once (installed version, available
+   version), and unbounded they pushed the install button and the update
+   history below the fold.
+
+   The clamp is CSS (`.notes-clamp`, app.css) — height rather than a line
+   count, because this is RENDERED Markdown and cutting twenty lines of
+   source would cut mid-element. The button ships `hidden` and is revealed
+   by public/assets/js/notes-clamp.js only when the block really overflows:
+   a two-line note must not grow a button that reveals nothing.
+
+   Parameters (pass `only`):
+     id       unique, used to tie block and button together
+     notes    the Markdown source
+     classes  utility classes for the block (typography, spacing) #}
+<div class="notes-clamp {{ classes|default('') }}"
+     id="{{ id }}"
+     data-notes-clamp="{{ id }}-toggle">{{ notes|markdown }}</div>
+<button type="button"
+        class="btn btn-link btn-sm p-0 mb-2"
+        id="{{ id }}-toggle"
+        data-notes-clamp-toggle
+        aria-controls="{{ id }}"
+        aria-expanded="false"
+        data-label-collapsed="Voir la description complète"
+        data-label-expanded="Réduire la description"
+        hidden>
+    <span data-notes-clamp-label>Voir la description complète</span>
+    <i class="bi bi-chevron-down ms-1" aria-hidden="true"></i>
+</button>

--- a/core/View/templates/partials/update_history_row.html.twig
+++ b/core/View/templates/partials/update_history_row.html.twig
@@ -1,0 +1,22 @@
+{# One row of Configuration > Maintenance's update history.
+
+   Extracted because the table is rendered in two <tbody> elements — the
+   five most recent, then the rest behind a Bootstrap collapse — and two
+   copies of a status ladder is two places for it to drift. Expects a
+   single `entry` (Core\Maintenance\UpdateHistory), passed `only`. #}
+<tr>
+    <td class="small text-nowrap">{{ entry.versionFrom }} → {{ entry.versionTo }}</td>
+    <td class="small text-nowrap">{{ entry.startedAt }}</td>
+    <td class="small">
+        {% if entry.status == 'completed' %}
+            {% include 'partials/status_badge.html.twig' with { status: 'done', label: 'Réussie' } only %}
+        {% elseif entry.status == 'failed' %}
+            {# title tooltips (error detail) — kept out of the shared partial, which carries none #}
+            <span class="badge text-bg-danger" title="{{ entry.errorMessage }}">Échouée</span>
+        {% elseif entry.status == 'rolled_back' %}
+            <span class="badge text-bg-warning" title="{{ entry.errorMessage }}">Échouée — restaurée automatiquement</span>
+        {% else %}
+            {% include 'partials/status_badge.html.twig' with { status: 'in_progress', label: 'En cours (' ~ entry.status ~ ')' } only %}
+        {% endif %}
+    </td>
+</tr>

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -844,3 +844,40 @@ body:has(> #cookie-banner) {
 .passage-stats-gender {
     height: 0.375rem;
 }
+
+/* ============================================================
+   Bornage des blocs qui grandissent tout seuls (§7.6)
+   ============================================================ */
+
+/* Notes de version : hauteur, pas nombre de lignes. Le contenu est du
+   Markdown rendu (titres, listes, blocs de code ont chacun leur propre
+   boîte de ligne), donc découper 20 lignes de source côté serveur
+   couperait au milieu d'un élément. 30em ≈ 20 lignes à la hauteur de
+   ligne Bootstrap (1.5). Bootstrap n'a pas d'équivalent multiligne de
+   .text-truncate : c'est la raison d'être de ces quelques lignes.
+   Le dégradé signale qu'il reste du texte ; public/assets/js/notes-clamp.js
+   retire la classe quand le contenu tient déjà. */
+.notes-clamp:not(.is-expanded) {
+    max-height: 30em;
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(to bottom, #000 82%, transparent 100%);
+            mask-image: linear-gradient(to bottom, #000 82%, transparent 100%);
+}
+
+/* Étiquette d'un déclencheur Bootstrap Collapse : c'est Bootstrap qui
+   pose et retire .collapsed sur le bouton, donc l'échange « Afficher /
+   Réduire » ne demande aucun JavaScript. */
+[data-bs-toggle="collapse"].collapsed .show-when-expanded,
+[data-bs-toggle="collapse"]:not(.collapsed) .show-when-collapsed {
+    display: none;
+}
+
+[data-bs-toggle="collapse"] .bi-chevron-down,
+[data-notes-clamp-toggle] .bi-chevron-down {
+    transition: transform 0.2s ease;
+}
+
+[data-bs-toggle="collapse"]:not(.collapsed) .bi-chevron-down,
+[data-notes-clamp-toggle][aria-expanded="true"] .bi-chevron-down {
+    transform: rotate(180deg);
+}

--- a/public/assets/js/notes-clamp.js
+++ b/public/assets/js/notes-clamp.js
@@ -1,0 +1,84 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+// « Show me the first twenty lines, and a button if there is more. »
+//
+// Release notes are author-written Markdown of no fixed length: a patch
+// release ships two lines, a version that lands a whole module ships
+// several screens of them, and Configuration > Maintenance renders two of
+// these blocks at once (the installed version's and the available one's).
+// Left unbounded they pushed the install button, the dependency warning
+// and the update history far below the fold — on the one page an
+// administrator opens precisely to reach those.
+//
+// The clamp itself is CSS (`.notes-clamp` in app.css): height, not line
+// count, because the content is rendered Markdown — headings, lists and
+// code blocks all have their own line box, so counting source lines
+// server-side would cut mid-element and produce broken HTML.
+//
+// What needs JavaScript is only the question CSS cannot answer: DID it
+// overflow? A three-line note must not grow a « Voir la description
+// complète » button that reveals nothing. So the button ships hidden and
+// is revealed here, per block, after measuring.
+(function () {
+    /**
+     * A clamped block whose content is taller than the clamp lets show.
+     *
+     * The tolerance absorbs sub-pixel rounding: a block whose content is
+     * a fraction of a pixel taller than its box is NOT overflowing in any
+     * sense a reader would notice, and revealing a button for it is the
+     * failure mode this whole function exists to avoid.
+     *
+     * @param {HTMLElement} block
+     * @returns {boolean}
+     */
+    function overflows(block) {
+        return block.scrollHeight - block.clientHeight > 2;
+    }
+
+    /**
+     * @param {HTMLElement} block
+     * @param {HTMLElement} button
+     */
+    function wire(block, button) {
+        if (!overflows(block)) {
+            // Nothing hidden: drop the clamp so the block is never a box
+            // with a fade over content that already fits, and leave the
+            // button hidden.
+            block.classList.remove('notes-clamp');
+            return;
+        }
+
+        button.hidden = false;
+
+        var collapsedLabel = button.dataset.labelCollapsed || button.textContent || '';
+        var expandedLabel = button.dataset.labelExpanded || collapsedLabel;
+        var label = button.querySelector('[data-notes-clamp-label]');
+
+        button.addEventListener('click', function () {
+            var expanded = block.classList.toggle('is-expanded');
+            button.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            if (label) {
+                label.textContent = expanded ? expandedLabel : collapsedLabel;
+            }
+        });
+    }
+
+    /**
+     * Markup-driven, like reveal-details.js: a block declares that it is
+     * clampable and names its button, so a third screen needing this
+     * needs no JavaScript of its own.
+     *
+     *   <div class="notes-clamp" data-notes-clamp="update-notes-toggle">…</div>
+     *   <button id="update-notes-toggle" hidden …>
+     */
+    document.querySelectorAll('[data-notes-clamp]').forEach(function (node) {
+        var block = /** @type {HTMLElement} */ (node);
+        var button = document.getElementById(block.dataset.notesClamp || '');
+        if (button) {
+            wire(block, /** @type {HTMLElement} */ (button));
+        }
+    });
+})();

--- a/tests/Core/Http/Controller/MaintenanceControllerTest.php
+++ b/tests/Core/Http/Controller/MaintenanceControllerTest.php
@@ -1644,6 +1644,62 @@ class MaintenanceControllerTest extends TestCase
         $this->assertTrue($this->updateHistoryRepository->findById($decoded['history_id'])->dependenciesChanged);
     }
 
+    // --- update history: five rows, then the rest on demand ---
+
+    private function seedUpdateHistory(int $count): void
+    {
+        for ($i = 0; $i < $count; $i++) {
+            $this->updateHistoryRepository->markCompleted(
+                $this->updateHistoryRepository->create('1.0.' . $i, '1.0.' . ($i + 1), false, null)
+            );
+        }
+    }
+
+    public function testTheUpdateHistoryShowsFiveRowsAndHidesTheRestBehindAButton(): void
+    {
+        // The page exists to install an update; twenty rows of history
+        // pushed the install button below the fold.
+        $this->seedUpdateHistory(8);
+
+        $body = $this->controller->index(new Request('GET', '/config/maintenance', [], [], [], []), [])->getBody();
+
+        // The extra rows ARE rendered — the controller already fetched
+        // them, so opening the list must not cost a round trip — but they
+        // sit in a collapsed tbody.
+        $this->assertStringContainsString('id="update-history-more"', $body);
+        $this->assertStringContainsString('class="collapse"', $body);
+        $this->assertStringContainsString('Afficher les 3 précédentes', $body);
+        // Nine: the eight entries plus the table's own header row.
+        $this->assertSame(9, substr_count($body, '<tr>'), 'every entry is rendered, five of them visible');
+    }
+
+    public function testAShortUpdateHistoryGrowsNoButtonAtAll(): void
+    {
+        $this->seedUpdateHistory(4);
+
+        $body = $this->controller->index(new Request('GET', '/config/maintenance', [], [], [], []), [])->getBody();
+
+        $this->assertStringNotContainsString('id="update-history-more"', $body);
+        $this->assertStringNotContainsString('précédentes', $body);
+    }
+
+    public function testReleaseNotesAreClampedWithATogglePreparedButHidden(): void
+    {
+        // The button ships hidden: notes-clamp.js reveals it only for a
+        // block that really overflows, so a two-line note never grows a
+        // button that would reveal nothing.
+        $this->settingService->set('update_latest_version', '99.0.0');
+        $this->settingService->set('update_download_url', 'https://github.com/owner/repo/releases/download/v99.0.0/release.zip');
+        $this->settingService->set('update_release_notes', str_repeat("Une ligne de notes.\n\n", 40));
+        $this->settingService->clearCache();
+
+        $body = $this->controller->index(new Request('GET', '/config/maintenance', [], [], [], []), [])->getBody();
+
+        $this->assertStringContainsString('data-notes-clamp="update-release-notes-toggle"', $body);
+        $this->assertStringContainsString('Voir la description complète', $body);
+        $this->assertStringContainsString('notes-clamp.js', $body);
+    }
+
     public function testIndexShowsTheWebhookWarningWhenDevLevelEnabledButWebhookNotConfigured(): void
     {
         $this->settingService->set('auto_update_enabled', '1');

--- a/tests/js/notes-clamp.test.js
+++ b/tests/js/notes-clamp.test.js
@@ -1,0 +1,100 @@
+// Isolated JavaScript unit test — jsdom-simulated DOM only. Exercises
+// the REAL implementation in public/assets/js/notes-clamp.js (imported
+// below, never reimplemented here).
+//
+// jsdom does no layout, so scrollHeight/clientHeight are both 0 on every
+// element: each test defines them explicitly, which is also the only
+// honest way to state the case under test ("content taller than its box"
+// / "content that fits"). That measurement is the whole point of the
+// module — the clamp itself is CSS.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const MARKUP = `
+    <div class="notes-clamp" id="notes" data-notes-clamp="notes-toggle">
+        <p>Des notes de version potentiellement très longues.</p>
+    </div>
+    <button type="button" id="notes-toggle" hidden aria-expanded="false"
+            data-label-collapsed="Voir la description complète"
+            data-label-expanded="Réduire la description">
+        <span data-notes-clamp-label>Voir la description complète</span>
+    </button>`;
+
+/**
+ * @param {HTMLElement} el
+ * @param {{scrollHeight: number, clientHeight: number}} box
+ */
+function measure(el, box) {
+    Object.defineProperty(el, 'scrollHeight', { value: box.scrollHeight, configurable: true });
+    Object.defineProperty(el, 'clientHeight', { value: box.clientHeight, configurable: true });
+}
+
+/** @param {{scrollHeight: number, clientHeight: number}} box */
+async function load(box) {
+    document.body.innerHTML = MARKUP;
+    measure(/** @type {HTMLElement} */ (document.getElementById('notes')), box);
+    vi.resetModules();
+    await import('../../public/assets/js/notes-clamp.js');
+
+    return {
+        block: /** @type {HTMLElement} */ (document.getElementById('notes')),
+        button: /** @type {HTMLButtonElement} */ (document.getElementById('notes-toggle')),
+        label: /** @type {HTMLElement} */ (document.querySelector('[data-notes-clamp-label]')),
+    };
+}
+
+describe('notes-clamp.js', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('reveals the button when the notes are taller than the clamp', async () => {
+        const { button, block } = await load({ scrollHeight: 900, clientHeight: 480 });
+
+        expect(button.hidden).toBe(false);
+        expect(block.classList.contains('notes-clamp')).toBe(true);
+    });
+
+    it('drops the clamp and keeps the button hidden when everything already fits', async () => {
+        // A two-line patch note: a button revealing nothing is worse than
+        // no button, and a fade over content that fits is a lie.
+        const { button, block } = await load({ scrollHeight: 120, clientHeight: 120 });
+
+        expect(button.hidden).toBe(true);
+        expect(block.classList.contains('notes-clamp')).toBe(false);
+    });
+
+    it('treats a sub-pixel difference as fitting, not as overflow', async () => {
+        const { button } = await load({ scrollHeight: 481, clientHeight: 480 });
+
+        expect(button.hidden).toBe(true);
+    });
+
+    it('expands on click, and says so to assistive technology', async () => {
+        const { block, button, label } = await load({ scrollHeight: 900, clientHeight: 480 });
+
+        button.click();
+
+        expect(block.classList.contains('is-expanded')).toBe(true);
+        expect(button.getAttribute('aria-expanded')).toBe('true');
+        expect(label.textContent).toBe('Réduire la description');
+    });
+
+    it('collapses again on a second click', async () => {
+        const { block, button, label } = await load({ scrollHeight: 900, clientHeight: 480 });
+
+        button.click();
+        button.click();
+
+        expect(block.classList.contains('is-expanded')).toBe(false);
+        expect(button.getAttribute('aria-expanded')).toBe('false');
+        expect(label.textContent).toBe('Voir la description complète');
+    });
+
+    it('ignores a block whose named button does not exist', async () => {
+        document.body.innerHTML = `<div class="notes-clamp" id="orphan" data-notes-clamp="nope"></div>`;
+        measure(/** @type {HTMLElement} */ (document.getElementById('orphan')), { scrollHeight: 900, clientHeight: 480 });
+        vi.resetModules();
+
+        await expect(import('../../public/assets/js/notes-clamp.js')).resolves.toBeDefined();
+    });
+});


### PR DESCRIPTION
## Description

Configuration > Maintenance existe pour installer une mise à jour, et deux blocs y grandissent sans borne : l'historique (vingt lignes depuis que la série d'échecs a rendu une liste longue utile) et les notes de version — du Markdown d'auteur sans longueur fixe, dont la page affiche **deux** blocs à la fois (version installée et version disponible). Ensemble, ils repoussaient le bouton d'installation, l'avertissement sur les dépendances et l'historique lui-même sous la ligne de flottaison.

**Historique** — les cinq plus récentes, puis « Afficher les N précédentes » sur un collapse Bootstrap. Les lignes restantes sont rendues quand même (le contrôleur les a déjà chargées : ouvrir la liste ne coûte aucun aller-retour), et le balisage d'une ligne part dans `partials/update_history_row.html.twig` pour que les deux `<tbody>` ne puissent pas diverger. L'échange d'étiquette « Afficher / Réduire » est du CSS pur : Bootstrap pose et retire `.collapsed` sur le déclencheur lui-même.

**Notes de version** — bornées à environ vingt lignes avec « Voir la description complète », sur les deux blocs.

Deux choix qui ne vont pas de soi :

- **La borne est une hauteur, pas un compte de lignes.** C'est du Markdown *rendu* : titres, listes et blocs de code ont chacun leur boîte de ligne, donc découper vingt lignes de source côté serveur couperait au milieu d'un élément et produirait du HTML cassé. 30em ≈ vingt lignes à la hauteur de ligne Bootstrap, avec un dégradé qui signale qu'il reste du texte. Bootstrap n'a pas d'équivalent multiligne de `.text-truncate` — d'où ces quelques lignes de CSS, qui ne dupliquent aucun composant.
- **Le bouton n'apparaît que s'il y a vraiment quelque chose à révéler.** CSS ne sait pas répondre à « est-ce que ça déborde ? » : c'est tout le rôle de `public/assets/js/notes-clamp.js`, qui mesure, révèle le bouton le cas échéant, et **retire** la borne sinon. Une note de deux lignes ne récolte donc ni bouton inutile ni dégradé mensonger.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — `tests/js/notes-clamp.test.js` (6 cas : débordement, contenu qui tient, différence sub-pixel, expansion, repli, bouton absent) ; suite JS complète 1703/1703 ; `npm run typecheck` sans nouvelle trouvaille

Tests PHP ajoutés : cinq lignes visibles et le reste replié, aucun bouton sous cinq entrées, bouton de notes préparé mais masqué. `UxConventionsTest` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkYeu7kMMWqK9Knmd1aCHP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkYeu7kMMWqK9Knmd1aCHP)_