### PR TITLE
chore(deps): aws/aws-sdk-php 3.394.8 → 3.394.9

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -62,16 +62,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.394.8",
+            "version": "3.394.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "9afa5f6652e7035a029369c98db68bc21279a3cf"
+                "reference": "c5e7a247fa6aeac7355d5be88f38873480789c71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9afa5f6652e7035a029369c98db68bc21279a3cf",
-                "reference": "9afa5f6652e7035a029369c98db68bc21279a3cf",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c5e7a247fa6aeac7355d5be88f38873480789c71",
+                "reference": "c5e7a247fa6aeac7355d5be88f38873480789c71",
                 "shasum": ""
             },
             "require": {
@@ -153,9 +153,9 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.394.8"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.394.9"
             },
-            "time": "2026-09-03T18:08:51+00:00"
+            "time": "2026-09-04T18:07:00+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
A patch release of the AWS SDK, and nothing else: `composer.json` is unchanged and the lock diff is this package alone.

Found by the release script's **dependency freshness gate**, which refused the 1.0.41 release. Worth recording *how* it refused, since that was the point of the recent gate reordering:

```
❌ Dependency freshness gate FAILED
    aws/aws-sdk-php 3.394.8 ! 3.394.9
ERROR: release blocked by the Dependency freshness gate. No long-running gate was started.
```

Seconds, not the ~25 minutes of tests → end-to-end → dynamic scan that the same finding used to cost. The release also left nothing behind: `VERSION` still reads 1.0.40, no commit, no tag.

`composer audit` clean · PHPStan clean · Modules suite green (8314 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF