### PR TITLE
La recherche insensible aux accents ne l'était que sur glibc

### DIFF
--- a/modules/support_dashboard/src/Service/SupportTicketService.php
+++ b/modules/support_dashboard/src/Service/SupportTicketService.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Modules\SupportDashboard\Service;
 
 use Core\Journal\JournalService;
+use Core\Service\TextNormalizerService;
 use Modules\SupportDashboard\Repository\SupportTicketRepository;
 use Modules\SupportDashboard\TicketCategory;
 
@@ -247,12 +248,19 @@ class SupportTicketService
     /**
      * Case- and accent-insensitive, because « problème » and « probleme »
      * are the same search to the person typing it.
+     *
+     * Delegates to Core\Service\TextNormalizerService::fold(), which is
+     * where this project's one accent-folding rule lives. This used to be
+     * `iconv('UTF-8', 'ASCII//TRANSLIT', …)`, which that helper's docblock
+     * names explicitly as the thing never to use: its output depends on the
+     * C library. On glibc « arrête » folds to « arrete »; on the libiconv
+     * that macOS and musl ship it comes back « arr^ete », so the search
+     * silently stopped ignoring accents on those hosts while CI, on glibc,
+     * stayed green and saw nothing.
      */
     private static function fold(string $value): string
     {
-        $folded = @iconv('UTF-8', 'ASCII//TRANSLIT', $value);
-
-        return mb_strtolower($folded !== false ? $folded : $value);
+        return TextNormalizerService::fold($value);
     }
 
     /**

--- a/tests/Core/Database/MigrationRunnerChunkingTest.php
+++ b/tests/Core/Database/MigrationRunnerChunkingTest.php
@@ -37,6 +37,16 @@ class MigrationRunnerChunkingTest extends TestCase
     {
         $this->tmpDir = sys_get_temp_dir() . '/migration_chunking_test_' . uniqid();
         mkdir($this->tmpDir);
+        // Canonicalised, because MigrationRunner canonicalises too: it keys
+        // both the schema-hash setting and the resumable progress row on
+        // realpath() of the schema file (ARCHITECTURE.md §10, « One file is
+        // one migration, however it is spelled »). On Linux sys_get_temp_dir()
+        // is already canonical and the difference never shows; on macOS
+        // /var/folders/... resolves to /private/var/folders/..., so a test
+        // deriving its expected key from the raw path looked for a setting
+        // the runner had written under a different name — and failed on a
+        // path difference while claiming the chunking was broken.
+        $this->tmpDir = realpath($this->tmpDir);
         $this->schemaPath = $this->tmpDir . '/schema.sql';
         file_put_contents(
             $this->schemaPath,


### PR DESCRIPTION
## Le défaut

`SupportTicketService::fold()` utilisait `iconv('UTF-8', 'ASCII//TRANSLIT', …)`. Le docblock de `Core\Service\TextNormalizerService::fold()` désigne **explicitement** cet appel comme celui qu'il ne faut jamais faire, et dit pourquoi en une ligne : sa sortie dépend de la bibliothèque C. Ce module a réinventé l'utilitaire du cœur et a choisi l'implémentation proscrite.

Mesuré :

| Plateforme | `fold('arrête')` |
|---|---|
| glibc (Linux, CI) | `arrete` ✅ |
| libiconv (macOS, musl/Alpine) | `arr^ete` ❌ |

Sur un tel hébergement, la recherche de la page Support **cessait silencieusement d'ignorer les accents** : un mainteneur tapant « arrete » ne trouvait rien, et rien ne disait pourquoi. La CI tourne en glibc, voyait la bonne moitié, et est restée verte tout du long.

Désormais délégué à l'utilitaire du cœur, qui applique une table explicite sans condition — précisément pour cette raison.

## Et un test qui avait tort, lui

`MigrationRunnerChunkingTest` dérivait ses clés de réglage attendues du chemin temporaire brut, alors que `MigrationRunner` les indexe sur le `realpath()` du même fichier (ARCHITECTURE.md §10, « One file is one migration, however it is spelled »).

Identique sous Linux, où `sys_get_temp_dir()` est déjà canonique. Sous macOS, `/var/folders` se résout en `/private/var/folders` : le test cherchait des réglages que le runner avait écrits sous un autre nom, et rapportait le découpage comme cassé. Il canonicalise maintenant, comme le code qu'il teste.

## Une remarque sur ma propre lecture

Ces trois échecs étaient présents sur cette machine depuis le début de la session, et je les ai qualifiés à plusieurs reprises de « locaux, verts en CI ». **Deux l'étaient. Le troisième était un vrai défaut que la CI ne pouvait pas voir.** C'est la porte des tests de la release, qui exige un `phpunit` vert localement, qui a forcé à les regarder pour de bon.

## Vérifications

- `vendor/bin/phpunit` — **14074 tests, zéro échec**, pour la première fois sur cette machine.
- `vendor/bin/phpstan analyse` — propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF