### PR TITLE
Le bouton d'historique affichait ses deux libellés à la fois

### DIFF
--- a/core/View/templates/config/maintenance.html.twig
+++ b/core/View/templates/config/maintenance.html.twig
@@ -242,9 +242,9 @@
                 {% if update_history|length > 5 %}
                     <button type="button" class="btn btn-outline-secondary btn-sm mt-2 collapsed"
                             data-bs-toggle="collapse" data-bs-target="#update-history-more"
-                            aria-expanded="false" aria-controls="update-history-more">
-                        <span class="show-when-collapsed">Afficher les {{ update_history|length - 5 }} précédentes</span>
-                        <span class="show-when-expanded">Afficher moins</span>
+                            aria-expanded="false" aria-controls="update-history-more"
+                            data-collapse-label-expanded="Afficher moins">
+                        <span data-collapse-label>Afficher les {{ update_history|length - 5 }} précédentes</span>
                         <i class="bi bi-chevron-down ms-1" aria-hidden="true"></i>
                     </button>
                 {% endif %}
@@ -699,4 +699,5 @@
     <script src="{{ asset('/assets/js/chunked-upload.js') }}" defer nonce="{{ csp_nonce }}"></script>
     <script src="{{ asset('/assets/js/maintenance.js') }}" defer nonce="{{ csp_nonce }}"></script>
     <script src="{{ asset('/assets/js/notes-clamp.js') }}" defer nonce="{{ csp_nonce }}"></script>
+    <script src="{{ asset('/assets/js/collapse-label.js') }}" defer nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -864,14 +864,6 @@ body:has(> #cookie-banner) {
             mask-image: linear-gradient(to bottom, #000 82%, transparent 100%);
 }
 
-/* Étiquette d'un déclencheur Bootstrap Collapse : c'est Bootstrap qui
-   pose et retire .collapsed sur le bouton, donc l'échange « Afficher /
-   Réduire » ne demande aucun JavaScript. */
-[data-bs-toggle="collapse"].collapsed .show-when-expanded,
-[data-bs-toggle="collapse"]:not(.collapsed) .show-when-collapsed {
-    display: none;
-}
-
 [data-bs-toggle="collapse"] .bi-chevron-down,
 [data-notes-clamp-toggle] .bi-chevron-down {
     transition: transform 0.2s ease;

--- a/public/assets/js/collapse-label.js
+++ b/public/assets/js/collapse-label.js
@@ -1,0 +1,47 @@
+/*!
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+// « Afficher les 15 précédentes » ⇄ « Afficher moins » on a Bootstrap
+// collapse trigger.
+//
+// Bootstrap toggles `.collapsed` and `aria-expanded` on the trigger
+// itself, so the obvious implementation is two spans and one CSS rule
+// hiding whichever one does not apply. That is what shipped, and
+// production showed why it is the wrong call HERE: `/assets/css/app.css`
+// is part of the service worker's app shell and is matched with
+// `ignoreSearch` (see public/sw.js), so its `?v=` cache-buster does NOT
+// force a refetch — until the previous worker is released, a page can
+// legitimately render NEW html against the PREVIOUS stylesheet. A
+// CSS-only swap then fails by showing both labels at once, and the
+// button reads « Afficher les 15 précédentes Afficher moins ».
+//
+// So the label lives in the markup exactly once, and this file — not
+// precached, therefore never stale — swaps its text. Degradation is the
+// point: if this script never runs, the button still reads correctly in
+// its collapsed state, it just stops changing.
+(function () {
+    document.querySelectorAll('[data-collapse-label-expanded]').forEach(function (node) {
+        var trigger = /** @type {HTMLElement} */ (node);
+        var selector = trigger.dataset.bsTarget || '';
+        var target = selector ? document.querySelector(selector) : null;
+        var label = trigger.querySelector('[data-collapse-label]');
+        if (!target || !label) {
+            return;
+        }
+
+        var whenCollapsed = label.textContent || '';
+        var whenExpanded = trigger.dataset.collapseLabelExpanded || whenCollapsed;
+
+        // `show`/`hide` rather than `shown`/`hidden`: the label belongs to
+        // the click that was just made, not to the end of a 350 ms
+        // animation the reader is already looking past.
+        target.addEventListener('show.bs.collapse', function () {
+            label.textContent = whenExpanded;
+        });
+        target.addEventListener('hide.bs.collapse', function () {
+            label.textContent = whenCollapsed;
+        });
+    });
+})();

--- a/tests/Core/Http/Controller/MaintenanceControllerTest.php
+++ b/tests/Core/Http/Controller/MaintenanceControllerTest.php
@@ -1668,7 +1668,12 @@ class MaintenanceControllerTest extends TestCase
         // sit in a collapsed tbody.
         $this->assertStringContainsString('id="update-history-more"', $body);
         $this->assertStringContainsString('class="collapse"', $body);
+        // One label in the markup, the other in a data attribute for
+        // collapse-label.js: a stale stylesheet must never be able to
+        // render both at once (that is exactly what production showed).
         $this->assertStringContainsString('Afficher les 3 précédentes', $body);
+        $this->assertStringContainsString('data-collapse-label-expanded="Afficher moins"', $body);
+        $this->assertSame(0, substr_count($body, '>Afficher moins<'), 'the expanded label lives in the attribute, never as a second visible span');
         // Nine: the eight entries plus the table's own header row.
         $this->assertSame(9, substr_count($body, '<tr>'), 'every entry is rendered, five of them visible');
     }

--- a/tests/js/collapse-label.test.js
+++ b/tests/js/collapse-label.test.js
@@ -1,0 +1,98 @@
+// Isolated JavaScript unit test — jsdom-simulated DOM only. Exercises
+// the REAL implementation in public/assets/js/collapse-label.js
+// (imported below, never reimplemented here).
+//
+// Bootstrap's own JS is not loaded here: what this module listens to are
+// the `show.bs.collapse` / `hide.bs.collapse` events Bootstrap dispatches
+// on the collapse TARGET, so the tests dispatch those events directly.
+// That is the contract, and it is the whole reason the swap moved out of
+// CSS — see the module's own docblock.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The <table> wrapper is not decoration: jsdom's parser discards a
+// <tbody> that is not inside one, exactly as a browser would.
+const MARKUP = `
+    <button type="button" class="collapsed" data-bs-toggle="collapse" data-bs-target="#more"
+            aria-expanded="false" data-collapse-label-expanded="Afficher moins">
+        <span data-collapse-label>Afficher les 15 précédentes</span>
+        <i class="bi bi-chevron-down"></i>
+    </button>
+    <table><tbody id="more" class="collapse"><tr><td>une ligne</td></tr></tbody></table>`;
+
+async function load(markup = MARKUP) {
+    document.body.innerHTML = markup;
+    vi.resetModules();
+    await import('../../public/assets/js/collapse-label.js');
+
+    return {
+        target: /** @type {HTMLElement} */ (document.getElementById('more')),
+        label: /** @type {HTMLElement|null} */ (document.querySelector('[data-collapse-label]')),
+    };
+}
+
+/** @param {HTMLElement} el @param {string} type */
+function fire(el, type) {
+    el.dispatchEvent(new Event(type, { bubbles: false }));
+}
+
+describe('collapse-label.js', () => {
+    beforeEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('ships one correct label before anything is clicked', async () => {
+        // The failure this module replaces rendered BOTH labels at once
+        // whenever the stylesheet was a version behind.
+        const { label } = await load();
+
+        expect(label.textContent).toBe('Afficher les 15 précédentes');
+        expect(document.body.textContent).not.toContain('Afficher moins');
+    });
+
+    it('swaps to the expanded label when the collapse opens', async () => {
+        const { target, label } = await load();
+
+        fire(target, 'show.bs.collapse');
+
+        expect(label.textContent).toBe('Afficher moins');
+    });
+
+    it('swaps back when the collapse closes', async () => {
+        const { target, label } = await load();
+
+        fire(target, 'show.bs.collapse');
+        fire(target, 'hide.bs.collapse');
+
+        expect(label.textContent).toBe('Afficher les 15 précédentes');
+    });
+
+    it('survives repeated toggling without accumulating text', async () => {
+        const { target, label } = await load();
+
+        for (let i = 0; i < 3; i++) {
+            fire(target, 'show.bs.collapse');
+            fire(target, 'hide.bs.collapse');
+        }
+
+        expect(label.textContent).toBe('Afficher les 15 précédentes');
+    });
+
+    it('ignores a trigger whose target does not exist', async () => {
+        const orphan = `
+            <button data-bs-toggle="collapse" data-bs-target="#nope" data-collapse-label-expanded="Afficher moins">
+                <span data-collapse-label>Afficher les 15 précédentes</span>
+            </button>`;
+
+        await expect(load(orphan)).resolves.toBeDefined();
+        expect(document.querySelector('[data-collapse-label]').textContent).toBe('Afficher les 15 précédentes');
+    });
+
+    it('ignores a trigger carrying no label element', async () => {
+        const noLabel = `
+            <button data-bs-toggle="collapse" data-bs-target="#more" data-collapse-label-expanded="Afficher moins"></button>
+            <div id="more"></div>`;
+        // (a plain <div> here: the point is the missing label, not the table)
+
+        await expect(load(noLabel)).resolves.toBeDefined();
+    });
+});


### PR DESCRIPTION
## Description

Sur le site, le bouton lisait « Afficher les 15 précédentes Afficher moins », dans les deux états.

Les deux libellés étaient rendus et une règle CSS masquait celui qui ne s'appliquait pas, en s'appuyant sur la classe `.collapsed` que Bootstrap pose lui-même sur le déclencheur. Le balisage, la règle et la CSS servie sont pourtant corrects — vérifié octet pour octet contre la production (35 673 octets identiques), et la règle fonctionne dans un navigateur réel.

**Ce qui manquait :** `/assets/css/app.css` fait partie de l'app shell du service worker et y est apparié **avec `ignoreSearch`** (`public/sw.js` le documente longuement, pour de bonnes raisons liées aux icônes). Son `?v=` ne force donc pas de rechargement : tant que le worker précédent n'est pas libéré, une page rend du **HTML neuf contre la feuille de style précédente**. Un échange purement CSS échoue alors en montrant les deux libellés — exactement ce qu'a montré la production.

**Le correctif :** le libellé n'existe plus qu'une fois dans le balisage, et `public/assets/js/collapse-label.js` — non précaché, donc jamais périmé — échange son texte sur les évènements `show.bs.collapse` / `hide.bs.collapse`. La dégradation est le sujet : si le script ne tourne pas, le bouton reste **correct** dans son état replié, il cesse simplement de changer. Le second libellé vit dans `data-collapse-label-expanded` et ne peut plus être rendu comme texte visible.

La règle CSS fragile est supprimée (la rotation du chevron reste : périmée, elle ne coûte qu'un chevron immobile).

Vérifié dans Chromium avec Bootstrap chargé — replié → déplié → replié, libellé et lignes suivent, y compris le collapse sur `<tbody>`.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — `tests/js/collapse-label.test.js` (6 cas) ; suite JS complète 1713/1713 ; `npm run typecheck` sans nouvelle trouvaille

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkYeu7kMMWqK9Knmd1aCHP

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkYeu7kMMWqK9Knmd1aCHP)_