### PR TITLE
Une étape d'année scoute est cochée par un écouteur, pas par du markup

### DIFF
--- a/public/assets/js/admin-scout-year.js
+++ b/public/assets/js/admin-scout-year.js
@@ -38,4 +38,25 @@
             }
         });
     });
+
+    // Every listener above is now attached, and this says so.
+    //
+    // Same convention, and the same reason, as sos-admin.js's `sos-js`
+    // marker and confirm.js's delegated flag: a step is ticked by a
+    // listener bound HERE, not by markup, so a page whose HTML has
+    // rendered is not yet a page that reacts. A click landing in that
+    // window toggles the box and submits nothing — no error, no request,
+    // no effect — and whoever was waiting for the POST waits out their
+    // ceiling instead.
+    //
+    // Nobody working by hand can lose that race: reading a thirteen-step
+    // workflow takes far longer than this file needs. A browser suite
+    // can, and did — specs/scout-year-transition.spec.js ticks four steps
+    // in a row and failed intermittently on « waitForResponse: Timeout
+    // 10000ms exceeded », passing 71/71 on the very next run.
+    //
+    // The class is the only honest proof that this file ran: written from
+    // here rather than into the template, so a page whose JavaScript
+    // failed to load never claims otherwise.
+    document.documentElement.classList.add('scout-year-js');
 })();

--- a/tests/e2e/specs/scout-year-transition.spec.js
+++ b/tests/e2e/specs/scout-year-transition.spec.js
@@ -153,6 +153,21 @@ async function chooseYear(form, label) {
  * @param {string} key
  */
 async function toggleStep(page, key) {
+    // Wait for the page to REACT before clicking it.
+    //
+    // Ticking a step is not markup: public/assets/js/admin-scout-year.js
+    // binds a `change` listener that submits the step's form. A click
+    // landing before that listener exists toggles the box and submits
+    // nothing, so the POST below never comes and this helper waits out its
+    // ceiling on a request the page was never going to make. That is what
+    // made this spec fail intermittently — « waitForResponse: Timeout
+    // 10000ms exceeded » on one run, 71/71 on the next.
+    //
+    // Same marker convention as support/sos.js and support/confirm-dialog.js.
+    await page.waitForFunction(
+        () => document.documentElement.classList.contains('scout-year-js')
+    );
+
     // The POST is what the round-trip hangs on, and the page it redirects
     // to is already the one we are on — so waiting on the URL would resolve
     // instantly and assert against the pre-submit DOM. Wait on the request


### PR DESCRIPTION
## Le symptôme, et pourquoi il fallait résister à la conclusion facile

`specs/scout-year-transition.spec.js` échouait par intermittence sur « waitForResponse: Timeout 10000ms exceeded » en cochant l'une des quatre étapes manuelles — puis passait **71/71 au run suivant**. C'est précisément ce qui rendait tentant de conclure « flake » et de relancer la release jusqu'à ce qu'elle passe.

Ce n'en est pas un.

## La cause

Cocher une étape, c'est du JavaScript : `admin-scout-year.js` attache un écouteur `change` sur `.js-step-checkbox` qui soumet le formulaire de l'étape. Un clic arrivé **avant** que cet écouteur existe coche la case et ne soumet rien — pas d'erreur, pas de requête, aucun effet. Le helper attend alors son plafond sur un POST que la page n'allait jamais faire.

C'est la même forme que les courses fermées par #122, et le dépôt avait déjà la réponse : la classe `sos-js` de `sos-admin.js`, le marqueur de `groups.js`, le drapeau délégué de `confirm.js`. Cette page avait manqué la convention.

Les deux moitiés la suivent désormais : le script pose `scout-year-js` une fois ses écouteurs attachés, le helper l'attend avant de cliquer.

Personne ne peut perdre cette course à la main — lire un workflow de treize étapes prend bien plus longtemps que le chargement du fichier. Une suite qui coche quatre étapes d'affilée, si.

## Pourquoi cela comptait maintenant

Deux portes de `scripts/release.sh` en dépendaient : la porte de bout en bout, et la porte de scan dynamique — qui refuse de conclure sur un trafic incomplet (« a scan is only as complete as the traffic it was given »). La release était bloquée par les deux.

## Vérifications

- `npm run e2e:full` — **71 passed**.
- `npx vitest run` — 1774 tests verts.
- `npm run typecheck` — propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF