### PR TITLE
Le scan dynamique devient exécutable hors Linux : l'instance et le navigateur s'accordent sur son nom

### DIFF
--- a/core/Module/InstallationProfile.php
+++ b/core/Module/InstallationProfile.php
@@ -65,9 +65,25 @@ final class InstallationProfile
     /**
      * Hosts that are a local installation whatever their shape.
      *
+     * `host.docker.internal` is the exact name Docker Desktop publishes for
+     * "the machine running the container", so an installation answering to
+     * it is a developer's machine by construction — never a deployment.
+     * scripts/dast.sh gives the throwaway instance that name off Linux, so
+     * that the browser (whose requests ZAP resolves from inside its own
+     * container) and the instance agree about what the instance is called.
+     * Without this line the security scan lost modules/test_tools to the
+     * visible_when filter and specs/journal-uncaught-error.spec.js got a
+     * 404 for /test-tools.
+     *
+     * The exact name and not the whole `.internal` TLD, even though
+     * StatisticsSender::NON_PUBLIC_TLDS reasonably lists it: a company
+     * intranet may legitimately serve a real installation from
+     * `scoutmagic.internal`, and that one should not be handed the test
+     * toolbox. This name cannot be anything but loopback.
+     *
      * @var array<int, string>
      */
-    private const LOCAL_HOSTS = ['localhost', '127.0.0.1', '::1'];
+    private const LOCAL_HOSTS = ['localhost', '127.0.0.1', '::1', 'host.docker.internal'];
 
     /**
      * Last DNS labels that mark a local installation ("unite.test",

--- a/scripts/dast.sh
+++ b/scripts/dast.sh
@@ -499,6 +499,24 @@ ZAP_PORT="${DAST_ZAP_PORT:-$(php "${SUPPORT}" free-port)}"
 # instance calling itself 127.0.0.1 cannot register a passkey at all, and
 # the browser suite's passkey scenario is part of the traffic this scan
 # replays).
+# The host the INSTANCE calls itself, decided here because provisioning
+# needs it and the ZAP block below runs much later. Linux keeps
+# `localhost` exactly as before; on Docker Desktop the browser reaches the
+# instance through ZAP, which resolves names inside its own container, so
+# the instance has to agree or every absolute link it builds (magic-link
+# e-mail, password reset, registration tracking, passkey rpId) points at a
+# host ZAP cannot reach. See e2e_base_url()'s docblock for the three
+# properties that were re-checked against this name.
+if [[ "$(uname -s)" == "Linux" ]]; then
+    INSTANCE_HOST="localhost"
+else
+    INSTANCE_HOST="host.docker.internal"
+fi
+export E2E_BASE_HOST="${INSTANCE_HOST}"
+
+# Host-side probing keeps using localhost: this script, the readiness
+# poll and the authorization matrix all run on the host, where
+# host.docker.internal does not resolve.
 BASE_URL="https://localhost:${PORT}"
 
 echo "DAST: generating a self-signed certificate for this run."
@@ -609,7 +627,7 @@ if [[ "$(uname -s)" == "Linux" ]]; then
     ZAP_LISTEN_HOST="127.0.0.1"
 else
     ZAP_NETWORK_ARGS=(--publish "127.0.0.1:${ZAP_PORT}:${ZAP_PORT}" --add-host "host.docker.internal:host-gateway")
-    ZAP_TARGET="https://host.docker.internal:${PORT}"
+    ZAP_TARGET="https://${INSTANCE_HOST}:${PORT}"
     ZAP_PROXY="http://127.0.0.1:${ZAP_PORT}"
     ZAP_LISTEN_HOST="0.0.0.0"
     echo "DAST: not Linux — ZAP will reach the instance as ${ZAP_TARGET}."
@@ -638,26 +656,24 @@ fi
 # HTTPS connection with its own CA, so the browser never sees the
 # instance's certificate, and ZAP does not verify it.
 #
-# NECESSARY BUT NOT YET SUFFICIENT ON DOCKER DESKTOP. This restores the
-# traffic — ZAP records the site map it used to leave empty — and most of
-# the suite passes. What still fails is every scenario that follows a link
-# the SERVER built: the instance is provisioned through
-# scripts/e2e-support.php e2e_base_url(), which hardcodes `localhost`, so
-# a magic-link email and a passkey's Relying Party ID still name a host
-# ZAP resolves to its own container. Measured: the password login and the
-# public pages pass, the magic link and the passkey do not.
+# THE INSTANCE NOW AGREES, which is what makes this gate runnable off
+# Linux at all. It used to restore the traffic and no more: ZAP recorded
+# its site map, most of the suite passed, and every scenario following a
+# link the SERVER built still failed, because e2e_base_url() hardcoded
+# `localhost` — so a magic-link e-mail, a password reset, a registration
+# tracking link and a passkey's Relying Party ID all named a host ZAP
+# resolved to its own container. Measured on macOS: 8 of 50 specs failed
+# that way, and raising DAST_TIMEOUT_FACTOR to 10 changed nothing, which
+# is what proved it was not latency.
 #
-# Making the instance agree is NOT the one-line change it looks like, and
-# e2e_base_url()'s own docblock is where to start before trying: three
-# documented behaviours are keyed to the literal name `localhost` — most
-# sharply Core\Statistics\StatisticsSender::isPublicHost(), which refuses
-# to report BECAUSE it recognises that name. An instance calling itself
-# host.docker.internal may consider itself a public host and start
-# reporting outward from a security scanning bench. Any fix has to answer
-# that first.
+# The three behaviours keyed to the literal `localhost` were the reason to
+# be careful, and each was checked against the new name rather than
+# assumed — the sharpest of them, StatisticsSender::isPublicHost(),
+# already answers false because `.internal` is in its NON_PUBLIC_TLDS
+# list. e2e_base_url()'s docblock records all three.
 #
-# Until then the dynamic gate is a Linux/CI gate: it runs green there (and
-# on af70f87c it did), and needs --skip-dast-gate to release from macOS.
+# Linux is untouched: INSTANCE_HOST is `localhost` there, so CI runs the
+# byte-identical harness it always did.
 BROWSER_URL="${ZAP_TARGET}"
 
 echo "DAST: starting OWASP ZAP (${DAST_ZAP_IMAGE}) on ${ZAP_PROXY}."

--- a/scripts/e2e-support.php
+++ b/scripts/e2e-support.php
@@ -187,6 +187,33 @@ function e2e_free_port(): int
  * server, the provisioning, the settings and Playwright's baseURL can
  * never disagree about what the instance is called.
  *
+ * The HOST is `localhost` unless E2E_BASE_HOST says otherwise, and only
+ * scripts/dast.sh sets it, only on Docker Desktop. There the browser
+ * reaches the instance as `host.docker.internal`, because ZAP resolves
+ * every request from inside its container where `localhost` is the
+ * container itself. An instance still calling ITSELF `localhost` then
+ * builds absolute links — a magic-link email, a password-reset link, a
+ * registration tracking link, a passkey's Relying Party ID — pointing at
+ * a host ZAP cannot reach, and those scenarios fail while the rest pass.
+ *
+ * The three properties above were re-checked against that name before
+ * this was allowed, because the concern is real and dast.sh records it:
+ *
+ *   - isPublicHost() already answers false for it, and not by accident:
+ *     `.internal` is in its NON_PUBLIC_TLDS list beside `.local` and
+ *     `.test`. A scanning bench cannot start reporting outward.
+ *   - DestinationMatcher still sees the instance as its own destination,
+ *     because `statistics_destination` is written from THIS function too,
+ *     so both sides move together.
+ *   - WebAuthn is unaffected: an rpId must be a domain rather than an IP
+ *     literal, and this is one.
+ *
+ * The one real difference is OgScraperService: on `localhost` it refuses
+ * because the name resolves to a private address, and under this name it
+ * refuses because the name does not resolve from the server at all. The
+ * documented degradation groups-discussion.spec.js relies on is the same
+ * refusal either way, for a different stated reason.
+ *
  * The scheme is `http` unless E2E_BASE_SCHEME says otherwise. Only
  * scripts/dast.sh sets it, to `https`: the security scan puts a TLS
  * terminator in front of `php -S` (scripts/dast-tls-proxy.php) because
@@ -204,7 +231,9 @@ function e2e_base_url(int $port): string
         exit(1);
     }
 
-    return $scheme . '://localhost:' . $port;
+    $host = ((string) getenv('E2E_BASE_HOST')) ?: 'localhost';
+
+    return $scheme . '://' . $host . ':' . $port;
 }
 
 /**


### PR DESCRIPTION
`scripts/dast.sh` portait une note concluant que la porte dynamique était **une porte Linux/CI**, nécessitant `--skip-dast-gate` pour publier depuis macOS.

Mesuré ici : **8 specs sur 50 échouaient**, et toutes suivaient un lien construit par le **serveur** — e-mail de lien magique, réinitialisation de mot de passe, lien de suivi d'inscription, Relying Party ID d'une passkey, jeton ICS.

## Ce qui a écarté la mauvaise piste

Porter `DAST_TIMEOUT_FACTOR` à 10 n'a rien changé sinon l'horloge : les specs sont passées de 42 s à 1,9 min et ont **échoué pareil**. C'est ce qui a éliminé la latence et désigné l'adresse.

## La cause

Hors Linux, le navigateur joint l'instance comme `host.docker.internal`, parce que ZAP résout chaque requête depuis son propre conteneur, où `localhost` est le conteneur. L'instance, elle, s'appelait toujours `localhost` : chaque lien absolu qu'elle construisait nommait un hôte que ZAP ne pouvait pas atteindre.

`E2E_BASE_HOST` met les deux d'accord — symétrique de l'`E2E_BASE_SCHEME` déjà présent, non défini partout ailleurs.

**Sur Linux, `INSTANCE_HOST` reste `localhost` : la CI exécute le harnais identique au bit près, et `npm run e2e` est inchangé (vérifié : 50/50).**

## Les objections de la note, vérifiées une par une

La prudence de la note était le bon réflexe. Chaque comportement a été **contrôlé** contre le nouveau nom, pas supposé :

| Comportement | Résultat |
|---|---|
| `StatisticsSender::isPublicHost()` | répond déjà `false` — `.internal` est dans `NON_PUBLIC_TLDS` |
| `DestinationMatcher` | correspond toujours : les deux côtés viennent de la même fonction |
| WebAuthn rpId | exige un domaine, pas une IP littérale — c'en est un |

## Un quatrième, que rien ne documentait

`Core\Module\InstallationProfile` indexe son drapeau *installation locale* sur le nom littéral, et ce drapeau filtre `modules/test_tools` via `visible_when`. L'instance renommée n'était plus « locale », le module disparaissait, `/test-tools` répondait 404 — trouvé **uniquement parce que le renommage l'a fait surgir**.

Le nom exact devient un hôte local, **délibérément pas le TLD `.internal` entier** : un intranet d'entreprise peut servir une vraie installation depuis `scoutmagic.internal` et ne doit pas recevoir la boîte à outils de test. Ce nom-ci ne peut être que du bouclage.

## Résultat sur macOS

**50/50, aucun finding ≥ Medium, 5,9 min** — contre 16,6 min au facteur 10, parce que la correction supprime les échecs au lieu de les attendre plus longtemps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF