### PR TITLE
Support : mesurer une lenteur pendant cinq minutes, pour tous les comptes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1620,6 +1620,19 @@ The instance's half of §8.49ter, on Configuration > Support, `superadmin` like 
 
 **The category list is the receiver's**, published in every answer of the ticket endpoint and remembered here — including on a refusal, which is exactly when it has most to say. `TicketCategories::shipped()` is what an installation offers before it has ever heard one: a form that could not be filled until a previous ticket had been sent could not be used to send the first one. One malformed entry discredits the whole stored list, because a picker half-built from a corrupted setting is worse than the shipped one.
 
+### 8.48ter Measuring a slow site from the Support page (`Core\Debug\MeasurementWindow`)
+
+« Le site est lent » is the ticket a maintainer can do the least with: which page, for whom, and which of the forty steps of a request. `RequestTimeline` (`core/Debug/`, lot 0 of `docs/chantiers/CHANTIER-performance.md`) answers all three, but only for a request that carries `?debug=1` — an administrator's URL trick, never a chef's ordinary tap. The measurement window turns it on for **every request of every account** for a few minutes, so the person who sees the slowness measures it on the pages they see it on, and ships the result with the ticket.
+
+**The window is a flag file, and its modification time is its expiry.** `Core\Debug\MeasurementWindow::isOpen()` is one `filemtime()` on `storage/temp/measure_until` — 2 µs when the file is absent, which is the ordinary case — asked at the very top of `public/index.php`, before the database is connected and before the settings exist, because the requests worth measuring are the ones slow to get that far. It is deliberately not a setting: a setting is readable only once the settings service is built, and a setting somebody forgets to switch back stays on. A file whose time has passed is simply closed; nothing has to run for that to happen, so a window nobody stopped cannot outlive its five minutes (`DEFAULT_MINUTES`; `open()` clamps to `MAX_MINUTES`, fifteen). When it is open, `RequestTimeline::activate()` records the request exactly as `?debug=1` would; the clock still starts at the request's own start.
+
+**Every request, whoever sent it, and capped.** At the end of the request `index.php` journals the timeline (`debug_request_timeline`, with the method, the path, the role and the checkpoints — the path only, never the query string) either because an admin asked for it explicitly with `?debug=1`, as before, or because the window is open and `recordRequest()` still accepted one: a second file counts the recorded requests one byte each and refuses past `MAX_REQUESTS` (500), so a busy site during a window does not write thousands of journal rows. The window is re-checked there rather than remembered from the top of the file, so a request that started inside it and ended after its close is still one of its requests, and the cap is what stops it, not the clock. Anonymous requests are recorded too — the public pages can be slow as well — with `role: public` and no account. `RequestTimeline::wasRequested()` tells the two triggers apart: only the explicit one also writes the early `debug_request_hit` entry that survives a request the execution-time limit kills.
+
+**Opened from Configuration > Support (`superadmin`), behind a confirmation.** `SupportController::startMeasurement()` (`POST /config/support/measure`) is a plain form with `data-confirm`, because the page has to say, before anything is recorded, that every page served for the next five minutes will be journaled for every account; `stopMeasurement()` closes it early and keeps the count. Both are journaled (`measurement_window_opened` / `measurement_window_closed`). The card shows the window's state — until when, on the application clock, and how many requests it recorded of the cap — and, once closed, reminds the administrator to generate a **new** support package before sending the ticket: the archive is what carries the measurements, and the one generated yesterday does not have them.
+
+**The archive gets two readable files, not journal rows.** `Core\Support\Collector\RequestTimelinesCollector` (`request_timelines`, described on the consent screen like every other collector — `ArchiveContents`) reads the `debug_request_timeline` rows of the same 48-hour window the journal export uses and writes `request-timelines.csv`, one line per **segment** of every recorded request (the time and the SQL statements between two consecutive checkpoints, which is how an N+1 or a heavy module block is read off a timeline rather than off the code), and `request-timelines-resume.txt`, one line per path, slowest first: count, median and worst total, median statement count, and the segment that costs the most. A window that recorded nothing is reported as `no_measurement_recorded`, not shipped as an empty file.
+
+**What it cannot see, said on the page and in the summary.** The timeline measures the server, between the first line of `index.php` and the last byte of the response. It sees nothing of the network, the service worker, the offline pre-download or the rendering — and the two symptoms that started the performance chantier (a slow installed app, a menu tap that seemed to do nothing) were entirely on that side. A ticket measured through this window and showing 50 ms pages is therefore not proof that all is well; `docs/chantiers/CHANTIER-performance.md` §6 describes the client-side beacon that would complete it.
 ### 8.49 Statistics receiver module (`modules/support_dashboard`)
 
 The other end of §8.47: one ScoutMagic installation acts as the receiver, collects every other installation's daily report, and shows them on a dashboard. The working name "GLOBAL STATISTICS" appears nowhere — the module is `support_dashboard`, "Tableau de bord support".
@@ -3353,10 +3366,12 @@ core/
   Image/         ImageDimensionGuard — the pixel-count ceiling every decode passes (SECURITY.md §25)
   System/        ExecutableLocator, ShellExecutor
   Debug/         RequestTimeline — opt-in `?debug=1` per-request timing/memory checkpoints, each
-                 stamped with the running SQL statement count (one per module block of index.php).
-                 Server time only: it sees nothing of the network, the service worker or the
-                 rendering (docs/chantiers/CHANTIER-performance.md §6 for the client-side beacon
-                 that would complete it)
+                 stamped with the running SQL statement count (one per module block of index.php);
+                 MeasurementWindow — the flag file that turns it on for every request for a few
+                 minutes, from Configuration > Support (§8.48ter). Server time only: it sees nothing
+                 of the network, the service worker or the rendering
+                 (docs/chantiers/CHANTIER-performance.md §6 for the client-side beacon that would
+                 complete it)
   Exception/     UserFacingException/UserFacingMessage — the marker that says a caught
                  exception's message may be shown to the visitor verbatim
   Service/       Cross-cutting helpers (e.g. TextNormalizerService, DeskDateParser)

--- a/core/Debug/MeasurementWindow.php
+++ b/core/Debug/MeasurementWindow.php
@@ -77,10 +77,11 @@ final class MeasurementWindow
         }
         // The content is for a reader (the Support page, the collector);
         // the modification time is for the request-time check.
-        file_put_contents($this->flagPath, (string) json_encode([
+        $content = (string) json_encode([
             'opened_at' => $now->getTimestamp(),
             'expires_at' => $expiresAt->getTimestamp(),
-        ]), LOCK_EX);
+        ]);
+        file_put_contents($this->flagPath, $content, LOCK_EX);
         touch($this->flagPath, $expiresAt->getTimestamp());
         @unlink($this->counterPath());
         clearstatcache(true, $this->flagPath);

--- a/core/Debug/MeasurementWindow.php
+++ b/core/Debug/MeasurementWindow.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Debug;
+
+/**
+ * A few minutes during which EVERY request journals its RequestTimeline —
+ * opened by a superadmin from Configuration > Support, so that « le site
+ * est lent » can be measured by the person who sees it, on the pages they
+ * see it on, and shipped to the support with the next ticket
+ * (Core\Support\Collector\RequestTimelinesCollector).
+ *
+ * The window is a flag file whose modification time is its expiry. That
+ * is the whole state, and it is deliberately not a setting: the check
+ * runs on every request of the site, before the database is connected,
+ * before the settings exist, and the day the window is open is the day
+ * the site is slow. One `filemtime()` on an absent file costs 2 µs and
+ * the ordinary case — no window — does no other work at all. A file
+ * whose time has passed is simply closed; nothing has to run to close it,
+ * so a window nobody stopped cannot stay open.
+ *
+ * A second file counts the requests recorded, one byte each, and caps
+ * them: a busy site during a fifteen-minute window would otherwise write
+ * thousands of journal rows.
+ *
+ * What the window records is the server's time only — see
+ * docs/chantiers/CHANTIER-performance.md §6 for what it cannot see.
+ */
+final class MeasurementWindow
+{
+    public const DEFAULT_MINUTES = 5;
+    public const MAX_MINUTES = 15;
+    public const MAX_REQUESTS = 500;
+
+    public function __construct(
+        private readonly string $flagPath,
+        private readonly int $maxRequests = self::MAX_REQUESTS,
+    ) {
+    }
+
+    /** Where the flag lives for an installation: alongside the other request-time caches. */
+    public static function flagPathIn(string $storagePath): string
+    {
+        return $storagePath . '/temp/measure_until';
+    }
+
+    /**
+     * The one question every request asks. One stat, no read.
+     */
+    public function isOpen(?int $now = null): bool
+    {
+        $expires = @filemtime($this->flagPath);
+
+        return $expires !== false && $expires > ($now ?? time());
+    }
+
+    /**
+     * Opens (or re-opens, restarting the count) the window for at most
+     * MAX_MINUTES from now.
+     *
+     * @return \DateTimeImmutable when it closes
+     */
+    public function open(int $minutes = self::DEFAULT_MINUTES, ?\DateTimeImmutable $now = null): \DateTimeImmutable
+    {
+        $minutes = max(1, min(self::MAX_MINUTES, $minutes));
+        $now ??= new \DateTimeImmutable();
+        $expiresAt = $now->modify('+' . $minutes . ' minutes');
+
+        $directory = dirname($this->flagPath);
+        if (!is_dir($directory)) {
+            @mkdir($directory, 0770, true);
+        }
+        // The content is for a reader (the Support page, the collector);
+        // the modification time is for the request-time check.
+        file_put_contents($this->flagPath, (string) json_encode([
+            'opened_at' => $now->getTimestamp(),
+            'expires_at' => $expiresAt->getTimestamp(),
+        ]), LOCK_EX);
+        touch($this->flagPath, $expiresAt->getTimestamp());
+        @unlink($this->counterPath());
+        clearstatcache(true, $this->flagPath);
+        clearstatcache(true, $this->counterPath());
+
+        return $expiresAt;
+    }
+
+    /**
+     * Closes the window now. The count of what was recorded is kept, so
+     * the Support page can still say how much the next archive carries.
+     */
+    public function close(): void
+    {
+        @unlink($this->flagPath);
+        clearstatcache(true, $this->flagPath);
+    }
+
+    public function expiresAt(): ?\DateTimeImmutable
+    {
+        if (!$this->isOpen()) {
+            return null;
+        }
+        $expires = @filemtime($this->flagPath);
+
+        return $expires === false ? null : (new \DateTimeImmutable('@' . $expires));
+    }
+
+    public function openedAt(): ?\DateTimeImmutable
+    {
+        $content = @file_get_contents($this->flagPath);
+        if ($content === false) {
+            return null;
+        }
+        $decoded = json_decode($content, true);
+        $openedAt = is_array($decoded) ? ($decoded['opened_at'] ?? null) : null;
+        if (!is_int($openedAt)) {
+            return null;
+        }
+
+        // A Unix timestamp this class wrote itself, never a stored
+        // date string: the '@' form neither parses prose nor answers
+        // "now" for an empty value.
+        return new \DateTimeImmutable('@' . $openedAt);
+    }
+
+    /**
+     * Counts one recorded request; false once the cap is reached, and the
+     * caller then journals nothing for this one.
+     */
+    public function recordRequest(): bool
+    {
+        if ($this->recordedRequests() >= $this->maxRequests) {
+            return false;
+        }
+        @file_put_contents($this->counterPath(), '.', FILE_APPEND | LOCK_EX);
+        clearstatcache(true, $this->counterPath());
+
+        return true;
+    }
+
+    /** How many requests the current (or last) window recorded. */
+    public function recordedRequests(): int
+    {
+        $size = @filesize($this->counterPath());
+
+        return $size === false ? 0 : (int) $size;
+    }
+
+    private function counterPath(): string
+    {
+        return $this->flagPath . '.count';
+    }
+}

--- a/core/Debug/RequestTimeline.php
+++ b/core/Debug/RequestTimeline.php
@@ -12,10 +12,11 @@ use Core\Database\QueryCounter;
 
 /**
  * Opt-in, per-request timing/memory checkpoints for diagnosing slow page
- * loads in production — activated by `?debug=1` on any URL, but only ever
- * written to the event journal for an authenticated admin (gated by the
- * caller, not this class, since role resolution happens well after this
- * needs to start recording). A plain static accumulator rather than an
+ * loads in production — activated by `?debug=1` on any URL, or for every
+ * request while a Core\Debug\MeasurementWindow is open, but only ever
+ * written to the event journal for an authenticated admin or inside that
+ * window (gated by the caller, not this class, since role resolution
+ * happens well after this needs to start recording). A plain static accumulator rather than an
  * injected service: the thing being measured is the whole request,
  * starting before most services exist, and ending past the point normal
  * request-scoped objects are still in scope for public/index.php to hand
@@ -43,11 +44,35 @@ final class RequestTimeline
     public static function isActive(): bool
     {
         if (self::$active === null) {
-            self::$active = isset($_GET['debug']);
+            self::$active = self::wasRequested();
             self::$start = $_SERVER['REQUEST_TIME_FLOAT'] ?? microtime(true);
         }
 
         return self::$active;
+    }
+
+    /**
+     * Whether THIS request asked for its timeline with `?debug=1` — as
+     * opposed to being recorded because a measurement window is open
+     * (Core\Debug\MeasurementWindow). The two are journaled differently:
+     * only the explicit request also gets the early `debug_request_hit`
+     * entry, and only an admin's explicit request is journaled outside a
+     * window.
+     */
+    public static function wasRequested(): bool
+    {
+        return isset($_GET['debug']);
+    }
+
+    /**
+     * Records this request whatever its query string: what a measurement
+     * window does to every request while it is open. Called before the
+     * first mark(); the clock still starts at the request's own start.
+     */
+    public static function activate(): void
+    {
+        self::isActive();
+        self::$active = true;
     }
 
     /**

--- a/core/Http/Controller/SupportController.php
+++ b/core/Http/Controller/SupportController.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Core\Http\Controller;
 
 use Core\Config\AppClock;
+use Core\Debug\MeasurementWindow;
 use Core\Config\SettingService;
 use Core\Http\FlashMessage;
 use Core\Http\Request;
@@ -90,7 +91,12 @@ class SupportController extends AbstractController
          * The diagnostic mail probes (roadmap IT-27). Null when nothing
          * wired one — the section then does not render, like the rest.
          */
-        private ?MailProbeSender $probeSender = null
+        private ?MailProbeSender $probeSender = null,
+        /**
+         * The measurement window (Core\Debug\MeasurementWindow). Null when
+         * nothing wired one — the card then does not render.
+         */
+        private ?MeasurementWindow $measurementWindow = null
     ) {
     }
 
@@ -192,7 +198,82 @@ class SupportController extends AbstractController
             // the support will be looking for. There is no probe button
             // any more: a probe goes with a ticket and only with one.
             'probe_last_run' => $this->probeSender?->lastRun(),
+            // The measurement window: whether one can be opened, whether one
+            // is open and until when (on the application clock, as a time
+            // of day — it closes within the hour), and how many requests
+            // the current or last one recorded, so the page can say what
+            // the next archive will carry.
+            'measurement_available' => $this->measurementWindow !== null,
+            'measurement_open' => $this->measurementWindow?->isOpen() ?? false,
+            'measurement_expires_at' => $this->measurementWindow?->expiresAt()?->setTimezone(AppClock::zone())->format('H:i') ?? '',
+            'measurement_requests' => $this->measurementWindow?->recordedRequests() ?? 0,
+            'measurement_minutes' => MeasurementWindow::DEFAULT_MINUTES,
+            'measurement_cap' => MeasurementWindow::MAX_REQUESTS,
         ]);
+    }
+
+    /**
+     * POST /config/support/measure — opens the measurement window for
+     * MeasurementWindow::DEFAULT_MINUTES (docs/chantiers/CHANTIER-performance.md
+     * §6). A plain form with data-confirm: the page has to say, before
+     * anything is recorded, that every request of every account will be.
+     *
+     * @param array<string, string> $params
+     */
+    public function startMeasurement(Request $request, array $params): Response
+    {
+        if (($guard = $this->guardCsrf($request, '/config/support')) !== null) {
+            return $guard;
+        }
+        if ($this->measurementWindow === null) {
+            FlashMessage::set('error', "La mesure n'est pas disponible sur cette installation.");
+
+            return $this->redirect('/config/support');
+        }
+
+        $expiresAt = $this->measurementWindow->open(MeasurementWindow::DEFAULT_MINUTES);
+        $this->journalService->log(
+            'core',
+            'measurement_window_opened',
+            'info',
+            'Fenêtre de mesure des performances ouverte pour ' . MeasurementWindow::DEFAULT_MINUTES . ' minutes',
+            ['expires_at' => $expiresAt->format(\DateTimeInterface::ATOM)],
+            AuthSession::getUserAccountId()
+        );
+        FlashMessage::set(
+            'success',
+            'Mesure en cours jusqu\'à ' . $expiresAt->setTimezone(AppClock::zone())->format('H:i')
+                . ' : parcourez les pages qui vous paraissent lentes, puis revenez ici générer un paquet de support et envoyer un ticket.'
+        );
+
+        return $this->redirect('/config/support');
+    }
+
+    /**
+     * POST /config/support/measure/stop — closes it early. What was
+     * recorded stays in the journal and goes into the next archive.
+     *
+     * @param array<string, string> $params
+     */
+    public function stopMeasurement(Request $request, array $params): Response
+    {
+        if (($guard = $this->guardCsrf($request, '/config/support')) !== null) {
+            return $guard;
+        }
+        if ($this->measurementWindow !== null && $this->measurementWindow->isOpen()) {
+            $this->measurementWindow->close();
+            $this->journalService->log(
+                'core',
+                'measurement_window_closed',
+                'info',
+                'Fenêtre de mesure des performances fermée, ' . $this->measurementWindow->recordedRequests() . ' requête(s) enregistrée(s)',
+                ['requests' => $this->measurementWindow->recordedRequests()],
+                AuthSession::getUserAccountId()
+            );
+        }
+        FlashMessage::set('success', 'Mesure arrêtée.');
+
+        return $this->redirect('/config/support');
     }
 
     /**

--- a/core/Http/Controller/SupportController.php
+++ b/core/Http/Controller/SupportController.php
@@ -205,7 +205,8 @@ class SupportController extends AbstractController
             // the next archive will carry.
             'measurement_available' => $this->measurementWindow !== null,
             'measurement_open' => $this->measurementWindow?->isOpen() ?? false,
-            'measurement_expires_at' => $this->measurementWindow?->expiresAt()?->setTimezone(AppClock::zone())->format('H:i') ?? '',
+            'measurement_expires_at' => $this->measurementWindow?->expiresAt()
+                ?->setTimezone(AppClock::zone())->format('H:i') ?? '',
             'measurement_requests' => $this->measurementWindow?->recordedRequests() ?? 0,
             'measurement_minutes' => MeasurementWindow::DEFAULT_MINUTES,
             'measurement_cap' => MeasurementWindow::MAX_REQUESTS,
@@ -243,7 +244,8 @@ class SupportController extends AbstractController
         FlashMessage::set(
             'success',
             'Mesure en cours jusqu\'à ' . $expiresAt->setTimezone(AppClock::zone())->format('H:i')
-                . ' : parcourez les pages qui vous paraissent lentes, puis revenez ici générer un paquet de support et envoyer un ticket.'
+                . ' : parcourez les pages qui vous paraissent lentes, puis revenez ici générer un paquet de support'
+                . ' et envoyer un ticket.'
         );
 
         return $this->redirect('/config/support');
@@ -266,7 +268,8 @@ class SupportController extends AbstractController
                 'core',
                 'measurement_window_closed',
                 'info',
-                'Fenêtre de mesure des performances fermée, ' . $this->measurementWindow->recordedRequests() . ' requête(s) enregistrée(s)',
+                'Fenêtre de mesure des performances fermée, ' . $this->measurementWindow->recordedRequests()
+                    . ' requête(s) enregistrée(s)',
                 ['requests' => $this->measurementWindow->recordedRequests()],
                 AuthSession::getUserAccountId()
             );

--- a/core/Support/Collector/RequestTimelinesCollector.php
+++ b/core/Support/Collector/RequestTimelinesCollector.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Core\Support\Collector;
+
+use Core\Support\SupportCollectorContext;
+use Core\Support\SupportCollectorInterface;
+
+/**
+ * The request timelines a measurement window recorded (Core\Debug\
+ * MeasurementWindow, Core\Debug\RequestTimeline), as two files a support
+ * reader can open without the site in front of them:
+ *
+ * - `request-timelines.csv`: one line per SEGMENT of every recorded
+ *   request — the time and SQL statements between two consecutive
+ *   checkpoints, which is how an N+1 or a slow module block is read off
+ *   a timeline rather than off the code.
+ * - `request-timelines-resume.txt`: one line per path, slowest first,
+ *   with the count, the median and the worst total, the median statement
+ *   count and the segment that costs the most. That page is what a
+ *   ticket saying « le site est lent » is about; this line says where.
+ *
+ * Same 48-hour window as the event journal, from which these rows come
+ * (`event_type = 'debug_request_timeline'`). The path is the only thing
+ * about a page that is kept; never a query string, never any content.
+ * A window that recorded nothing is said, not left as an empty file.
+ */
+class RequestTimelinesCollector implements SupportCollectorInterface
+{
+    public const WINDOW_HOURS = EventJournalCollector::WINDOW_HOURS;
+
+    public function name(): string
+    {
+        return 'request_timelines';
+    }
+
+    public function collect(SupportCollectorContext $context): void
+    {
+        $cutoff = (new \DateTimeImmutable('-' . self::WINDOW_HOURS . ' hours'))->format('Y-m-d H:i:s');
+        $stmt = $context->pdo()->prepare(
+            "SELECT logged_at, context FROM event_log
+             WHERE event_type = 'debug_request_timeline' AND logged_at >= ?
+             ORDER BY id"
+        );
+        $stmt->execute([$cutoff]);
+
+        $rows = [];
+        /** @var array<string, array{count: int, totals: list<float>, sql: list<int>, segments: array<string, list<float>>}> $byPath */
+        $byPath = [];
+        foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) ?: [] as $entry) {
+            $decoded = json_decode((string) ($entry['context'] ?? ''), true);
+            if (!is_array($decoded) || !is_array($decoded['timeline'] ?? null)) {
+                continue;
+            }
+            $method = self::asString($decoded['method'] ?? 'GET');
+            $path = $context->redact(self::asString($decoded['path'] ?? '?'), 200);
+            $role = self::asString($decoded['role'] ?? '');
+            $loggedAt = self::asString($entry['logged_at'] ?? '');
+
+            $segments = self::segments($decoded['timeline']);
+            if ($segments === []) {
+                continue;
+            }
+            $last = end($segments);
+            $totalMs = $last['at_ms'];
+            $totalSql = $last['sql_at'];
+
+            foreach ($segments as $segment) {
+                $rows[] = [
+                    $loggedAt, $method, $path, $role,
+                    self::ms($totalMs), $totalSql,
+                    $segment['label'], self::ms($segment['ms']), $segment['sql'], self::ms($segment['sql_ms']), $segment['mem_mb'],
+                ];
+            }
+
+            $key = $method . ' ' . $path;
+            $byPath[$key] ??= ['count' => 0, 'totals' => [], 'sql' => [], 'segments' => []];
+            $byPath[$key]['count']++;
+            $byPath[$key]['totals'][] = $totalMs;
+            $byPath[$key]['sql'][] = $totalSql;
+            foreach ($segments as $segment) {
+                $byPath[$key]['segments'][$segment['label']][] = $segment['ms'];
+            }
+        }
+
+        if ($rows === []) {
+            $context->markUnavailable('no_measurement_recorded');
+
+            return;
+        }
+
+        $context->addFileFromContent('request-timelines.csv', self::csv(array_merge(
+            [['horodatage', 'methode', 'chemin', 'role', 'total_ms', 'total_sql', 'segment', 'segment_ms', 'segment_sql', 'segment_sql_ms', 'memoire_mo']],
+            $rows
+        )));
+        $context->addFileFromContent('request-timelines-resume.txt', self::summary($byPath));
+        $context->addNote(count($byPath) . ' chemin(s) mesuré(s), ' . array_sum(array_column($byPath, 'count')) . ' requête(s)');
+    }
+
+    /**
+     * The deltas between consecutive checkpoints. Entries written before
+     * the SQL counters existed have no `sql` keys and count as zero.
+     *
+     * @param array<int, mixed> $timeline
+     * @return list<array{label: string, ms: float, sql: int, sql_ms: float, at_ms: float, sql_at: int, mem_mb: string}>
+     */
+    private static function segments(array $timeline): array
+    {
+        $segments = [];
+        $previous = null;
+        foreach ($timeline as $entry) {
+            if (!is_array($entry)) {
+                continue;
+            }
+            $at = (float) ($entry['t_ms'] ?? 0);
+            $sqlAt = (int) ($entry['sql'] ?? 0);
+            $sqlMsAt = (float) ($entry['sql_ms'] ?? 0);
+            if ($previous !== null) {
+                $segments[] = [
+                    'label' => self::asString($entry['label'] ?? '?'),
+                    'ms' => $at - $previous['at'],
+                    'sql' => $sqlAt - $previous['sql'],
+                    'sql_ms' => $sqlMsAt - $previous['sql_ms'],
+                    'at_ms' => $at,
+                    'sql_at' => $sqlAt,
+                    'mem_mb' => self::asString($entry['mem_mb'] ?? ''),
+                ];
+            }
+            $previous = ['at' => $at, 'sql' => $sqlAt, 'sql_ms' => $sqlMsAt];
+        }
+
+        return $segments;
+    }
+
+    /**
+     * @param array<string, array{count: int, totals: list<float>, sql: list<int>, segments: array<string, list<float>>}> $byPath
+     */
+    private static function summary(array $byPath): string
+    {
+        uasort($byPath, static fn(array $a, array $b): int => self::median($b['totals']) <=> self::median($a['totals']));
+
+        $lines = [
+            'Chronologies de requêtes enregistrées pendant une fenêtre de mesure (' . self::WINDOW_HOURS . ' dernières heures).',
+            'Temps serveur uniquement : le réseau, le service worker et le rendu ne sont pas mesurés.',
+            '',
+        ];
+        foreach ($byPath as $key => $stats) {
+            $heaviestLabel = '';
+            $heaviestMs = -1.0;
+            foreach ($stats['segments'] as $label => $values) {
+                $median = self::median($values);
+                if ($median > $heaviestMs) {
+                    $heaviestMs = $median;
+                    $heaviestLabel = $label;
+                }
+            }
+            $lines[] = sprintf(
+                '%s — %d requête(s), médiane %s ms, maximum %s ms, %d instruction(s) SQL en médiane, segment le plus lourd : %s (%s ms)',
+                $key,
+                $stats['count'],
+                self::ms(self::median($stats['totals'])),
+                self::ms((float) max($stats['totals'])),
+                (int) round(self::median(array_map('floatval', $stats['sql']))),
+                $heaviestLabel,
+                self::ms($heaviestMs)
+            );
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @param array<int, array<int, string|int|float>> $rows
+     */
+    private static function csv(array $rows): string
+    {
+        $stream = fopen('php://memory', 'r+');
+        if ($stream === false) {
+            return '';
+        }
+        foreach ($rows as $row) {
+            fputcsv($stream, $row, ';', '"', '\\', "\n");
+        }
+        rewind($stream);
+        $csv = (string) stream_get_contents($stream);
+        fclose($stream);
+
+        return $csv;
+    }
+
+    /**
+     * @param list<float> $values
+     */
+    private static function median(array $values): float
+    {
+        if ($values === []) {
+            return 0.0;
+        }
+        sort($values);
+        $count = count($values);
+        $middle = intdiv($count, 2);
+
+        return $count % 2 === 1 ? $values[$middle] : ($values[$middle - 1] + $values[$middle]) / 2;
+    }
+
+    private static function ms(float $value): string
+    {
+        return number_format($value, 1, '.', '');
+    }
+
+    private static function asString(mixed $value): string
+    {
+        return is_scalar($value) ? (string) $value : '';
+    }
+}

--- a/core/Support/Collector/RequestTimelinesCollector.php
+++ b/core/Support/Collector/RequestTimelinesCollector.php
@@ -29,6 +29,10 @@ use Core\Support\SupportCollectorInterface;
  * (`event_type = 'debug_request_timeline'`). The path is the only thing
  * about a page that is kept; never a query string, never any content.
  * A window that recorded nothing is said, not left as an empty file.
+ *
+ * @phpstan-type PathStats array{count: int, totals: list<float>, sql: list<int>, segments: array<string, list<float>>}
+ * @phpstan-type Segment array{label: string, ms: float, sql: int, sql_ms: float, at_ms: float, sql_at: int,
+ *     mem_mb: string}
  */
 class RequestTimelinesCollector implements SupportCollectorInterface
 {
@@ -50,7 +54,7 @@ class RequestTimelinesCollector implements SupportCollectorInterface
         $stmt->execute([$cutoff]);
 
         $rows = [];
-        /** @var array<string, array{count: int, totals: list<float>, sql: list<int>, segments: array<string, list<float>>}> $byPath */
+        /** @var array<string, PathStats> $byPath */
         $byPath = [];
         foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) ?: [] as $entry) {
             $decoded = json_decode((string) ($entry['context'] ?? ''), true);
@@ -74,7 +78,8 @@ class RequestTimelinesCollector implements SupportCollectorInterface
                 $rows[] = [
                     $loggedAt, $method, $path, $role,
                     self::ms($totalMs), $totalSql,
-                    $segment['label'], self::ms($segment['ms']), $segment['sql'], self::ms($segment['sql_ms']), $segment['mem_mb'],
+                    $segment['label'], self::ms($segment['ms']), $segment['sql'],
+                    self::ms($segment['sql_ms']), $segment['mem_mb'],
                 ];
             }
 
@@ -94,12 +99,14 @@ class RequestTimelinesCollector implements SupportCollectorInterface
             return;
         }
 
-        $context->addFileFromContent('request-timelines.csv', self::csv(array_merge(
-            [['horodatage', 'methode', 'chemin', 'role', 'total_ms', 'total_sql', 'segment', 'segment_ms', 'segment_sql', 'segment_sql_ms', 'memoire_mo']],
-            $rows
-        )));
+        $header = [
+            'horodatage', 'methode', 'chemin', 'role', 'total_ms', 'total_sql',
+            'segment', 'segment_ms', 'segment_sql', 'segment_sql_ms', 'memoire_mo',
+        ];
+        $context->addFileFromContent('request-timelines.csv', self::csv(array_merge([$header], $rows)));
         $context->addFileFromContent('request-timelines-resume.txt', self::summary($byPath));
-        $context->addNote(count($byPath) . ' chemin(s) mesuré(s), ' . array_sum(array_column($byPath, 'count')) . ' requête(s)');
+        $requests = array_sum(array_column($byPath, 'count'));
+        $context->addNote(count($byPath) . ' chemin(s) mesuré(s), ' . $requests . ' requête(s)');
     }
 
     /**
@@ -107,7 +114,7 @@ class RequestTimelinesCollector implements SupportCollectorInterface
      * the SQL counters existed have no `sql` keys and count as zero.
      *
      * @param array<int, mixed> $timeline
-     * @return list<array{label: string, ms: float, sql: int, sql_ms: float, at_ms: float, sql_at: int, mem_mb: string}>
+     * @return list<Segment>
      */
     private static function segments(array $timeline): array
     {
@@ -138,14 +145,18 @@ class RequestTimelinesCollector implements SupportCollectorInterface
     }
 
     /**
-     * @param array<string, array{count: int, totals: list<float>, sql: list<int>, segments: array<string, list<float>>}> $byPath
+     * @param array<string, PathStats> $byPath
      */
     private static function summary(array $byPath): string
     {
-        uasort($byPath, static fn(array $a, array $b): int => self::median($b['totals']) <=> self::median($a['totals']));
+        uasort(
+            $byPath,
+            static fn(array $a, array $b): int => self::median($b['totals']) <=> self::median($a['totals'])
+        );
 
         $lines = [
-            'Chronologies de requêtes enregistrées pendant une fenêtre de mesure (' . self::WINDOW_HOURS . ' dernières heures).',
+            'Chronologies de requêtes enregistrées pendant une fenêtre de mesure ('
+                . self::WINDOW_HOURS . ' dernières heures).',
             'Temps serveur uniquement : le réseau, le service worker et le rendu ne sont pas mesurés.',
             '',
         ];
@@ -160,7 +171,8 @@ class RequestTimelinesCollector implements SupportCollectorInterface
                 }
             }
             $lines[] = sprintf(
-                '%s — %d requête(s), médiane %s ms, maximum %s ms, %d instruction(s) SQL en médiane, segment le plus lourd : %s (%s ms)',
+                '%s — %d requête(s), médiane %s ms, maximum %s ms, %d instruction(s) SQL en médiane,'
+                    . ' segment le plus lourd : %s (%s ms)',
                 $key,
                 $stats['count'],
                 self::ms(self::median($stats['totals'])),

--- a/core/Support/SupportPackageFactory.php
+++ b/core/Support/SupportPackageFactory.php
@@ -24,6 +24,7 @@ use Core\Support\Collector\FilesystemCollector;
 use Core\Support\Collector\LogsCollector;
 use Core\Support\Collector\OpcacheCollector;
 use Core\Support\Collector\PhpInfoCollector;
+use Core\Support\Collector\RequestTimelinesCollector;
 use Core\Support\Collector\ScheduledTasksCollector;
 use Core\Support\Collector\StatisticsCollector;
 use Core\Support\Collector\UpdateHistoryCollector;
@@ -68,6 +69,7 @@ final class SupportPackageFactory
             new DatabaseStructureCollector(),
             new ConfigurationParametersCollector(),
             new EventJournalCollector(),
+            new RequestTimelinesCollector(),
             new ScheduledTasksCollector(StatisticsServiceFactory::moduleManager($context)),
             new UpdateHistoryCollector(),
             new PhpInfoCollector(),
@@ -101,6 +103,7 @@ final class SupportPackageFactory
             'database_structure',
             'configuration_parameters',
             'event_journal',
+            'request_timelines',
             'scheduled_tasks',
             'update_history',
             'phpinfo',

--- a/core/Support/Ticket/ArchiveContents.php
+++ b/core/Support/Ticket/ArchiveContents.php
@@ -36,6 +36,8 @@ final class ArchiveContents
         'configuration_parameters' => "Les paramètres de configuration du site, secrets retirés.",
         'event_journal' => "Un résumé du journal des évènements des dernières 48 h, qui contient des identifiants "
             . "internes.",
+        'request_timelines' => "Les chronologies de requêtes enregistrées pendant une fenêtre de mesure : le chemin de "
+            . "chaque page servie et le temps passé dans chaque étape, jamais le contenu des pages.",
         'scheduled_tasks' => "L'état des tâches planifiées du site.",
         'update_history' => 'Quelle version tournait à quel moment, et le résultat de chaque mise à jour.',
         'phpinfo' => "La configuration détaillée de PHP sur votre hébergement (sans les variables d'environnement).",

--- a/core/View/templates/config/support.html.twig
+++ b/core/View/templates/config/support.html.twig
@@ -76,6 +76,48 @@
 </div>
 
 {% if ticket_available %}
+{% if measurement_available %}
+<div class="card mb-3">
+    <div class="card-body">
+        <h2 class="h5 mb-3">Mesurer une lenteur</h2>
+
+        <p class="small text-body-secondary">
+            Pendant {{ measurement_minutes }} minutes, chaque page servie par le site enregistre dans le journal le
+            temps passé dans chacune de ses étapes et le nombre de requêtes à la base de données — pour tous les
+            comptes, pas seulement le vôtre. Parcourez les pages qui vous paraissent lentes, puis générez un nouveau
+            paquet de support et joignez-le à un ticket : l'archive contient ces mesures. Seul le chemin des pages
+            est enregistré, jamais leur contenu ni leurs paramètres. La mesure s'arrête d'elle-même et ne concerne
+            que le serveur : le réseau et l'appareil du visiteur ne sont pas mesurés.
+        </p>
+
+        {% if measurement_open %}
+            <div class="alert alert-info small" role="status">
+                Mesure en cours jusqu'à {{ measurement_expires_at }} — {{ measurement_requests }} requête(s)
+                enregistrée(s) sur {{ measurement_cap }} au maximum.
+            </div>
+            <form method="post" action="/config/support/measure/stop"
+                  data-confirm="Arrêter la mesure maintenant ? Ce qui a déjà été enregistré est conservé."
+                  data-confirm-label="Arrêter">
+                {{ csrf_field()|raw }}
+                <button type="submit" class="btn btn-outline-secondary">Arrêter la mesure</button>
+            </form>
+        {% else %}
+            {% if measurement_requests > 0 %}
+                <p class="small">
+                    La dernière mesure a enregistré {{ measurement_requests }} requête(s). Générez un nouveau paquet
+                    de support avant d'envoyer le ticket : c'est lui qui les emporte.
+                </p>
+            {% endif %}
+            <form method="post" action="/config/support/measure"
+                  data-confirm="Activer la mesure pendant {{ measurement_minutes }} minutes ? Chaque page servie pendant ce temps sera enregistrée dans le journal, pour tous les comptes."
+                  data-confirm-label="Mesurer">
+                {{ csrf_field()|raw }}
+                <button type="submit" class="btn btn-outline-primary">Mesurer pendant {{ measurement_minutes }} minutes</button>
+            </form>
+        {% endif %}
+    </div>
+</div>
+{% endif %}
 <div class="card mb-3">
     <div class="card-body">
         <h2 class="h5 mb-3">Contacter le support</h2>

--- a/core/View/templates/config/support.html.twig
+++ b/core/View/templates/config/support.html.twig
@@ -91,10 +91,10 @@
         </p>
 
         {% if measurement_open %}
-            <div class="alert alert-info small" role="status">
+            <output class="alert alert-info small d-block">
                 Mesure en cours jusqu'à {{ measurement_expires_at }} — {{ measurement_requests }} requête(s)
                 enregistrée(s) sur {{ measurement_cap }} au maximum.
-            </div>
+            </output>
             <form method="post" action="/config/support/measure/stop"
                   data-confirm="Arrêter la mesure maintenant ? Ce qui a déjà été enregistré est conservé."
                   data-confirm-label="Arrêter">

--- a/docs/chantiers/CHANTIER-performance.md
+++ b/docs/chantiers/CHANTIER-performance.md
@@ -474,15 +474,17 @@ sauvegarde a déjà tourné, ils passent en 22 s. Ce n'est pas lié au chantier.
 
 ## 6. Suite envisagée : une fenêtre de mesure depuis la page Support
 
-Idée retenue le 4 septembre 2026, pas encore implémentée. Le superadmin
-ouvre, depuis Configuration > Support et après confirmation, une fenêtre
-de mesure de quelques minutes ; pendant ce temps chaque requête journalise
-sa chronologie comme le fait `?debug=1` ; il envoie ensuite un ticket dont
-l'archive contient les mesures. Ce qui existe déjà couvre l'essentiel :
-`RequestTimeline` écrit dans `event_log`, et `EventJournalCollector`
-embarque les 48 dernières heures du journal dans l'archive.
+Idée retenue le 4 septembre 2026, **implémentée le même jour**
+(`Core\Debug\MeasurementWindow`, `Core\Support\Collector\RequestTimelinesCollector`,
+`ARCHITECTURE.md` §8.48ter). Le superadmin ouvre, depuis Configuration >
+Support et après confirmation, une fenêtre de mesure de cinq minutes ;
+pendant ce temps chaque requête journalise sa chronologie comme le fait
+`?debug=1` ; il envoie ensuite un ticket dont l'archive contient les
+mesures. Ce qui existait déjà couvrait l'essentiel : `RequestTimeline`
+écrit dans `event_log`, et `EventJournalCollector` embarque les 48
+dernières heures du journal dans l'archive.
 
-À faire, dans cet ordre :
+Ce qui a été fait, dans cet ordre (les cinq points ci-dessous) :
 
 1. **Activation par une date de fin**, jamais par un drapeau : un réglage
    ou un fichier témoin `storage/cache/measure_until` dont la date
@@ -510,7 +512,8 @@ du plancher de 28 ms. Un `filemtime()` sur un fichier témoin absent coûte
 **2 µs**. Les deux approches sont donc sans effet mesurable ; celle du
 fichier témoin garde en plus la propriété actuelle, « aucun travail quand
 le mode est fermé », et se lit avant que les réglages ne soient
-disponibles. C'est celle à retenir.
+disponibles. C'est celle qui a été retenue : `storage/temp/measure_until`,
+dont la date de modification est l'expiration.
 
 ### Limite : on ne mesure que le serveur
 
@@ -522,7 +525,7 @@ application installée, « second appui » sur le menu) étaient entièrement
 côté client ; une fenêtre de mesure serveur les aurait montrés comme des
 pages à 50 ms.
 
-Second temps, à faire quand le besoin se présentera : pendant la fenêtre,
+Second temps, **pas fait**, à faire quand le besoin se présentera : pendant la fenêtre,
 la page envoie un petit beacon (`navigator.sendBeacon`) vers une route
 dédiée avec les métriques de navigation du navigateur
 (`PerformanceNavigationTiming` : temps jusqu'au premier octet, réponse

--- a/docs/help/support-mesure.md
+++ b/docs/help/support-mesure.md
@@ -1,0 +1,49 @@
+---
+id: support-mesure
+title: Mesurer une lenteur du site
+summary: Cinq minutes pendant lesquelles chaque page servie est chronométrée, pour le support.
+category: Configuration
+role_min: superadmin
+question: Le site est lent, comment le montrer au support ?
+question: Que mesure le bouton « Mesurer une lenteur » ?
+paths: /config/support
+related: support, journal
+---
+
+Quand le site paraît lent, le bloc « Mesurer une lenteur » de la page
+Support enregistre, pendant cinq minutes, le détail de chaque page
+servie : le temps passé dans chacune de ses étapes et le nombre de
+requêtes à la base de données. C'est ce qui permet à celui qui vous
+dépanne de dire **quelle** page est lente et **où** elle perd son temps,
+au lieu de le deviner.
+
+## Ce qui est enregistré, et pour qui
+
+La mesure vaut **pour tous les comptes**, pas seulement le vôtre : la
+page lente est souvent celle d'un animateur ou d'un parent, pas celle du
+super-administrateur qui a appuyé sur le bouton. Le site le dit avant de
+commencer et demande une confirmation.
+
+Seul le **chemin** des pages est enregistré, jamais leur contenu ni
+leurs paramètres. Les enregistrements vont dans le journal des
+évènements et s'arrêtent d'eux-mêmes au bout de cinq minutes, ou après
+cinq cents pages ; le bouton « Arrêter la mesure » les arrête avant.
+
+## Comment s'en servir
+
+1. Appuyez sur « Mesurer une lenteur » et confirmez.
+2. Pendant les cinq minutes, parcourez les pages qui vous paraissent
+   lentes — vous, ou la personne qui s'en plaint.
+3. Revenez sur la page Support : elle dit combien de pages ont été
+   enregistrées.
+4. Générez un **nouveau** paquet de support, puis joignez-le à un
+   ticket. C'est l'archive qui emporte les mesures, sous la rubrique
+   « chronologies de requêtes » ; celle générée la veille ne les a pas.
+
+## Ce que la mesure ne voit pas
+
+Elle ne mesure que le serveur, entre l'arrivée de la demande et l'envoi
+de la page. Une lenteur du réseau, de l'appareil ou de l'application
+installée sur le téléphone n'y apparaît pas : si c'est ce que vous
+observez, dites-le dans le ticket, la mesure ne le dira pas à votre
+place.

--- a/docs/help/support.md
+++ b/docs/help/support.md
@@ -7,7 +7,7 @@ role_min: superadmin
 question: Comment envoyer un diagnostic à celui qui nous dépanne ?
 question: Où voir combien le site est utilisé ?
 paths: /config/support
-related: support-sondes-email, mises-a-jour, installation-serveur
+related: support-mesure, support-sondes-email, mises-a-jour, installation-serveur
 ---
 
 La page Support regroupe deux choses distinctes : le rapport

--- a/public/index.php
+++ b/public/index.php
@@ -194,6 +194,18 @@ $secretManager = new SecretManager(
 $dkimManager = new DkimManager(__DIR__ . '/../storage/keys');
 $schemaPath = __DIR__ . '/../schema/core.sql';
 
+// A measurement window opened from Configuration > Support records the
+// timeline of every request while it lasts (Core\Debug\MeasurementWindow).
+// One stat on an absent file when there is none — checked here, before
+// the database and the settings exist, because the window is about the
+// requests that are slow to get that far.
+$measurementWindow = new \Core\Debug\MeasurementWindow(
+    \Core\Debug\MeasurementWindow::flagPathIn(__DIR__ . '/../storage')
+);
+if ($measurementWindow->isOpen()) {
+    \Core\Debug\RequestTimeline::activate();
+}
+
 // Create the request early to check the path
 $request = Request::fromGlobals();
 \Core\Debug\RequestTimeline::mark('request_parsed', ['path' => $request->getPath()]);
@@ -958,7 +970,7 @@ $auditAccessResolver = new \Core\Audit\AuditAccessResolver();
 // deferred to the end-of-request summary, specifically so a debug run
 // against /admin/journal itself shows up on the very page load that
 // triggered it, rather than only becoming visible on a second reload.
-if (\Core\Debug\RequestTimeline::isActive() && \Core\Security\AuthSession::isAuthenticated()
+if (\Core\Debug\RequestTimeline::wasRequested() && \Core\Security\AuthSession::isAuthenticated()
     && in_array(\Core\Security\AuthSession::getRole(), ['admin', 'superadmin'], true)
 ) {
     \Core\Debug\RequestTimeline::mark('debug_active_confirmed');
@@ -2178,6 +2190,8 @@ $router->addRoute('POST', '/config/settings/logo-notify-ios', SettingsController
 // Support (Core\Statistics, Core\Support — ARCHITECTURE.md §8.47/§8.48)
 $router->addRoute('GET', '/config/support', SupportController::class, 'index', 'superadmin', ['label' => 'Support', 'parents' => [MenuBuilder::labelFor(MenuBuilder::MENU_CONFIGURATION)]]);
 $router->addRoute('POST', '/config/support/statistics', SupportController::class, 'saveStatistics', 'superadmin');
+$router->addRoute('POST', '/config/support/measure', SupportController::class, 'startMeasurement', 'superadmin');
+$router->addRoute('POST', '/config/support/measure/stop', SupportController::class, 'stopMeasurement', 'superadmin');
 $router->addRoute('POST', '/config/support/statistics/test', SupportController::class, 'sendTestStatistics', 'superadmin');
 $router->addRoute('POST', '/config/support/package', SupportController::class, 'generatePackage', 'superadmin');
 // One support ticket, sent now (roadmap IT-25). Same floor as the rest of
@@ -2865,7 +2879,10 @@ $frontController->registerController(SupportController::class, new SupportContro
         $mailService,
         $journalService,
         \Core\Maintenance\VersionFile::read(dirname(__DIR__))
-    )
+    ),
+    // The measurement window (docs/chantiers/CHANTIER-performance.md §6):
+    // the same instance the top of this file asked whether to record.
+    $measurementWindow
 ));
 $frontController->registerController(ScheduledActionsController::class,
     new ScheduledActionsController($twig, $schedulerRepo));
@@ -6617,17 +6634,26 @@ if ($usageStatsRecorder !== null) {
 // URL param anyone could replay) would make this a standing, unauthenticated
 // way to force extra journal writes on every request. Written last, so a
 // slow request shows up in the same timeline in full.
-if (\Core\Debug\RequestTimeline::isActive() && \Core\Security\AuthSession::isAuthenticated()
-    && in_array(\Core\Security\AuthSession::getRole(), ['admin', 'superadmin'], true)
-) {
+// Inside a measurement window every request is recorded, whoever sent it
+// and up to the window's cap; outside one, only an admin's explicit
+// ?debug=1. The window is re-checked here rather than remembered from
+// the top of the file: a request that started inside it and ends after
+// its close is still one of its requests, and the cap is what stops it.
+if (\Core\Debug\RequestTimeline::isActive() && (
+    (\Core\Debug\RequestTimeline::wasRequested() && \Core\Security\AuthSession::isAuthenticated()
+        && in_array(\Core\Security\AuthSession::getRole(), ['admin', 'superadmin'], true))
+    || (!\Core\Debug\RequestTimeline::wasRequested() && $measurementWindow->recordRequest())
+)) {
     $journalService->log(
         'core',
         'debug_request_timeline',
         'info',
-        'Chronologie détaillée de requête (?debug=1) : ' . $request->getMethod() . ' ' . $request->getPath(),
+        'Chronologie détaillée de requête (' . (\Core\Debug\RequestTimeline::wasRequested() ? '?debug=1' : 'fenêtre de mesure') . ') : '
+            . $request->getMethod() . ' ' . $request->getPath(),
         [
             'method' => $request->getMethod(),
             'path' => $request->getPath(),
+            'role' => \Core\Security\AuthSession::getRole(),
             'timeline' => \Core\Debug\RequestTimeline::getEntries(),
         ],
         \Core\Security\AuthSession::getUserAccountId()

--- a/public/index.php
+++ b/public/index.php
@@ -6648,7 +6648,8 @@ if (\Core\Debug\RequestTimeline::isActive() && (
         'core',
         'debug_request_timeline',
         'info',
-        'Chronologie détaillée de requête (' . (\Core\Debug\RequestTimeline::wasRequested() ? '?debug=1' : 'fenêtre de mesure') . ') : '
+        'Chronologie détaillée de requête ('
+            . (\Core\Debug\RequestTimeline::wasRequested() ? '?debug=1' : 'fenêtre de mesure') . ') : '
             . $request->getMethod() . ' ' . $request->getPath(),
         [
             'method' => $request->getMethod(),

--- a/tests/Core/Debug/MeasurementWindowTest.php
+++ b/tests/Core/Debug/MeasurementWindowTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Debug;
+
+use Core\Debug\MeasurementWindow;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The window is a flag file whose modification time is its expiry: these
+ * tests drive it with an explicit clock so that "open", "expired" and
+ * "closed early" are three states and not three waits.
+ */
+class MeasurementWindowTest extends TestCase
+{
+    private string $directory;
+    private string $flag;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/scoutmagic-measure-' . bin2hex(random_bytes(6));
+        $this->flag = $this->directory . '/temp/measure_until';
+    }
+
+    protected function tearDown(): void
+    {
+        @unlink($this->flag);
+        @unlink($this->flag . '.count');
+        @rmdir($this->directory . '/temp');
+        @rmdir($this->directory);
+    }
+
+    public function testNothingIsOpenWhileNoFlagExists(): void
+    {
+        $window = new MeasurementWindow($this->flag);
+
+        $this->assertFalse($window->isOpen());
+        $this->assertNull($window->expiresAt());
+        $this->assertNull($window->openedAt());
+        $this->assertSame(0, $window->recordedRequests());
+    }
+
+    public function testOpeningCreatesTheDirectoryAndSetsTheExpiryOnTheFile(): void
+    {
+        $window = new MeasurementWindow($this->flag);
+        $now = new \DateTimeImmutable('2026-09-04 10:00:00');
+
+        $expiresAt = $window->open(5, $now);
+
+        $this->assertSame('2026-09-04 10:05:00', $expiresAt->format('Y-m-d H:i:s'));
+        $this->assertTrue($window->isOpen($now->getTimestamp()));
+        $this->assertTrue($window->isOpen($now->getTimestamp() + 299));
+        $this->assertFalse($window->isOpen($now->getTimestamp() + 300), 'closed at the expiry, without anybody closing it');
+        $this->assertSame($now->getTimestamp(), $window->openedAt()?->getTimestamp());
+    }
+
+    public function testTheDurationIsClampedToTheMaximum(): void
+    {
+        $window = new MeasurementWindow($this->flag);
+        $now = new \DateTimeImmutable('2026-09-04 10:00:00');
+
+        $this->assertSame('10:15', $window->open(120, $now)->format('H:i'));
+        $this->assertSame('10:01', $window->open(0, $now)->format('H:i'));
+    }
+
+    public function testClosingEarlyKeepsTheCountOfWhatWasRecorded(): void
+    {
+        $window = new MeasurementWindow($this->flag);
+        $window->open(5);
+        $this->assertTrue($window->recordRequest());
+        $this->assertTrue($window->recordRequest());
+
+        $window->close();
+
+        $this->assertFalse($window->isOpen());
+        $this->assertSame(2, $window->recordedRequests(), 'the Support page still says what the next archive carries');
+    }
+
+    public function testReopeningRestartsTheCount(): void
+    {
+        $window = new MeasurementWindow($this->flag);
+        $window->open(5);
+        $window->recordRequest();
+
+        $window->open(5);
+
+        $this->assertSame(0, $window->recordedRequests());
+    }
+
+    public function testTheCapStopsRecordingAndSaysSo(): void
+    {
+        $window = new MeasurementWindow($this->flag, 3);
+        $window->open(5);
+
+        $this->assertTrue($window->recordRequest());
+        $this->assertTrue($window->recordRequest());
+        $this->assertTrue($window->recordRequest());
+        $this->assertFalse($window->recordRequest(), 'the fourth request is not journaled');
+        $this->assertSame(3, $window->recordedRequests());
+        $this->assertTrue($window->isOpen(), 'the cap does not close the window; its time does');
+    }
+
+    public function testTheFlagLivesWithTheOtherRequestTimeCaches(): void
+    {
+        $this->assertSame('/srv/site/storage/temp/measure_until', MeasurementWindow::flagPathIn('/srv/site/storage'));
+    }
+}

--- a/tests/Core/Debug/RequestTimelineTest.php
+++ b/tests/Core/Debug/RequestTimelineTest.php
@@ -85,4 +85,24 @@ class RequestTimelineTest extends TestCase
         $this->assertSame(2, $after['sql'] - $before['sql'], 'the delta between two checkpoints is the segment\'s own statement count');
         $this->assertGreaterThanOrEqual($before['sql_ms'], $after['sql_ms']);
     }
+
+    public function testActivateRecordsWithoutTheDebugQueryParam(): void
+    {
+        $this->assertFalse(RequestTimeline::wasRequested());
+
+        RequestTimeline::activate();
+        RequestTimeline::mark('inside_a_measurement_window');
+
+        $this->assertTrue(RequestTimeline::isActive());
+        $this->assertFalse(RequestTimeline::wasRequested(), 'a window is not an explicit request');
+        $this->assertSame('inside_a_measurement_window', RequestTimeline::getEntries()[0]['label']);
+    }
+
+    public function testAnExplicitRequestIsToldApartFromAWindow(): void
+    {
+        $_GET['debug'] = '1';
+
+        $this->assertTrue(RequestTimeline::wasRequested());
+        $this->assertTrue(RequestTimeline::isActive());
+    }
 }

--- a/tests/Core/Http/Controller/SupportControllerTest.php
+++ b/tests/Core/Http/Controller/SupportControllerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Core\Http\Controller;
 use Core\Config\AppConfig;
 use Core\Config\SettingRepository;
 use Core\Config\SettingService;
+use Core\Debug\MeasurementWindow;
 use Core\Http\Controller\SupportController;
 use Core\Http\FrontController;
 use Core\Http\Request;
@@ -139,6 +140,7 @@ class SupportControllerTest extends TestCase
 {
     private \PDO $pdo;
     private SupportController $controller;
+    private MeasurementWindow $measurementWindow;
     private SettingService $settings;
     private SettingRepository $settingRepository;
     private Environment $twig;
@@ -233,7 +235,8 @@ class SupportControllerTest extends TestCase
                 '1.0.33'
             ),
             $ticketIdentity,
-            $archiveSender
+            $archiveSender,
+            measurementWindow: $this->measurementWindow = new MeasurementWindow($this->projectRoot . '/storage/temp/measure_until')
         );
 
         $stmt = $this->pdo->prepare('INSERT INTO user_accounts (email_encrypted, email_blind_index, is_super_admin) VALUES (?, ?, 1)');
@@ -297,6 +300,64 @@ class SupportControllerTest extends TestCase
         $_POST['_csrf_token'] = $token;
 
         return $token;
+    }
+
+    // ── The measurement window (CHANTIER-performance §6) ────────────────
+
+    public function testThePageOffersToMeasureAndSaysWhatItRecordsAndWhatItCannot(): void
+    {
+        $body = $this->controller->index(new Request('GET', '/config/support', [], [], [], []), [])->getBody();
+
+        $this->assertStringContainsString('Mesurer une lenteur', $body);
+        $this->assertStringContainsString('Mesurer pendant 5 minutes', $body);
+        $this->assertStringContainsString('pour tous les comptes', $body);
+        $this->assertStringContainsString('le réseau et l\'appareil du visiteur ne sont pas mesurés', $body);
+        $this->assertStringContainsString('data-confirm=', $body);
+        $this->assertStringNotContainsString('Mesure en cours', $body);
+    }
+
+    public function testStartingOpensTheWindowJournalsItAndComesBackToThePage(): void
+    {
+        $this->issueCsrfToken();
+        $request = new Request('POST', '/config/support/measure', [], ['_csrf_token' => $_POST['_csrf_token']], [], []);
+
+        $response = $this->controller->startMeasurement($request, []);
+
+        $this->assertSame(302, $response->getStatusCode());
+        $this->assertSame('/config/support', $response->getHeaders()['Location'] ?? null);
+        $this->assertTrue($this->measurementWindow->isOpen());
+        $this->assertLessThanOrEqual(5 * 60, $this->measurementWindow->expiresAt()->getTimestamp() - time());
+        $this->assertSame(['measurement_window_opened'], $this->journalEventTypes());
+
+        $body = $this->controller->index(new Request('GET', '/config/support', [], [], [], []), [])->getBody();
+        $this->assertStringContainsString('Mesure en cours jusqu', $body);
+        $this->assertStringContainsString('Arrêter la mesure', $body);
+    }
+
+    public function testStartingWithoutTheTokenChangesNothing(): void
+    {
+        $request = new Request('POST', '/config/support/measure', [], [], [], []);
+
+        $this->controller->startMeasurement($request, []);
+
+        $this->assertFalse($this->measurementWindow->isOpen());
+        $this->assertSame([], $this->journalEventTypes());
+    }
+
+    public function testStoppingClosesTheWindowAndTheNextArchiveIsStillAnnounced(): void
+    {
+        $this->measurementWindow->open(5);
+        $this->measurementWindow->recordRequest();
+        $this->issueCsrfToken();
+        $request = new Request('POST', '/config/support/measure/stop', [], ['_csrf_token' => $_POST['_csrf_token']], [], []);
+
+        $this->controller->stopMeasurement($request, []);
+
+        $this->assertFalse($this->measurementWindow->isOpen());
+        $this->assertSame(['measurement_window_closed'], $this->journalEventTypes());
+        $body = $this->controller->index(new Request('GET', '/config/support', [], [], [], []), [])->getBody();
+        $this->assertStringContainsString('La dernière mesure a enregistré 1 requête(s)', $body);
+        $this->assertStringContainsString('Mesurer pendant 5 minutes', $body);
     }
 
     // ── The support ticket (roadmap IT-25) ─────────────────────────────

--- a/tests/Core/Support/ApplicationCollectorsTest.php
+++ b/tests/Core/Support/ApplicationCollectorsTest.php
@@ -11,6 +11,7 @@ use Core\Scheduler\CoreTaskHandlers;
 use Core\Support\Collector\ConfigurationParametersCollector;
 use Core\Support\Collector\DatabaseStructureCollector;
 use Core\Support\Collector\EventJournalCollector;
+use Core\Support\Collector\RequestTimelinesCollector;
 use Core\Support\Collector\OpcacheCollector;
 use Core\Support\Collector\ScheduledTasksCollector;
 use Core\Support\Collector\UpdateHistoryCollector;
@@ -563,6 +564,103 @@ class ApplicationCollectorsTest extends TestCase
         $this->pdo->prepare(
             'INSERT INTO update_history (version_from, version_to, status, started_at, completed_at, error_message) VALUES (?, ?, ?, ?, ?, ?)'
         )->execute([$from, $to, $status, $startedAt, $completedAt, $error]);
+    }
+
+    /**
+     * A `debug_request_timeline` row as public/index.php writes it: the
+     * cumulative checkpoints of one request.
+     *
+     * @param array<int, array{label: string, t_ms: float, sql: int, sql_ms: float}> $timeline
+     */
+    private function insertTimelineEntry(string $relativeTime, string $path, array $timeline, string $role = 'chief'): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO event_log (logged_at, user_account_id, ip_address, category, event_type, level, description, context) VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            (new \DateTimeImmutable($relativeTime))->format('Y-m-d H:i:s'),
+            null,
+            '192.0.2.10',
+            'core',
+            'debug_request_timeline',
+            'info',
+            'Chronologie détaillée de requête (fenêtre de mesure) : GET ' . $path,
+            json_encode(['method' => 'GET', 'path' => $path, 'role' => $role, 'timeline' => array_map(
+                static fn(array $entry): array => $entry + ['mem_mb' => 4.0],
+                $timeline
+            )]),
+        ]);
+    }
+
+    // --- request-timelines.csv ---
+
+    public function testAWindowThatRecordedNothingIsSaidNotShippedEmpty(): void
+    {
+        $this->insertJournalEntry('-1 hour', 'login_success');
+
+        $result = $this->runCollector(new RequestTimelinesCollector());
+
+        $this->assertSame('no_measurement_recorded', $result['unavailable']);
+        $this->assertSame([], $result['entries']);
+    }
+
+    public function testEverySegmentOfARecordedRequestIsOneLineWithItsOwnDeltas(): void
+    {
+        $this->insertTimelineEntry('-10 minutes', '/chefs/staffs', [
+            ['label' => 'request_parsed', 't_ms' => 1.0, 'sql' => 0, 'sql_ms' => 0.0],
+            ['label' => 'services_ready', 't_ms' => 21.0, 'sql' => 30, 'sql_ms' => 8.0],
+            ['label' => 'controller_dispatch_done', 't_ms' => 145.5, 'sql' => 53, 'sql_ms' => 30.5],
+        ]);
+
+        $result = $this->runCollector(new RequestTimelinesCollector());
+        $csv = $result['entries']['request-timelines.csv'];
+        $lines = array_values(array_filter(explode("\n", $csv)));
+
+        $this->assertSame('horodatage;methode;chemin;role;total_ms;total_sql;segment;segment_ms;segment_sql;segment_sql_ms;memoire_mo', $lines[0]);
+        $this->assertCount(3, $lines, 'a header and one line per segment between two checkpoints');
+        $this->assertStringContainsString(';GET;/chefs/staffs;chief;145.5;53;services_ready;20.0;30;8.0;4', $lines[1]);
+        $this->assertStringContainsString(';GET;/chefs/staffs;chief;145.5;53;controller_dispatch_done;124.5;23;22.5;4', $lines[2]);
+    }
+
+    public function testTheSummaryNamesTheSlowestPathFirstAndItsHeaviestSegment(): void
+    {
+        $fast = [
+            ['label' => 'request_parsed', 't_ms' => 1.0, 'sql' => 0, 'sql_ms' => 0.0],
+            ['label' => 'services_ready', 't_ms' => 20.0, 'sql' => 30, 'sql_ms' => 8.0],
+            ['label' => 'controller_dispatch_done', 't_ms' => 30.0, 'sql' => 35, 'sql_ms' => 9.0],
+        ];
+        $slow = [
+            ['label' => 'request_parsed', 't_ms' => 1.0, 'sql' => 0, 'sql_ms' => 0.0],
+            ['label' => 'services_ready', 't_ms' => 20.0, 'sql' => 30, 'sql_ms' => 8.0],
+            ['label' => 'controller_dispatch_done', 't_ms' => 160.0, 'sql' => 53, 'sql_ms' => 30.0],
+        ];
+        $this->insertTimelineEntry('-3 minutes', '/', $fast);
+        $this->insertTimelineEntry('-2 minutes', '/chefs/staffs', $slow);
+        $this->insertTimelineEntry('-1 minute', '/chefs/staffs', $slow);
+
+        $result = $this->runCollector(new RequestTimelinesCollector());
+        $summary = $result['entries']['request-timelines-resume.txt'];
+        $lines = array_values(array_filter(explode("\n", $summary), static fn(string $l): bool => str_contains($l, ' — ')));
+
+        $this->assertStringStartsWith('GET /chefs/staffs — 2 requête(s), médiane 160.0 ms, maximum 160.0 ms, 53 instruction(s) SQL en médiane, segment le plus lourd : controller_dispatch_done (140.0 ms)', $lines[0]);
+        $this->assertStringStartsWith('GET / — 1 requête(s), médiane 30.0 ms', $lines[1]);
+        $this->assertStringContainsString('Temps serveur uniquement', $summary);
+        $this->assertContains('2 chemin(s) mesuré(s), 3 requête(s)', $result['notes']);
+    }
+
+    public function testTimelinesOlderThanTheJournalWindowAreLeftOut(): void
+    {
+        $timeline = [
+            ['label' => 'request_parsed', 't_ms' => 1.0, 'sql' => 0, 'sql_ms' => 0.0],
+            ['label' => 'services_ready', 't_ms' => 20.0, 'sql' => 30, 'sql_ms' => 8.0],
+        ];
+        $this->insertTimelineEntry('-49 hours', '/vieux', $timeline);
+        $this->insertTimelineEntry('-1 hour', '/recent', $timeline);
+
+        $csv = $this->runCollector(new RequestTimelinesCollector())['entries']['request-timelines.csv'];
+
+        $this->assertStringContainsString('/recent', $csv);
+        $this->assertStringNotContainsString('/vieux', $csv);
     }
 
     private function insertJournalEntry(string $relativeTime, string $eventType): void


### PR DESCRIPTION
## Description

Le chantier performance (lots 0 à 4) est déjà sur `main` ; cette PR y ajoute la suite convenue : une **fenêtre de mesure** ouverte depuis Configuration > Support.

« Le site est lent » est le ticket avec lequel on peut le moins faire : quelle page, pour qui, laquelle des quarante étapes d'une requête. La chronologie `?debug=1` y répond, mais seulement pour une URL bricolée par un administrateur. Le superadmin ouvre désormais, après confirmation, une fenêtre de cinq minutes pendant laquelle **chaque requête du site, quel que soit le compte**, journalise sa chronologie ; le paquet de support suivant l'emporte.

- `Core\Debug\MeasurementWindow` : un fichier témoin (`storage/temp/measure_until`) dont la date de modification est l'expiration. Un `filemtime()` par requête (2 µs sur un fichier absent), avant la base et les réglages ; rien ne doit tourner pour fermer la fenêtre, et un compteur plafonne à 500 requêtes enregistrées.
- `RequestTimeline::activate()` / `wasRequested()` : la fenêtre enregistre comme `?debug=1` ; seule la demande explicite écrit l'entrée précoce `debug_request_hit`.
- `SupportController::startMeasurement()` / `stopMeasurement()` (`POST /config/support/measure[/stop]`, superadmin, CSRF, `data-confirm`), journalisés ; la carte « Mesurer une lenteur » affiche l'état de la fenêtre et rappelle de régénérer le paquet avant le ticket.
- `Core\Support\Collector\RequestTimelinesCollector` (`request_timelines`, décrit sur l'écran de consentement) : `request-timelines.csv`, une ligne par segment avec ses deltas de temps et de SQL, et `request-timelines-resume.txt`, un chemin par ligne, le plus lent d'abord, avec le segment le plus lourd.
- La limite est dite sur la page, dans le résumé, dans l'aide (nouvelle rubrique `support-mesure`) et dans `ARCHITECTURE.md` §8.48ter : on ne mesure que le serveur, jamais le réseau ni l'appareil. `docs/chantiers/CHANTIER-performance.md` §6 décrit le beacon client qui compléterait la mesure, pas fait.

Vérifié en direct sur une instance de mesure : six requêtes dont une anonyme journalisées pendant la fenêtre avec leur rôle, le compteur affiché sur la page, le résumé les classe.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`) — 15 049 tests
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — no JavaScript changed in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011DNzn4LyBHL4KjC15twWTn

---
_Generated by [Claude Code](https://claude.ai/code/session_011DNzn4LyBHL4KjC15twWTn)_