### PR TITLE
Reliquat Sonar : les vrais findings, et ceux que Twig lui fait imaginer

### DIFF
--- a/core/View/templates/config/maintenance.html.twig
+++ b/core/View/templates/config/maintenance.html.twig
@@ -501,10 +501,15 @@
                         notification lorsqu'elle sera prête.
                     </p>
                     <form id="full-backup-form" {{ not zip_encryption_supported ? 'class="d-none"' : '' }}>
-                        {# A group of radios is labelled by a <legend> inside a
-                           <fieldset>, not by a loose <label> pointing at nothing:
-                           a screen reader announces the legend with each option,
-                           which is the whole point of the grouping. #}
+                        {# A group of radios is labelled by a legend inside a
+                           fieldset, not by a loose label pointing at nothing: a
+                           screen reader announces the legend with each option,
+                           which is the whole point of the grouping.
+
+                           Tag names spelled in words on purpose — Sonar's HTML
+                           parser does not know Twig comments, so writing them in
+                           angle brackets here makes it see a stray element and
+                           report it (Web:S8732 did exactly that on this block). #}
                         <fieldset class="mb-2 border-0 p-0">
                             <legend class="form-label small float-none w-auto">Portée</legend>
                             <div class="form-check">

--- a/core/View/templates/config/maintenance.html.twig
+++ b/core/View/templates/config/maintenance.html.twig
@@ -501,8 +501,12 @@
                         notification lorsqu'elle sera prête.
                     </p>
                     <form id="full-backup-form" {{ not zip_encryption_supported ? 'class="d-none"' : '' }}>
-                        <div class="mb-2">
-                            <label class="form-label small">Portée</label>
+                        {# A group of radios is labelled by a <legend> inside a
+                           <fieldset>, not by a loose <label> pointing at nothing:
+                           a screen reader announces the legend with each option,
+                           which is the whole point of the grouping. #}
+                        <fieldset class="mb-2 border-0 p-0">
+                            <legend class="form-label small float-none w-auto">Portée</legend>
                             <div class="form-check">
                                 <input class="form-check-input" type="radio" name="scope" id="scope-config" value="full_config" checked>
                                 <label class="form-check-label small" for="scope-config">Configuration seule (paramètres, structure — sans les données membres)</label>
@@ -517,7 +521,7 @@
                                     <label class="form-check-label small" for="scope-with-gallery">Site complet, avec la galerie photo</label>
                                 </div>
                             {% endif %}
-                        </div>
+                        </fieldset>
                         {% include 'partials/form_field.html.twig' with {
                             field_id: 'full-backup-password', type: 'password',
                             label: "Mot de passe de l'archive", required: true,

--- a/core/View/templates/config/support.html.twig
+++ b/core/View/templates/config/support.html.twig
@@ -151,7 +151,7 @@
                    clic AU-DESSUS de la case, jamais après elle.
 
                    Les deux cases, elles, restent hors du repli, et c'est
-                   technique autant qu'éthique : un `<input required>`
+                   technique autant qu'éthique : un champ requis
                    dans un conteneur `display:none` est un contrôle que le
                    navigateur ne peut pas mettre en avant, et Chrome
                    refuse alors l'envoi sans rien afficher du tout. #}

--- a/core/View/templates/members/show.html.twig
+++ b/core/View/templates/members/show.html.twig
@@ -4,7 +4,7 @@
    etc.) lives in components.css, which base.html.twig does NOT load by
    default — every other page using these components (Staffs, trombinoscope,
    calendar) links it explicitly via this same block. Without this link the
-   photo/placeholder has no sizing rule at all and the <img> renders at its
+   photo/placeholder has no sizing rule at all and the image renders at its
    raw intrinsic size, which is the actual root cause of the member photo
    "taking the whole screen" — not the CSS technique itself. #}
 {% block stylesheets %}

--- a/core/View/templates/partials/email_variable_buttons.html.twig
+++ b/core/View/templates/partials/email_variable_buttons.html.twig
@@ -8,7 +8,7 @@
 
   With `target` set, a click inserts `{{ '{{ nom }}' }}` at the cursor —
   in the subject field, and in the rich-text editor itself, which is a
-  `contenteditable` rather than an `<input>`: `public/assets/js/
+  `contenteditable` rather than a text field: `public/assets/js/
   email-variables.js` handles both, because the caret is the caret.
 
   With `target` null, a click copies the placeholder to the clipboard

--- a/core/View/templates/partials/select_bar.html.twig
+++ b/core/View/templates/partials/select_bar.html.twig
@@ -68,7 +68,7 @@
   `aria-current="true"` marks the selected row. A screen reader, a JS-off
   browser and a cached offline page all work.
 
-  mode: 'multi' — rows are <button aria-pressed>, toggled by
+  mode: 'multi' — rows are buttons carrying aria-pressed, toggled by
   public/assets/js/select-bar.js, which dispatches a `select-bar:change`
   CustomEvent (detail: { selectedIds }) on the container after every
   toggle. The trigger summarises the selection rather than drawing every

--- a/modules/attestations/views/batch.html.twig
+++ b/modules/attestations/views/batch.html.twig
@@ -160,7 +160,10 @@
                                             <select class="form-select form-select-sm"
                                                     form="attestations-assign-{{ line.id }}"
                                                     name="member_id"
-                                                    aria-label="Choisir le membre de l'attestation lue « {{ line.readName|default('sans nom lisible') }} »">
+                                                    {# The accessible name starts with the option text a sighted
+                                                       user reads (« Choisir un membre »), so voice control can say
+                                                       what it sees — WCAG 2.5.3, Label in Name. #}
+                                                    aria-label="Choisir un membre pour l'attestation lue « {{ line.readName|default('sans nom lisible') }} »">
                                                 <option value="">Choisir un membre…</option>
                                                 {% for candidateId in line.candidateMemberIds %}
                                                     <option value="{{ candidateId }}">

--- a/modules/sos_staff/views/config.html.twig
+++ b/modules/sos_staff/views/config.html.twig
@@ -73,7 +73,7 @@
             </button>
             <div id="consumer-key-validation" class="mt-2 {{ has_pending_consumer_key ? '' : 'd-none' }}">
                 <p class="small">Ouvrez ce lien pour confirmer les droits sur le site OVH, puis cliquez sur « J'ai validé, vérifier ».</p>
-                <p><a href="#" target="_blank" rel="noopener" id="consumer-key-validation-link"></a></p>
+                <p><a href="#" target="_blank" rel="noopener" id="consumer-key-validation-link">Ouvrir la page de validation OVH</a></p>
                 <button type="button" class="btn btn-sm btn-outline-primary" id="validate-consumer-key-btn">J'ai validé, vérifier</button>
             </div>
         {% endif %}

--- a/public/assets/js/news-form-builder.js
+++ b/public/assets/js/news-form-builder.js
@@ -1111,7 +1111,7 @@
                 priceInput.className = 'form-control';
                 priceInput.value = field.price_per_unit || '';
                 priceInput.addEventListener('input', function () {
-                    field.price_per_unit = priceInput.value !== '' ? parseFloat(priceInput.value) : null;
+                    field.price_per_unit = priceInput.value !== '' ? Number.parseFloat(priceInput.value) : null;
                     renderFieldList();
                 });
                 priceRow.appendChild(priceInput);
@@ -1274,9 +1274,9 @@
             var lines = [];
             numberFields.forEach(function (inputEl) {
                 var input = /** @type {HTMLInputElement} */ (inputEl);
-                var price = parseFloat(input.dataset.price);
+                var price = Number.parseFloat(input.dataset.price);
                 if (!price) return;
-                var qty = parseFloat(input.value) || 0;
+                var qty = Number.parseFloat(input.value) || 0;
                 var subtotal = qty * price;
                 total += subtotal;
                 lines.push('<p class="mb-1">' + input.dataset.label + ' : ' + qty + ' × ' + price.toFixed(2).replace('.', ',') + '€ = ' + subtotal.toFixed(2).replace('.', ',') + '€</p>');

--- a/public/assets/js/push-notifications.js
+++ b/public/assets/js/push-notifications.js
@@ -37,11 +37,13 @@
     // string the server exposes via data-vapid-public-key.
     function urlBase64ToUint8Array(base64String) {
         var padding = '='.repeat((4 - (base64String.length % 4)) % 4);
-        var base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+        var base64 = (base64String + padding).replaceAll('-', '+').replaceAll('_', '/');
         var rawData = atob(base64);
         var outputArray = new Uint8Array(rawData.length);
         for (var i = 0; i < rawData.length; i++) {
-            outputArray[i] = rawData.charCodeAt(i);
+            // Safe here: atob() yields a binary string, every code unit
+            // 0-255, so no surrogate pair can make the two disagree.
+            outputArray[i] = rawData.codePointAt(i);
         }
         return outputArray;
     }

--- a/public/sw.js
+++ b/public/sw.js
@@ -185,8 +185,8 @@ const CONTENT_CACHE_PREFIX = 'content-';
  * @returns {string}
  */
 function trimSlashes(value) {
-    var from = 0;
-    var to = value.length;
+    let from = 0;
+    let to = value.length;
     while (from < to && value[from] === '/') { from++; }
     while (to > from && value[to - 1] === '/') { to--; }
 

--- a/tests/js/news-payment-total.test.js
+++ b/tests/js/news-payment-total.test.js
@@ -1,0 +1,79 @@
+// Isolated JavaScript unit test — jsdom only. Exercises the REAL
+// implementation in public/assets/js/news-form-builder.js.
+//
+// A file of its own rather than a case inside news-form-builder.test.js,
+// and the reason is structural: the live payment total is not reachable
+// through that file's `ScoutMagicNewsFormBuilderInternals` seam. Its
+// `recalcPayment` is a closure created only when the module finds
+// `#news-payment-summary` in the DOM AT IMPORT TIME, inside the IIFE. A
+// test that imports the module first and builds the DOM afterwards can
+// never reach it — so the DOM is built at module scope here, before the
+// dynamic imports below.
+//
+// What it pins (module spec §11.4): the public submission form's running
+// total, which is what a family sees before they commit to paying. The
+// arithmetic is read out of `data-price` and the typed quantity, and both
+// reads are `Number.parseFloat` — a field left empty must count as zero
+// rather than poison the total with NaN.
+import { describe, expect, it } from 'vitest';
+
+document.body.innerHTML = `
+    <div id="news-payment-summary">
+        <input class="news-number-field" data-price="12.50" data-label="Repas" value="2">
+        <input class="news-number-field" data-price="3.25" data-label="Boisson" value="">
+        <input class="news-number-field" data-label="Sans prix" value="9">
+        <div id="news-payment-lines"></div>
+        <span id="news-payment-total"></span>
+    </div>
+`;
+
+// The site-wide toolboxes base.html.twig loads before every page script,
+// in the same order.
+await import('../../public/assets/js/api.js');
+await import('../../public/assets/js/toast.js');
+await import('../../public/assets/js/news-form-builder.js');
+
+const total = () => document.getElementById('news-payment-total').textContent;
+const lines = () => document.getElementById('news-payment-lines').innerHTML;
+const field = (label) => /** @type {HTMLInputElement} */ (
+    document.querySelector(`[data-label="${label}"]`)
+);
+
+describe('news-form-builder.js: live payment total', () => {
+    it('totals the priced fields on load, in euros with a comma', () => {
+        // 2 × 12,50 = 25,00. The empty « Boisson » contributes nothing, and
+        // the field with no data-price is not a priced line at all.
+        expect(total()).toBe('25,00');
+    });
+
+    it('counts an empty quantity as zero rather than as NaN', () => {
+        // The whole point of `|| 0` behind the parseFloat: one blank field
+        // must not turn the total into "NaN" in front of a family.
+        expect(total()).not.toContain('NaN');
+        expect(lines()).not.toContain('NaN');
+    });
+
+    it('ignores a field carrying no price', () => {
+        expect(lines()).not.toContain('Sans prix');
+    });
+
+    it('recomputes when a quantity is typed', () => {
+        const drink = field('Boisson');
+        drink.value = '4';
+        drink.dispatchEvent(new Event('input'));
+
+        // 2 × 12,50 + 4 × 3,25 = 25,00 + 13,00 = 38,00
+        expect(total()).toBe('38,00');
+        expect(lines()).toContain('Boisson');
+    });
+
+    it('treats a non-numeric quantity as zero', () => {
+        const meal = field('Repas');
+        meal.value = 'beaucoup';
+        meal.dispatchEvent(new Event('input'));
+
+        // Only the drink line survives: 4 × 3,25 = 13,00.
+        expect(total()).toBe('13,00');
+        expect(total()).not.toContain('NaN');
+    });
+});


### PR DESCRIPTION
Une analyse fraîche de `main` après la première passe laissait **13 findings « reliability » et 5 HIGH**. Ils se séparent proprement en deux, et la distinction mérite d'être faite plutôt que d'enchaîner la liste tête baissée.

## Réellement faux, et corrigés ici

- **`public/sw.js`** — ma propre régression de la première passe : le helper `trimSlashes` est arrivé en `var` dans un fichier écrit en `const`/`let`.
- **`parseFloat` → `Number.parseFloat`** dans `news-form-builder.js` — le même pur alias que `parseInt`, trois sites que la première passe avait manqués.
- **`push-notifications.js`** — le décodeur base64url de Web Push, jumeau de celui des passkeys déjà traité : `replaceAll` pour les deux substitutions littérales, `codePointAt` pour la lecture d'octet. Sûr pour la même raison, écrite sur place : `atob()` rend une chaîne binaire, chaque unité vaut 0-255, aucune paire de substitution ne peut exister pour que les deux divergent.
- **Un `<a>` vide** dans la config SOS, que `sos-config.js` remplit en révélant le bloc (sa ligne 196 écrase `textContent`) : un libellé par défaut ne coûte rien et évite que l'ancre existe sans nom accessible.
- **Les radios de portée de sauvegarde** étaient étiquetées par un `<label>` ne pointant vers aucun contrôle. Un groupe de radios s'étiquette par un `<legend>` dans un `<fieldset>` — c'est aussi ce qui fait répéter « Portée » à chaque option par un lecteur d'écran.
- **Le sélecteur de membre des attestations** : son `aria-label` commence désormais par le texte de l'option qu'un utilisateur voyant lit, pour que le pilotage vocal puisse dire ce qu'il voit (WCAG 2.5.3, *Label in Name*).

## Pas faux, et reformulés plutôt que « corrigés »

Le parseur HTML de Sonar ne comprend pas les `{# #}` de Twig : une prose qui épelle une balise est lue comme du vrai markup. Un `<input required>` dans un commentaire devenait « un champ sans label », un `<img>` dans un commentaire « une image sans alt ».

Quatre commentaires décrivent maintenant l'élément en mots plutôt qu'en chevrons. **Rien ne change dans la page rendue** ; ce qui change, c'est que ces findings cessent de se tenir devant chaque release sans que personne puisse agir dessus.

## Deux findings laissés délibérément

À rejeter dans SonarQube avec ce raisonnement, plutôt qu'à masquer dans le markup :

- **`form_field.html.twig`** — `autocomplete="{{ autocomplete }}"` est une expression Twig que Sonar lit comme une valeur d'attribut littérale et juge invalide. Il n'y a rien à corriger : l'attribut n'est émis que si un appelant passe un vrai token.
- **`groups/side_column.html.twig`** — WCAG 2.5.3 s'applique aux composants dont le libellé comporte du texte visible. Le contenu de cette ancre est des images à `alt` vide : elle n'a pas de libellé visible, la règle ne s'applique pas.

## Vérifications

- `npx vitest run` — 1769 tests verts.
- `npm run typecheck` — propre.
- Suites de vues (Maintenance, UxConventions, SwitchAriaChecked, FormField, SelectBar) vertes, hors l'échec `SupportTicketService` de repliement d'accents que cette machine a depuis le début et que la CI ne reproduit pas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF