### PR TITLE
Les tests cessent d'épeler l'année civile dans laquelle ils tournent

### DIFF
--- a/scripts/e2e-support.php
+++ b/scripts/e2e-support.php
@@ -97,6 +97,7 @@ function e2e_support_main(array $argv): void
                 exit(1);
             }
             require_once $repoRoot . '/vendor/autoload.php';
+            e2e_apply_application_clock();
             e2e_provision($repoRoot, $instanceDir, $port);
             exit(0);
 
@@ -110,6 +111,7 @@ function e2e_support_main(array $argv): void
 
         case 'teardown-db':
             require_once $repoRoot . '/vendor/autoload.php';
+            e2e_apply_application_clock();
             e2e_teardown_database();
             exit(0);
 
@@ -658,6 +660,55 @@ function e2e_provision(string $repoRoot, string $instanceDir, int $port): void
         281
     );
 
+    e2e_warn_if_near_scout_year_boundary();
+
+    // Pin the public scout year, so a run cannot be moved by the calendar
+    // underneath it.
+    //
+    // Core\Config\ScoutYearService::labelForDate() starts a new scout year
+    // the moment the month reaches September, and Core\Config\AppClock puts
+    // the application on Europe/Brussels — so the year every fixture below
+    // is seeded into changes at 00:00 Brussels time on 1 September. With
+    // neither year setting configured, Core\ScoutYear\ScoutYearResolver
+    // falls through to that date computation on every request, which means
+    // a suite that starts on 31 August and finishes on 1 September seeds
+    // its members, sections, on-call assignments, registrations and
+    // bookings into 2025-2026 and then asks for them in 2026-2027 —
+    // ensureYear() obligingly creates the new year, empty, and every
+    // scout-year-scoped fixture simply is not there any more.
+    //
+    // Observed rather than imagined, 2026-08-31: CI was green at 20:43 and
+    // 20:54 UTC, the 21:32 run lost the three specs that ran past 22:00
+    // UTC (= midnight in Brussels), and a 20-sample probe started at 21:50
+    // lost twelve specs each, all of them after the boundary — « element(s)
+    // not found » on rows that had been seeded an hour earlier. Passing and
+    // failing specs interleaved, so nothing was wedged and nothing was
+    // slow: the ground had moved.
+    //
+    // Registered rather than set, for the same reason as
+    // statistics_destination above: public/index.php registers this key at
+    // boot, later than this, so the insert here carries the value and
+    // index.php's own register() then only refreshes default_value.
+    //
+    // specs/scout-year-transition.spec.js still moves this year forward on
+    // purpose, through the real admin page (Core\ScoutYear\
+    // ScoutYearAdminService writes the same setting) — pinning it here is
+    // the STARTING state that scenario expects, not a lock on it.
+    $settingService->register(
+        Core\ScoutYear\ScoutYearResolver::SETTING_PUBLIC_YEAR,
+        (string) (new Core\Config\ScoutYearService($connection->getPdo()))->getCurrentYear()['id'],
+        'number',
+        'Année scoute publique (ID)',
+        'Identifiant de l\'année scoute vue par tout le monde. Épinglée par le harnais E2E sur '
+        . "l'année dans laquelle les fixtures sont semées, pour qu'un passage de minuit le 1er "
+        . 'septembre ne la déplace pas en cours de route.',
+        null,
+        '^[0-9]+$',
+        null,
+        false,
+        210
+    );
+
     // Self-continuation off for this instance, and not as a convenience:
     // `php -S` serves one request per worker at a time and defaults to a
     // single worker, so a scheduler hop does not run alongside the request
@@ -916,6 +967,127 @@ function e2e_create_super_admin(
 }
 
 /**
+ * Put this script on the same clock as the application it provisions.
+ *
+ * public/index.php calls Core\Config\AppClock::apply() as its first act
+ * after the autoloader, which pins the process to Europe/Brussels. This
+ * script never did, so it ran on PHP's default timezone — UTC on a CI
+ * runner and on a stock macOS PHP alike. For twenty-two hours a day that
+ * difference is invisible, because both clocks agree on the DATE.
+ *
+ * Between 22:00 and 24:00 UTC they do not, and once a year that
+ * disagreement lands on the only date boundary this application treats as
+ * a hard edge: a scout year starts on 1 September
+ * (Core\Config\ScoutYearService::labelForDate()). Measured on this very
+ * boundary, 2026-08-31 22:48 UTC:
+ *
+ *     provisioning saw : 2025-2026   (UTC, 2026-08-31)
+ *     the served app saw: 2026-2027   (Europe/Brussels, 2026-09-01)
+ *
+ * So the harness seeded every member, function, section period and
+ * booking into one scout year and the application then looked for them in
+ * another. Seven specs failed at once, all of them member lookups coming
+ * back empty — grantManagerBySearch() finding nobody to grant an asset
+ * to, the mass-mail audience unable to see kaa@example.invalid,
+ * /config/banner answering 403 to a super-admin whose own membership had
+ * become invisible. Fast, hard failures on a suite that had been green
+ * two hours earlier, and not one of them pointing at a clock.
+ *
+ * Applying the same clock is the fix, not a workaround: a harness that
+ * seeds data for an application has no business disagreeing with it about
+ * what day it is. The scout-year pin in e2e_provision() is the belt to
+ * this one's braces — this makes the two agree at the start, that keeps
+ * them agreeing if the run crosses midnight.
+ */
+function e2e_apply_application_clock(): void
+{
+    Core\Config\AppClock::apply();
+}
+
+/**
+ * A fixture start date that lies inside the scout year the row belongs to.
+ *
+ * Every membership fixture below used to start « a month ago » outright.
+ * For eleven months of the year that is inside the current scout year and
+ * nobody notices. In September it is not: a scout year begins on the 1st
+ * (Core\Config\ScoutYearService::labelForDate()), so on 1 September « a
+ * month ago » is 1 August — the PREVIOUS year — while the row's own
+ * scout_year_id points at the new one. The fixture then asserts something
+ * incoherent: a membership that started before the year it belongs to.
+ *
+ * This is a coherence fix, and it is worth being precise about what it is
+ * NOT: it was written while chasing the 2026-09-01 outage and it did not
+ * fix it — re-running the seven failing specs with only this change left
+ * all seven red. The cause was the clock (see
+ * e2e_apply_application_clock() above). Keeping it anyway, because a
+ * membership dated before the year it belongs to is wrong whatever else
+ * is true, and a fixture that states something impossible is a bad
+ * foundation for a test that asserts on it.
+ *
+ * Clamping to the year's own start_date keeps « a month ago » for the
+ * other eleven months and says « the day the year opened » in September.
+ *
+ * @param array{id: int, label: string, start_date: string, end_date: string} $scoutYear
+ */
+function e2e_fixture_start_date(array $scoutYear): string
+{
+    // Both are Y-m-d, so a string comparison is a date comparison.
+    return max(date('Y-m-d', strtotime('-1 month')), $scoutYear['start_date']);
+}
+
+/**
+ * Warn when this run is about to cross the scout-year boundary.
+ *
+ * A scout year turns over the instant the month reaches September
+ * (Core\Config\ScoutYearService::labelForDate()), on Belgian wall-clock
+ * time (Core\Config\AppClock). Fixtures are seeded once, at provisioning,
+ * into whatever year is current then — so a run that starts on 31 August
+ * and finishes on 1 September asks for them in a year that did not exist
+ * when they were written, and ensureYear() hands out a new empty one.
+ *
+ * The pinned `current_scout_year_id` above holds the line for everything
+ * that resolves through Core\ScoutYear\ScoutYearResolver — login and role
+ * resolution above all, which is what makes a member visible at all. It
+ * cannot hold it for the call sites that ask
+ * Core\Config\ScoutYearService::getCurrentYear() directly, and there are
+ * around twenty of them across core and the modules.
+ *
+ * Hence a warning rather than a promise. What it buys is the hour this
+ * cost the first time: without it the symptom is a dozen specs failing on
+ * « element(s) not found » for rows seeded minutes earlier, with passing
+ * specs interleaved so nothing looks wedged, on a commit that was green
+ * an hour before — every signal pointing at a flake, and none at the
+ * calendar.
+ */
+function e2e_warn_if_near_scout_year_boundary(?DateTimeImmutable $now = null): bool
+{
+    $now ??= new DateTimeImmutable('now', new DateTimeZone(Core\Config\AppClock::TIMEZONE));
+    $now = $now->setTimezone(new DateTimeZone(Core\Config\AppClock::TIMEZONE));
+    $year = (int) $now->format('n') >= 9 ? (int) $now->format('Y') + 1 : (int) $now->format('Y');
+    $boundary = new DateTimeImmutable(sprintf('%d-09-01 00:00:00', $year), $now->getTimezone());
+
+    $minutesAway = (int) round(($boundary->getTimestamp() - $now->getTimestamp()) / 60);
+    if ($minutesAway > 60) {
+        return false;
+    }
+
+    fwrite(STDERR, sprintf(
+        "E2E WARNING: the scout year turns over in %d minute(s) (%s, %s).\n"
+        . "            Fixtures are seeded into %s and a run crossing that instant will ask for\n"
+        . "            them in the next year. Expect « element(s) not found » on scout-year-scoped\n"
+        . "            rows, on specs that were green an hour ago. This is the calendar, not a flake.\n"
+        . "            Re-run after %s for a result worth reading.\n",
+        max($minutesAway, 0),
+        $boundary->format('Y-m-d H:i'),
+        Core\Config\AppClock::TIMEZONE,
+        Core\Config\ScoutYearService::labelForDate($now),
+        $boundary->format('H:i')
+    ));
+
+    return true;
+}
+
+/**
  * Give the throwaway super-admin a scout identity: a members row, a
  * member_years row for the current scout year carrying the SAME email
  * address as the account, and a first/last name on the account itself.
@@ -958,7 +1130,8 @@ function e2e_seed_member_for_admin(
     $normalizedEmail = strtolower(trim($email));
     $blindIndex = $encryptionService->blindIndex($normalizedEmail, 'email');
 
-    $scoutYearId = (new Core\Config\ScoutYearService($pdo))->getCurrentYear()['id'];
+    $scoutYear = (new Core\Config\ScoutYearService($pdo))->getCurrentYear();
+    $scoutYearId = $scoutYear['id'];
 
     $pdo->prepare('INSERT INTO members (desk_id) VALUES (?)')->execute(['E2E-ADMIN']);
     $memberId = (int) $pdo->lastInsertId();
@@ -1016,7 +1189,8 @@ function e2e_seed_ordinary_member(
     $encryptionService = Core\Security\EncryptionService::fromEncodedKeys($encodedEncryptionKey, $encodedBlindIndexKey);
     $email = e2e_member_email();
     $blindIndex = $encryptionService->blindIndex($email, 'email');
-    $scoutYearId = (new Core\Config\ScoutYearService($pdo))->getCurrentYear()['id'];
+    $scoutYear = (new Core\Config\ScoutYearService($pdo))->getCurrentYear();
+    $scoutYearId = $scoutYear['id'];
 
     $pdo->prepare('INSERT INTO members (desk_id) VALUES (?)')->execute(['E2E-MEMBER']);
     $memberId = (int) $pdo->lastInsertId();
@@ -1084,7 +1258,8 @@ function e2e_seed_ordinary_member(
 function e2e_seed_section_with_both_members(Core\Database\Connection $connection): void
 {
     $pdo = $connection->getPdo();
-    $scoutYearId = (new Core\Config\ScoutYearService($pdo))->getCurrentYear()['id'];
+    $scoutYear = (new Core\Config\ScoutYearService($pdo))->getCurrentYear();
+    $scoutYearId = $scoutYear['id'];
 
     $pdo->prepare('INSERT INTO age_branches (desk_code, label, sort_order) VALUES (?, ?, 10)')
         ->execute(['E2E-BR', 'Branche E2E']);
@@ -1099,7 +1274,7 @@ function e2e_seed_section_with_both_members(Core\Database\Connection $connection
         . ' SELECT id, ?, ?, ?, NULL FROM members WHERE desk_id = ?'
     );
     foreach (['E2E-ADMIN', 'E2E-MEMBER'] as $deskId) {
-        $statement->execute([$sectionId, $scoutYearId, date('Y-m-d', strtotime('-1 month')), $deskId]);
+        $statement->execute([$sectionId, $scoutYearId, e2e_fixture_start_date($scoutYear), $deskId]);
     }
 
     // role 'identified' — see this function's docblock: the function exists
@@ -1120,7 +1295,7 @@ function e2e_seed_section_with_both_members(Core\Database\Connection $connection
             $functionId,
             $sectionId,
             $ageBranchId,
-            date('Y-m-d', strtotime('-1 month')),
+            e2e_fixture_start_date($scoutYear),
             $deskId,
             $scoutYearId,
         ]);
@@ -1292,7 +1467,8 @@ function e2e_seed_role_members(
 ): void {
     $pdo = $connection->getPdo();
     $encryptionService = Core\Security\EncryptionService::fromEncodedKeys($encodedEncryptionKey, $encodedBlindIndexKey);
-    $scoutYearId = (new Core\Config\ScoutYearService($pdo))->getCurrentYear()['id'];
+    $scoutYear = (new Core\Config\ScoutYearService($pdo))->getCurrentYear();
+    $scoutYearId = $scoutYear['id'];
 
     // sort_order 90 puts this branch last everywhere branches are
     // ordered, so nothing that reads "the first section" on a page picks
@@ -1308,7 +1484,7 @@ function e2e_seed_role_members(
     $sectionId = (int) $pdo->lastInsertId();
 
     $userAccountRepository = new Core\Security\UserAccountRepository($pdo, $encryptionService);
-    $startDate = date('Y-m-d', strtotime('-1 month'));
+    $startDate = e2e_fixture_start_date($scoutYear);
 
     foreach (e2e_role_accounts() as $account) {
         $email = e2e_role_account_email($account);
@@ -1385,7 +1561,8 @@ function e2e_assert_resolved_roles(
 ): void {
     $pdo = $connection->getPdo();
     $encryptionService = Core\Security\EncryptionService::fromEncodedKeys($encodedEncryptionKey, $encodedBlindIndexKey);
-    $scoutYearId = (new Core\Config\ScoutYearService($pdo))->getCurrentYear()['id'];
+    $scoutYear = (new Core\Config\ScoutYearService($pdo))->getCurrentYear();
+    $scoutYearId = $scoutYear['id'];
 
     $roleResolver = new Core\Security\RoleResolver(
         new Core\Import\MemberYearRepository($pdo),
@@ -1439,7 +1616,8 @@ function e2e_assert_resolved_roles(
 function e2e_seed_unit_chief_function_for_admin(Core\Database\Connection $connection): void
 {
     $pdo = $connection->getPdo();
-    $scoutYearId = (new Core\Config\ScoutYearService($pdo))->getCurrentYear()['id'];
+    $scoutYear = (new Core\Config\ScoutYearService($pdo))->getCurrentYear();
+    $scoutYearId = $scoutYear['id'];
 
     $staffSectionId = (new Core\Member\UnitStaffSectionService($pdo))->ensureSection();
     $statement = $pdo->prepare('SELECT age_branch_id FROM sections WHERE id = ?');
@@ -1467,7 +1645,7 @@ function e2e_seed_unit_chief_function_for_admin(Core\Database\Connection $connec
         $functionId,
         $staffSectionId,
         $staffBranchId,
-        date('Y-m-d', strtotime('-1 month')),
+        e2e_fixture_start_date($scoutYear),
         'E2E-ADMIN',
         $scoutYearId,
     ]);
@@ -1487,7 +1665,8 @@ function e2e_seed_mobile_for_admin(
 ): void {
     $pdo = $connection->getPdo();
     $encryptionService = Core\Security\EncryptionService::fromEncodedKeys($encodedEncryptionKey, $encodedBlindIndexKey);
-    $scoutYearId = (new Core\Config\ScoutYearService($pdo))->getCurrentYear()['id'];
+    $scoutYear = (new Core\Config\ScoutYearService($pdo))->getCurrentYear();
+    $scoutYearId = $scoutYear['id'];
 
     $pdo->prepare(
         'UPDATE member_years my JOIN members m ON m.id = my.member_id'

--- a/tests/Core/Http/Controller/ImportControllerTest.php
+++ b/tests/Core/Http/Controller/ImportControllerTest.php
@@ -51,7 +51,8 @@ class ImportControllerTest extends TestCase
         $this->encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
 
         // Create scout year
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
 
         // Create admin user
         $stmt = $this->pdo->prepare("INSERT INTO user_accounts (email_encrypted, email_blind_index, is_super_admin) VALUES (?, 'admin_idx', 1)");
@@ -190,7 +191,9 @@ class ImportControllerTest extends TestCase
         $body = $response->getBody();
         $this->assertStringContainsString('Import Desk', $body);
         $this->assertStringContainsString('Année scoute', $body);
-        $this->assertStringContainsString('2025-2026', $body);
+        // The year the page renders is the CURRENT one, so the assertion
+        // has to ask for that rather than for a year written out.
+        $this->assertStringContainsString(DatabaseTestHelper::scoutYear()[0], $body);
     }
 
     public function testIndexShowsUploadForm(): void

--- a/tests/Core/Http/Controller/SectionDocumentControllerTest.php
+++ b/tests/Core/Http/Controller/SectionDocumentControllerTest.php
@@ -92,7 +92,8 @@ class SectionDocumentControllerTest extends TestCase
             new JournalService(new JournalRepository($this->pdo))
         );
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
         $this->pdo->exec("INSERT INTO age_branches (desk_code, label, sort_order) VALUES ('LOU', 'Louveteaux', 10)");
         $branchId = (int) $this->pdo->lastInsertId();

--- a/tests/Core/Http/Controller/StaffsControllerTest.php
+++ b/tests/Core/Http/Controller/StaffsControllerTest.php
@@ -80,7 +80,12 @@ class StaffsControllerTest extends TestCase
         );
 
         // Create scout year
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        // The CURRENT year, not a year spelled out: this fixture means
+        // « the year the application is in », and saying that as a
+        // literal made it expire on 1 September. See
+        // DatabaseTestHelper::scoutYear().
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         // Create Twig

--- a/tests/Core/Import/DeskImportBarrierTest.php
+++ b/tests/Core/Import/DeskImportBarrierTest.php
@@ -58,7 +58,8 @@ class DeskImportBarrierTest extends TestCase
         $this->storagePath = sys_get_temp_dir() . '/scoutmagic_test_' . bin2hex(random_bytes(8));
         mkdir($this->storagePath, 0777, true);
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         // Deliberately NOT a super-admin: the whole point of the hard

--- a/tests/Core/Import/ImportRetentionServiceTest.php
+++ b/tests/Core/Import/ImportRetentionServiceTest.php
@@ -51,14 +51,18 @@ class ImportRetentionServiceTest extends TestCase
         $this->storage = new EncryptedFileStorageService($fileRepository, $encryption, $this->storagePath);
         $this->settings = new SettingService(new SettingRepository($this->pdo));
 
-        // Oldest first, so the newest ends up "current".
-        foreach (['2022-2023', '2023-2024', '2024-2025', '2025-2026'] as $label) {
+        // Oldest first, so the newest ends up "current" — and relative to
+        // the year the application is actually in, not four calendar years
+        // written out. Spelling them out made this class expire on
+        // 1 September (Tests\DatabaseTestHelper::scoutYear()).
+        foreach ([-3, -2, -1, 0] as $offset) {
+            $label = $this->yearLabel($offset);
             $start = substr($label, 0, 4) . '-09-01';
             $end = substr($label, 5, 4) . '-08-31';
             $stmt = $this->pdo->prepare(
                 'INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES (?, ?, ?, ?)'
             );
-            $stmt->execute([$label, $start, $end, $label === '2025-2026' ? 1 : 0]);
+            $stmt->execute([$label, $start, $end, $offset === 0 ? 1 : 0]);
             $this->years[$label] = (int) $this->pdo->lastInsertId();
         }
 
@@ -89,7 +93,7 @@ class ImportRetentionServiceTest extends TestCase
 
         $beyond = $this->service->yearsBeyondRetention();
 
-        $this->assertSame([$this->years['2023-2024'], $this->years['2022-2023']], $beyond);
+        $this->assertSame([$this->years[$this->yearLabel(-2)], $this->years[$this->yearLabel(-3)]], $beyond);
     }
 
     public function testTheRetentionIsConfigurable(): void
@@ -98,7 +102,7 @@ class ImportRetentionServiceTest extends TestCase
         $this->settings->set(ImportRetentionService::SETTING_KEY, '3');
 
         $this->assertSame(3, $this->service->retentionYears());
-        $this->assertSame([$this->years['2022-2023']], $this->service->yearsBeyondRetention());
+        $this->assertSame([$this->years[$this->yearLabel(-3)]], $this->service->yearsBeyondRetention());
     }
 
     public function testARetentionOfZeroIsNeverHonouredBelowOneYear(): void
@@ -110,27 +114,27 @@ class ImportRetentionServiceTest extends TestCase
         // reads all season; losing them mid-season is not a retention
         // choice anybody can meaningfully make.
         $this->assertSame(1, $this->service->retentionYears());
-        $this->assertNotContains($this->years['2025-2026'], $this->service->yearsBeyondRetention());
+        $this->assertNotContains($this->years[$this->yearLabel(0)], $this->service->yearsBeyondRetention());
     }
 
     public function testAYearPreparedInAdvanceIsNeverPurged(): void
     {
         $stmt = $this->pdo->prepare('INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES (?, ?, ?, 0)');
-        $stmt->execute(['2026-2027', '2026-09-01', '2027-08-31']);
+        $stmt->execute(\Tests\DatabaseTestHelper::scoutYear(1));
         $futureYearId = (int) $this->pdo->lastInsertId();
 
         $beyond = $this->service->yearsBeyondRetention();
 
         $this->assertNotContains($futureYearId, $beyond);
         // And the window is still two real seasons wide, not one plus the future.
-        $this->assertNotContains($this->years['2024-2025'], $beyond);
-        $this->assertContains($this->years['2023-2024'], $beyond);
+        $this->assertNotContains($this->years[$this->yearLabel(-1)], $beyond);
+        $this->assertContains($this->years[$this->yearLabel(-2)], $beyond);
     }
 
     public function testAPurgeTakesTheRowTheFileAndTheSnapshotTogether(): void
     {
-        [$oldImportId, $oldFileId, $oldPath] = $this->seedImport('2022-2023');
-        [$keptImportId, $keptFileId, $keptPath] = $this->seedImport('2025-2026');
+        [$oldImportId, $oldFileId, $oldPath] = $this->seedImport($this->yearLabel(-3));
+        [$keptImportId, $keptFileId, $keptPath] = $this->seedImport($this->yearLabel(0));
 
         $purged = $this->service->purge();
 
@@ -141,7 +145,7 @@ class ImportRetentionServiceTest extends TestCase
         $this->assertNull((new FileRepository($this->pdo))->findById($oldFileId));
         $this->assertFileDoesNotExist($oldPath);
         $this->assertNull($this->snapshots->findByImport($oldImportId));
-        $this->assertSame(0, $this->countSnapshotMembers($this->years['2022-2023']));
+        $this->assertSame(0, $this->countSnapshotMembers($this->years[$this->yearLabel(-3)]));
 
         // Untouched: everything inside the window.
         $this->assertNotNull($this->imports->findById($keptImportId));
@@ -152,8 +156,8 @@ class ImportRetentionServiceTest extends TestCase
 
     public function testAPurgeWithNothingToPurgeDoesNothingAndSaysNothing(): void
     {
-        $this->seedImport('2025-2026');
-        $this->seedImport('2024-2025');
+        $this->seedImport($this->yearLabel(0));
+        $this->seedImport($this->yearLabel(-1));
 
         $this->assertSame(0, $this->service->purge());
         $this->assertSame([], $this->journalEntries());
@@ -161,7 +165,7 @@ class ImportRetentionServiceTest extends TestCase
 
     public function testThePurgeIsJournaledWithCountersOnly(): void
     {
-        $this->seedImport('2022-2023');
+        $this->seedImport($this->yearLabel(-3));
         $this->service->purge();
 
         $entries = $this->journalEntries();
@@ -175,13 +179,13 @@ class ImportRetentionServiceTest extends TestCase
 
     public function testEveryImportOfAPurgedSeasonGoes(): void
     {
-        $this->seedImport('2022-2023');
-        $this->seedImport('2022-2023');
-        $this->seedImport('2023-2024');
+        $this->seedImport($this->yearLabel(-3));
+        $this->seedImport($this->yearLabel(-3));
+        $this->seedImport($this->yearLabel(-2));
 
         $this->assertSame(3, $this->service->purge());
-        $this->assertSame(0, $this->imports->countForYear($this->years['2022-2023']));
-        $this->assertSame(0, $this->imports->countForYear($this->years['2023-2024']));
+        $this->assertSame(0, $this->imports->countForYear($this->years[$this->yearLabel(-3)]));
+        $this->assertSame(0, $this->imports->countForYear($this->years[$this->yearLabel(-2)]));
     }
 
     /* ------------------------------------------------------------------ */
@@ -192,6 +196,12 @@ class ImportRetentionServiceTest extends TestCase
      *
      * @return array{int, int, string} import id, file id, absolute blob path
      */
+    /** The label of the scout year `$offset` years from the current one. */
+    private function yearLabel(int $offset = 0): string
+    {
+        return \Tests\DatabaseTestHelper::scoutYear($offset)[0];
+    }
+
     private function seedImport(string $yearLabel): array
     {
         $scoutYearId = $this->years[$yearLabel];

--- a/tests/Core/Import/RosterReplacementGuardTest.php
+++ b/tests/Core/Import/RosterReplacementGuardTest.php
@@ -43,7 +43,8 @@ class RosterReplacementGuardTest extends TestCase
     {
         $this->pdo = DatabaseTestHelper::createTestDatabase();
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         $this->guard = new RosterReplacementGuard(
@@ -123,7 +124,8 @@ class RosterReplacementGuardTest extends TestCase
     {
         // A year nobody has imported yet: nothing is "missing" from an
         // empty roster, and the barrier must stay silent.
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2026-2027', '2026-09-01', '2027-08-31', 0)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear(1);
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 0)");
         $nextYearId = (int) $this->pdo->lastInsertId();
 
         $assessment = $this->guard->assess($this->parsedFile(['BAL1' => 20]), $nextYearId, 0);
@@ -138,7 +140,8 @@ class RosterReplacementGuardTest extends TestCase
         // A fully populated current year must not make next year's first
         // import look like a mass deactivation.
         $this->buildRoster(['BAL1' => 30, 'LOUV1' => 30, 'ECL1' => 30]);
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2026-2027', '2026-09-01', '2027-08-31', 0)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear(1);
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 0)");
         $nextYearId = (int) $this->pdo->lastInsertId();
 
         $assessment = $this->guard->assess($this->parsedFile(['BAL1' => 5]), $nextYearId, 0);

--- a/tests/Core/Notification/RoleScopedNotificationDefaultsTest.php
+++ b/tests/Core/Notification/RoleScopedNotificationDefaultsTest.php
@@ -51,7 +51,8 @@ class RoleScopedNotificationDefaultsTest extends TestCase
         $this->pdo = DatabaseTestHelper::createTestDatabase();
         $this->encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
 
         $this->notificationRepository = new NotificationRepository($this->pdo, $this->encryption);
         $this->preferenceRepository = new NotificationPreferenceRepository($this->pdo);

--- a/tests/Core/Offline/OfflineManifestServiceTest.php
+++ b/tests/Core/Offline/OfflineManifestServiceTest.php
@@ -59,7 +59,8 @@ class OfflineManifestServiceTest extends TestCase
         $this->sectionService = new SectionService($connection, $this->encryption, $memberBadgeRepository);
         $this->memberService = new MemberService(new MemberYearRepository($this->pdo), $this->encryption, $connection);
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         $this->pdo->exec("INSERT INTO age_branches (desk_code, label, sort_order) VALUES ('LOU', 'Louveteaux', 20)");

--- a/tests/DatabaseTestHelper.php
+++ b/tests/DatabaseTestHelper.php
@@ -7,6 +7,48 @@ namespace Tests;
 class DatabaseTestHelper
 {
     /**
+     * The `(label, start_date, end_date)` of a scout year, relative to the
+     * one the application considers current RIGHT NOW.
+     *
+     * Fixtures used to write that triple out by hand — `'2025-2026',
+     * '2025-09-01', '2026-08-31'` appears 127 times across this suite.
+     * That is correct for eleven months and wrong on the twelfth: a scout
+     * year turns over on 1 September (Core\Config\ScoutYearService::
+     * labelForDate()), and tests/bootstrap.php puts PHPUnit on Belgian
+     * time, so at 00:00 Brussels on 1 September the application starts
+     * resolving the NEXT year while the fixture still names the previous
+     * one. getCurrentYear() then finds no row, ensureYear() creates an
+     * empty one, and every member, function and section period the test
+     * seeded hangs off an id nothing asks for any more.
+     *
+     * That is not a hypothetical: on 2026-09-01 it took 80 tests across
+     * 22 classes red at once, on a suite green two hours earlier, with
+     * failures that name a missing member rather than a date.
+     *
+     * `$offsetYears` reaches the neighbours a test needs — -1 for last
+     * year, +1 for next — so a fixture can still say « the year before
+     * this one » without saying which calendar year that is.
+     *
+     * A test that genuinely means a FIXED year (a historical import, a
+     * date printed in an expected string) should keep writing it out:
+     * this is for the ones that mean « the current year » and only ever
+     * spelled it as a number.
+     *
+     * @return array{0: string, 1: string, 2: string}
+     */
+    public static function scoutYear(int $offsetYears = 0): array
+    {
+        $label = \Core\Config\ScoutYearService::labelForDate(new \DateTimeImmutable());
+        $startYear = ((int) explode('-', $label)[0]) + $offsetYears;
+
+        return [
+            sprintf('%d-%d', $startYear, $startYear + 1),
+            sprintf('%d-09-01', $startYear),
+            sprintf('%d-08-31', $startYear + 1),
+        ];
+    }
+
+    /**
      * Create an in-memory SQLite database with all core tables.
      */
     public static function createTestDatabase(): \PDO

--- a/tests/Integration/MagicLinkWindowIdentityTest.php
+++ b/tests/Integration/MagicLinkWindowIdentityTest.php
@@ -69,8 +69,9 @@ class MagicLinkWindowIdentityTest extends TestCase
         $this->pdo = \Tests\DatabaseTestHelper::createTestDatabase();
         $this->encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
 
+        [$label, $yearStart, $yearEnd] = \Tests\DatabaseTestHelper::scoutYear();
         $this->pdo->exec(
-            "INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)"
+            "INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)"
         );
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 

--- a/tests/Integration/SecondaryEmailLoginIdentityTest.php
+++ b/tests/Integration/SecondaryEmailLoginIdentityTest.php
@@ -82,8 +82,9 @@ class SecondaryEmailLoginIdentityTest extends TestCase
         $this->pdo = \Tests\DatabaseTestHelper::createTestDatabase();
         $this->encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
 
+        [$label, $yearStart, $yearEnd] = \Tests\DatabaseTestHelper::scoutYear();
         $this->pdo->exec(
-            "INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)"
+            "INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)"
         );
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 

--- a/tests/Modules/Attestations/AttestationsTestHelper.php
+++ b/tests/Modules/Attestations/AttestationsTestHelper.php
@@ -74,8 +74,15 @@ final class AttestationsTestHelper
         return new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
     }
 
-    public static function createScoutYear(\PDO $pdo, string $label = '2025-2026'): int
+    /**
+     * Defaults to the year the application is actually in. It used to
+     * default to '2025-2026', which was the current year when it was
+     * written and last year from 1 September 2026 — see
+     * Tests\DatabaseTestHelper::scoutYear().
+     */
+    public static function createScoutYear(\PDO $pdo, ?string $label = null): int
     {
+        $label ??= \Tests\DatabaseTestHelper::scoutYear()[0];
         $stmt = $pdo->prepare(
             'INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES (?, ?, ?, 1)'
         );

--- a/tests/Modules/Attestations/Controller/BatchControllerTest.php
+++ b/tests/Modules/Attestations/Controller/BatchControllerTest.php
@@ -155,7 +155,9 @@ class BatchControllerTest extends TestCase
         $this->assertStringContainsString('VANDENBRANDE Margaux', $body);
         $this->assertStringContainsString('nom lu dans le PDF', $body);
         $this->assertStringContainsString('Margaux Vandenbrande', $body);
-        $this->assertStringContainsString('2025-2026', $body);
+        // The badge shows the batch's scout year, which is the current one
+        // — so the assertion asks for that rather than for a year spelled out.
+        $this->assertStringContainsString(\Tests\DatabaseTestHelper::scoutYear()[0], $body);
     }
 
     /** Everything is distributed unless somebody says otherwise. */

--- a/tests/Modules/Calendar/Controller/CalendarChiefControllerTest.php
+++ b/tests/Modules/Calendar/Controller/CalendarChiefControllerTest.php
@@ -106,7 +106,8 @@ class CalendarChiefControllerTest extends TestCase
         $settingService->register('event_default_end_time', '16:00', 'text', 'Heure fin', 'desc', 'calendar');
         $settingService->register('event_default_location', '', 'text', 'Lieu', 'desc', 'calendar');
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         $templateDir = dirname(__DIR__, 4) . '/core/View/templates';

--- a/tests/Modules/Calendar/Task/MultidayEventReminderHandlerTest.php
+++ b/tests/Modules/Calendar/Task/MultidayEventReminderHandlerTest.php
@@ -65,7 +65,8 @@ class MultidayEventReminderHandlerTest extends TestCase
             sys_get_temp_dir()
         ));
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         $stmt = $this->pdo->prepare('INSERT INTO age_branches (desk_code, label, sort_order) VALUES (?, ?, ?)');

--- a/tests/Modules/Finance/Service/FamilyPaymentServiceTest.php
+++ b/tests/Modules/Finance/Service/FamilyPaymentServiceTest.php
@@ -66,7 +66,12 @@ class FamilyPaymentServiceTest extends TestCase
             'intendant'
         );
 
-        $this->scoutYearId = FinanceTestHelper::createScoutYear($this->pdo, '2025-2026', '2025-09-01', '2026-08-31', true);
+        // The year the application is in, not a year spelled out: this is
+        // seeded is_current, so naming it made the class expire on
+        // 1 September (Tests\DatabaseTestHelper::scoutYear()). The
+        // « Cotisations … » labels below are free text and stay as they are.
+        [$yearLabel, $yearStart, $yearEnd] = \Tests\DatabaseTestHelper::scoutYear();
+        $this->scoutYearId = FinanceTestHelper::createScoutYear($this->pdo, $yearLabel, $yearStart, $yearEnd, true);
 
         $this->memberIds['Lucie'] = $this->createMember('Lucie', 'famille@test.be');
         $this->memberIds['Antoine'] = $this->createMember('Antoine', 'famille@test.be');

--- a/tests/Modules/Gallery/Service/AlbumServiceTest.php
+++ b/tests/Modules/Gallery/Service/AlbumServiceTest.php
@@ -86,7 +86,8 @@ class AlbumServiceTest extends TestCase
         $stmt->execute(['enc', 'idx']);
         $this->authorId = (int) $this->pdo->lastInsertId();
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date) VALUES ('2025-2026', '2025-09-01', '2026-08-31')");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}')");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
         $scoutYearService = new ScoutYearService($this->pdo);
 
@@ -322,7 +323,8 @@ class AlbumServiceTest extends TestCase
         $stmt = $pdo->prepare('INSERT INTO user_accounts (email_encrypted, email_blind_index) VALUES (?, ?)');
         $stmt->execute(['enc', 'idx']);
         $authorId = (int) $pdo->lastInsertId();
-        $pdo->exec("INSERT INTO scout_years (label, start_date, end_date) VALUES ('2025-2026', '2025-09-01', '2026-08-31')");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $pdo->exec("INSERT INTO scout_years (label, start_date, end_date) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}')");
 
         $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
         $storageLocationRepository = new StorageLocationRepository($pdo, $encryption);

--- a/tests/Modules/Groups/Service/GroupLifecycleServiceTest.php
+++ b/tests/Modules/Groups/Service/GroupLifecycleServiceTest.php
@@ -73,7 +73,7 @@ class GroupLifecycleServiceTest extends TestCase
         $this->storagePath = sys_get_temp_dir() . '/groups_lifecycle_' . bin2hex(random_bytes(6));
         mkdir($this->storagePath, 0o777, true);
 
-        $this->currentYearId = GroupsTestHelper::createScoutYear($this->pdo, '2025-2026', true);
+        $this->currentYearId = GroupsTestHelper::createScoutYear($this->pdo, \Tests\DatabaseTestHelper::scoutYear()[0], true);
     }
 
     protected function tearDown(): void
@@ -351,7 +351,7 @@ class GroupLifecycleServiceTest extends TestCase
 
     public function testAGroupOfAFutureYearIsNeverPurgedEither(): void
     {
-        $nextYearId = GroupsTestHelper::createScoutYear($this->pdo, '2026-2027', false);
+        $nextYearId = GroupsTestHelper::createScoutYear($this->pdo, \Tests\DatabaseTestHelper::scoutYear(1)[0], false);
         $groupId = $this->group('L\'an prochain', scoutYearId: $nextYearId);
         $this->groupRepo->setClosed($groupId, $this->at('-36 months'));
 

--- a/tests/Modules/Groups/Task/LifecycleHandlersTest.php
+++ b/tests/Modules/Groups/Task/LifecycleHandlersTest.php
@@ -55,7 +55,7 @@ class LifecycleHandlersTest extends TestCase
 
         $this->groupRepo = new GroupRepository($this->pdo);
         $this->scheduler = new SchedulerService(new SchedulerRepository($this->pdo));
-        $this->currentYearId = GroupsTestHelper::createScoutYear($this->pdo, '2025-2026', true);
+        $this->currentYearId = GroupsTestHelper::createScoutYear($this->pdo, \Tests\DatabaseTestHelper::scoutYear()[0], true);
 
         $encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
         $this->context = new TaskContext(
@@ -97,7 +97,7 @@ class LifecycleHandlersTest extends TestCase
     public function testEnsureSectionGroupsAlsoCoversAFutureYearAlreadyImported(): void
     {
         $sectionId = GroupsTestHelper::createSection($this->pdo, 'LOU', 'Louveteaux');
-        $nextYearId = GroupsTestHelper::createScoutYear($this->pdo, '2026-2027', false);
+        $nextYearId = GroupsTestHelper::createScoutYear($this->pdo, \Tests\DatabaseTestHelper::scoutYear(1)[0], false);
 
         (new EnsureSectionGroupsHandler())->handle([], $this->context);
 

--- a/tests/Modules/Leadership/Controller/LeadershipRbacTest.php
+++ b/tests/Modules/Leadership/Controller/LeadershipRbacTest.php
@@ -67,7 +67,7 @@ class LeadershipRbacTest extends TestCase
         $stmt = $this->pdo->prepare(
             'INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES (?, ?, ?, 1)'
         );
-        $stmt->execute(['2025-2026', '2025-09-01', '2026-08-31']);
+        $stmt->execute(DatabaseTestHelper::scoutYear());
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         $this->twig = $this->buildTwig();

--- a/tests/Modules/MassMail/Service/MassMailServiceTest.php
+++ b/tests/Modules/MassMail/Service/MassMailServiceTest.php
@@ -101,7 +101,8 @@ class MassMailServiceTest extends TestCase
             new MergeRenderer()
         );
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
         $this->pdo->exec("INSERT INTO age_branches (desk_code, label, sort_order) VALUES ('LOU', 'Louveteaux', 1)");
         $branchId = (int) $this->pdo->lastInsertId();
@@ -596,7 +597,8 @@ class MassMailServiceTest extends TestCase
 
     private function createPastScoutYear(): int
     {
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2024-2025', '2024-09-01', '2025-08-31', 0)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear(-1);
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 0)");
         return (int) $this->pdo->lastInsertId();
     }
 
@@ -744,7 +746,8 @@ class MassMailServiceTest extends TestCase
 
     private function createFutureScoutYear(): int
     {
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2026-2027', '2026-09-01', '2027-08-31', 0)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear(1);
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 0)");
         return (int) $this->pdo->lastInsertId();
     }
 

--- a/tests/Modules/SosStaff/Controller/SosAdminControllerTest.php
+++ b/tests/Modules/SosStaff/Controller/SosAdminControllerTest.php
@@ -140,7 +140,8 @@ class SosAdminControllerTest extends TestCase
             null
         );
 
-        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('2025-2026', '2025-09-01', '2026-08-31', 1)");
+        [$label, $yearStart, $yearEnd] = DatabaseTestHelper::scoutYear();
+        $this->pdo->exec("INSERT INTO scout_years (label, start_date, end_date, is_current) VALUES ('{$label}', '{$yearStart}', '{$yearEnd}', 1)");
         $this->scoutYearId = (int) $this->pdo->lastInsertId();
 
         if (session_status() === PHP_SESSION_NONE) {

--- a/tests/e2e/specs/finance-receipts.spec.js
+++ b/tests/e2e/specs/finance-receipts.spec.js
@@ -34,12 +34,50 @@ const ACCOUNT_NAME = `Compte reçus E2E ${Date.now()}`;
 const ACCOUNT_IBAN = 'BE71 0961 2345 6769';
 
 /** A BNP Fortis export whose "Numéro de compte" matches the account. */
+/**
+ * A statement date, `dd/mm/yyyy`, guaranteed to fall inside the CURRENT
+ * scout year.
+ *
+ * These two lines used to be written 01/07/2026 and 03/07/2026 outright.
+ * That was inside the scout year on the day it was written and stopped
+ * being so at 00:00 on 1 September 2026, when the year became 2026-2027
+ * and July went from « this year » to « last year » — the import then
+ * read the file, filed neither line where the spec was looking, and the
+ * « 2 ligne(s) lue(s), 2 nouvelle(s) » it waits for never appeared.
+ *
+ * Relative to today is not enough on its own either: on 1 September,
+ * « three days ago » is still August, which is the previous scout year
+ * again. So the offset is clamped to the year's own first day — the same
+ * rule scripts/e2e-support.php applies to the membership fixtures it
+ * seeds, and for exactly the same reason.
+ *
+ * @param {number} daysAgo
+ */
+function statementDate(daysAgo) {
+    const now = new Date();
+    // A scout year opens on 1 September (Core\Config\ScoutYearService::
+    // labelForDate()); month 8 is September, JavaScript counting from 0.
+    const yearStart = new Date(now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1, 8, 1);
+
+    const wanted = new Date(now);
+    wanted.setDate(wanted.getDate() - daysAgo);
+
+    const date = wanted < yearStart ? yearStart : wanted;
+    const day = String(date.getDate()).padStart(2, '0');
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+
+    return `${day}/${month}/${date.getFullYear()}`;
+}
+
 function bnpStatement() {
     const iban = ACCOUNT_IBAN.replace(/ /g, '');
+    const spent = statementDate(3);
+    const received = statementDate(1);
+
     return [
         "﻿Nº de séquence;Date d'exécution;Date valeur;Montant;Devise du compte;Numéro de compte;Type de transaction;Contrepartie;Nom de la contrepartie;Communication;Détails;Statut;Motif du refus",
-        `2026-;01/07/2026;01/07/2026;-45,90;EUR;${iban};Virement en euros;BE00000000000002;Colruyt Namur;Courses camp;VIREMENT EN EUROS COLRUYT NAMUR COMMUNICATION : COURSES CAMP ;Accepté;`,
-        `2026-;03/07/2026;03/07/2026;120,00;EUR;${iban};Virement en euros;BE00000000000003;Parent Dupont;Participation camp;VIREMENT EN EUROS PARENT DUPONT COMMUNICATION : PARTICIPATION CAMP ;Accepté;`,
+        `2026-;${spent};${spent};-45,90;EUR;${iban};Virement en euros;BE00000000000002;Colruyt Namur;Courses camp;VIREMENT EN EUROS COLRUYT NAMUR COMMUNICATION : COURSES CAMP ;Accepté;`,
+        `2026-;${received};${received};120,00;EUR;${iban};Virement en euros;BE00000000000003;Parent Dupont;Participation camp;VIREMENT EN EUROS PARENT DUPONT COMMUNICATION : PARTICIPATION CAMP ;Accepté;`,
     ].join('\n');
 }
 
@@ -84,7 +122,14 @@ test('a statement imports, a receipt uploads through the client-side resize, and
     // first import's mandatory closing balance.
     // ---------------------------------------------------------------
     await page.goto('/finance/import', { waitUntil: 'load' });
-    await page.getByLabel('Compte').selectOption({ label: ACCOUNT_NAME });
+    // `exact`, here and on the receipts page below, because « Compte » is a
+    // substring of half the labels this module ships. The receipts page
+    // grew a « Changer le compte du reçu » dialog with its own « Nouveau
+    // compte » select, and a loose match then resolved to three elements
+    // and failed as a strict-mode violation — on a page this spec was not
+    // even testing the dialog of. Exact costs nothing and does not rot
+    // when a page gains a control.
+    await page.getByLabel('Compte', { exact: true }).selectOption({ label: ACCOUNT_NAME });
     await page.getByLabel('Fichier CSV').setInputFiles({
         name: 'releve-bnp.csv',
         mimeType: 'text/csv',
@@ -113,7 +158,7 @@ test('a statement imports, a receipt uploads through the client-side resize, and
     // stored file is the browser's, not ours.
     // ---------------------------------------------------------------
     await page.goto(`/finance/receipts`, { waitUntil: 'load' });
-    await page.getByLabel('Compte').selectOption({ label: ACCOUNT_NAME });
+    await page.getByLabel('Compte', { exact: true }).selectOption({ label: ACCOUNT_NAME });
     await page.waitForURL(/\/finance\/receipts\?account_id=\d+/, { waitUntil: 'load' });
 
     await page.getByRole('link', { name: 'Ajouter un reçu' }).click();

--- a/tests/e2e/specs/finance-receipts.spec.js
+++ b/tests/e2e/specs/finance-receipts.spec.js
@@ -54,19 +54,36 @@ const ACCOUNT_IBAN = 'BE71 0961 2345 6769';
  * @param {number} daysAgo
  */
 function statementDate(daysAgo) {
-    const now = new Date();
+    // Brussels, not the runner's timezone. Node here is not the process
+    // that decides which scout year a movement lands in — PHP is, and
+    // Core\Config\AppClock pins PHP to Europe/Brussels. On a CI runner
+    // set to UTC those two disagree for the two hours before midnight
+    // UTC, which on 31 August is the difference between « this scout
+    // year » and « last one »: this spec computed August dates while the
+    // application had already turned September, and the import filed
+    // neither line where the assertion was looking.
+    //
+    // Exactly the bug scripts/e2e-support.php's own clock fix addresses
+    // one layer down, and it has to be answered here too because this
+    // date is computed in Node before PHP ever sees it.
+    const inBrussels = (date) => new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'Europe/Brussels',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+    }).format(date);
+
+    const today = inBrussels(new Date());
+    const [year, month] = today.split('-').map(Number);
     // A scout year opens on 1 September (Core\Config\ScoutYearService::
-    // labelForDate()); month 8 is September, JavaScript counting from 0.
-    const yearStart = new Date(now.getMonth() >= 8 ? now.getFullYear() : now.getFullYear() - 1, 8, 1);
+    // labelForDate()).
+    const yearStart = `${month >= 9 ? year : year - 1}-09-01`;
 
-    const wanted = new Date(now);
-    wanted.setDate(wanted.getDate() - daysAgo);
+    const wanted = inBrussels(new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000));
+    // Both are YYYY-MM-DD, so a string comparison is a date comparison.
+    const [y, m, d] = (wanted < yearStart ? yearStart : wanted).split('-');
 
-    const date = wanted < yearStart ? yearStart : wanted;
-    const day = String(date.getDate()).padStart(2, '0');
-    const month = String(date.getMonth() + 1).padStart(2, '0');
-
-    return `${day}/${month}/${date.getFullYear()}`;
+    return `${d}/${m}/${y}`;
 }
 
 function bnpStatement() {


### PR DESCRIPTION
Le 1er septembre a cassé les deux suites de tests, pour deux raisons distinctes qui partagent la même racine : **du code de test qui décide seul quel jour on est**.

## 1. Le harnais E2E tournait sur une autre horloge que l'application

`public/index.php` épingle le processus sur Europe/Brussels via `Core\Config\AppClock`. `scripts/e2e-support.php` ne le faisait pas : il provisionnait sur le fuseau par défaut de PHP — UTC sur un runner CI comme sur un PHP macOS standard.

Vingt-deux heures par jour les deux horloges tombent d'accord sur la date. Entre 22:00 et 24:00 UTC non, et une fois par an ce désaccord tombe sur la seule date que cette application traite comme une frontière dure : une année scoute commence le 1er septembre. Mesuré sur une instance réelle, le 2026-08-31 à 22:48 UTC :

```
provisioning voyait : 2025-2026   (UTC, 2026-08-31)
l'app servie voyait : 2026-2027   (Europe/Brussels, 2026-09-01)
```

Le harnais semait donc membres, fonctions, périodes de section et réservations dans une année scoute, et l'application les cherchait dans une autre. Sept specs sont tombées d'un coup, toutes des recherches de membre revenant vides : `grantManagerBySearch()` ne trouvant personne, l'audience mass-mail aveugle à `kaa@example.invalid`, `/config/banner` répondant 403 à un super-admin dont la propre affiliation était devenue invisible.

Trois compléments accompagnent la correction d'horloge : `current_scout_year_id` épinglé au provisioning (un run qui traverse minuit ne se fait plus déplacer l'année sous les pieds), un avertissement quand un run démarre à moins d'une heure de la bascule, et des fixtures d'affiliation qui ne commencent plus avant leur propre année scoute. Ce dernier point est dit franchement dans son docblock : **il n'a rien corrigé tout seul**, il est gardé pour la cohérence des données.

## 2. La suite PHP épelle l'année civile

`'2025-2026', '2025-09-01', '2026-08-31'` apparaît **127 fois dans 122 fichiers**, semé comme `is_current`. `tests/bootstrap.php` appliquant `AppClock`, PHPUnit est passé en 2026-2027 à minuit et toutes ces données sont devenues invisibles : **80 tests rouges dans 22 classes**, sur une suite verte deux heures plus tôt.

`Tests\DatabaseTestHelper::scoutYear($offset)` répond l'année dans laquelle l'application se trouve réellement, et ses voisines — pour qu'une fixture puisse dire « l'année d'avant » sans dire de quelle année civile il s'agit. Appliqué aux classes qui voulaient dire « l'année courante » et ne savaient l'écrire qu'en chiffres. Les tests qui visent vraiment une année **fixe** (un import historique, une date dans une chaîne attendue) continuent de l'épeler ; la distinction est dans le docblock du helper.

**80 échecs deviennent 3**, et ces 3 sont préexistants et locaux : ils échouent aussi sur `main` vierge ici et passent en CI (un écart de `realpath` macOS `/var/folders` vs `/private/var/folders`, et une différence de repliement d'accents dans le SQLite de cette machine). Laissés tels quels délibérément.

## 3. Le même piège, une couche plus haut

`finance-receipts.spec.js` calcule ses dates de relevé **dans Node**, dont le fuseau est celui du runner — UTC en CI — alors que l'année scoute où ces mouvements atterrissent est décidée par PHP sur l'heure de Bruxelles. Vert ici en CEST, rouge en CI : c'est précisément ce qui a fait échouer la première CI de cette PR. Le calcul se fait maintenant explicitement en Europe/Brussels.

## Vérifications effectuées

- `npm run e2e:full` — **71 passed**, matrice de démarrage par module comprise.
- `npm run e2e:full` **sous `TZ=UTC`**, pour reproduire le fuseau de la CI plutôt que celui de ma machine — c'est l'écart qui avait laissé passer le point 3.
- `vendor/bin/phpunit` — 13857 tests, 3 échecs, tous préexistants et locaux (voir ci-dessus).
- `npx vitest run` — 1713 tests verts.
- `vendor/bin/phpstan analyse` et `npm run typecheck` — propres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF