### PR TITLE
fix(e2e): measure both day cells in one layout pass

### DIFF
--- a/tests/e2e/specs/rental-request.spec.js
+++ b/tests/e2e/specs/rental-request.spec.js
@@ -186,6 +186,16 @@ test.describe('Rentals', () => {
         await renter.locator('input[name="accept_conditions"]').check();
         await renter.locator('input[name="accept_privacy"]').check();
 
+        // NOTE FOR ANYONE PROBING THIS SPEC'S STABILITY: do not reach for
+        // --repeat-each. HumanCheck's third barrier is a per-IP sliding
+        // window (5 attempts / 10 minutes by default,
+        // core/Security/HumanCheck/HumanCheckService.php), and every repeat
+        // submits this form from the same address, so the 6th run is
+        // refused with « Votre demande n'a pas pu être envoyée » — a real
+        // rejection by a barrier working exactly as specified, which reads
+        // as a flaky test and is not one. Sample this spec with separate
+        // invocations instead.
+        //
         // Core\Security\HumanCheck refuses a form submitted faster than a
         // human could have filled it — a real barrier, and one this
         // scenario has to clear the way a visitor does rather than

--- a/tests/e2e/support/calendar.js
+++ b/tests/e2e/support/calendar.js
@@ -61,28 +61,51 @@ export async function expectRendersAsACalendar(grid) {
     const days = week.locator('.daygrid-day');
     await expect(days).toHaveCount(7);
 
-    // Both boxes read together, and retried until both answer.
+    // Both boxes measured in ONE page evaluation, and retried until the
+    // cells are there to measure.
     //
-    // boundingBox() is a one-shot measurement, and on the rental pages
-    // this grid is LIVE: public/assets/js/rental-calendar.js replaces
+    // On the rental pages this grid is LIVE:
+    // public/assets/js/rental-calendar.js replaces
     // #rental-calendar-fragment's innerHTML when a month is paged or an
-    // estimate recomputed, so the cell measured a millisecond ago can be
-    // detached by the time the next line asks for its neighbour, and
-    // boundingBox() then answers null. Measuring the two separately, even
-    // straight after a toBeVisible(), is therefore a race — one that fails
-    // as "expect(second).not.toBeNull()" and reads as a broken calendar
-    // when the calendar is fine. Polling the PAIR is what makes the
-    // comparison below a comparison of two cells that coexisted.
+    // estimate recomputed. Two separate boundingBox() calls are two
+    // separate round trips to the browser, so the cell measured a
+    // millisecond ago can be detached — answering null — by the time the
+    // next line asks for its neighbour.
+    //
+    // Polling the pair until both answer fixes the null half and NOT the
+    // other half, which is the one that actually cost time: two non-null
+    // rectangles can still come from two DIFFERENT renders, and then the
+    // comparison below is between cells that never coexisted. That is how
+    // this read « two days of one week must share a row » as 8 px apart,
+    // intermittently, and only under scripts/dast.sh — where every request
+    // crosses ZAP and a TLS terminator, so the window between the two
+    // round trips is widest. The browser suite passed the same spec in the
+    // same run, which is what says it was never the calendar.
+    //
+    // evaluateAll() runs once inside the page: both rectangles come out of
+    // the same layout pass, and a re-render cannot slip between them.
     /** @type {{first: {x: number, y: number, height: number}, second: {x: number}}} */
     let box;
     await expect
         .poll(async () => {
-            const first = await days.nth(0).boundingBox();
-            const second = await days.nth(1).boundingBox();
-            if (first === null || second === null) {
+            // ONE evaluation in the page, so both rectangles come from
+            // the same layout pass.
+            const pair = await days.evaluateAll((nodes) => {
+                if (nodes.length < 2) {
+                    return null;
+                }
+                const a = nodes[0].getBoundingClientRect();
+                const b = nodes[1].getBoundingClientRect();
+
+                return {
+                    first: { x: a.x, y: a.y, height: a.height },
+                    second: { x: b.x, y: b.y },
+                };
+            });
+            if (pair === null) {
                 return false;
             }
-            box = { first, second };
+            box = pair;
 
             return true;
         }, { message: "the week's first two day cells must both be laid out at the same moment" })
@@ -124,12 +147,24 @@ export async function expectRendersAsAnEventCalendar(container) {
     let box;
     await expect
         .poll(async () => {
-            const first = await days.nth(0).boundingBox();
-            const second = await days.nth(1).boundingBox();
-            if (first === null || second === null) {
+            // ONE evaluation in the page, so both rectangles come from
+            // the same layout pass.
+            const pair = await days.evaluateAll((nodes) => {
+                if (nodes.length < 2) {
+                    return null;
+                }
+                const a = nodes[0].getBoundingClientRect();
+                const b = nodes[1].getBoundingClientRect();
+
+                return {
+                    first: { x: a.x, y: a.y, height: a.height },
+                    second: { x: b.x, y: b.y },
+                };
+            });
+            if (pair === null) {
                 return false;
             }
-            box = { first, second };
+            box = pair;
 
             return true;
         }, { message: "the week's first two day cells must both be laid out at the same moment" })


### PR DESCRIPTION
## The failure

The release's Dynamic scan gate failed intermittently on `rental-request.spec.js:86` with:

```
expect(Math.abs(box.second.y - box.first.y), 'and share a row').toBeLessThan(2)
Expected: < 2   Received: 8
```

The decisive fact: the **End-to-end gate passed the same spec in the same run**. The difference was the scan's environment, not the code — so it was never the calendar.

## The cause

`expectRendersAsACalendar()` read the two day cells with two separate `boundingBox()` calls — two round trips to the browser. The `expect.poll` around them guarded only against either answering `null`. Two non-null rectangles can still come from two **different renders**, and this grid is live: `rental-calendar.js` replaces `#rental-calendar-fragment`'s `innerHTML`. The comparison was then between cells that never coexisted.

Under `scripts/dast.sh` every request crosses ZAP and a TLS terminator, so the window between the two round trips is at its widest — which is why only that gate saw it.

## The fix

`evaluateAll()` runs once inside the page: both rectangles come out of the same layout pass, and a re-render cannot slip between them. Applied to both helpers in `tests/e2e/support/calendar.js`.

## Verification

- 11 runs of `rental-request.spec.js` under the DAST profile — all green.
- `calendar-events.spec.js` and `rental-management.spec.js`, the other two users of the helper — green.

## Bonus finding

Probing with `--repeat-each=6` produced a *different* failure: « Votre demande n'a pas pu être envoyée ». That is `HumanCheck`'s third barrier — a per-IP sliding window of 5 attempts / 10 minutes — refusing the 6th submission from the same address. A barrier working exactly as specified, which reads as a flaky test. Documented in the spec so the next person sampling it does not chase it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF