### PR TITLE
fix(e2e): a server round trip gets a round-trip ceiling, not an action's

### DIFF
--- a/tests/e2e/specs/banner-visibility.spec.js
+++ b/tests/e2e/specs/banner-visibility.spec.js
@@ -39,6 +39,7 @@ import { expect, test } from '@playwright/test';
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { autoConfirm } from '../support/confirm-dialog.js';
 import { loginAsAdmin } from '../support/admin-login.js';
+import { waitForServerResponse } from '../support/response.js';
 
 const BANNER_TEXT = `Grand nettoyage du local samedi ${Date.now()}`;
 
@@ -105,7 +106,7 @@ test('a banner is created via the modal (or rolled back on dismiss), and its rol
     // The compensating delete's body is never read by the page (its fetch
     // is deliberately fire-and-forget), so this waits on the response
     // status only; the reload below asserts the actual effect.
-    const rollback = page.waitForResponse((response) => response.url().includes('/config/banner/delete'));
+    const rollback = waitForServerResponse(page, (response) => response.url().includes('/config/banner/delete'));
     // The dialog's only dismissal is its header ✕ (Bootstrap's .btn-close,
     // which the shared partial gives no accessible name).
     await modal.locator('.btn-close').click();
@@ -137,7 +138,7 @@ test('a banner is created via the modal (or rolled back on dismiss), and its rol
     // nothing.
     await page.goto('/config/banner', { waitUntil: 'load' });
     const bannerRow = page.locator('#banner-list [data-id]', { hasText: BANNER_TEXT });
-    const roleSave = page.waitForResponse((response) => response.url().includes('/config/banner/role-min'));
+    const roleSave = waitForServerResponse(page, (response) => response.url().includes('/config/banner/role-min'));
     await bannerRow.getByLabel('Visibilité minimale').selectOption('chief');
     expect((await roleSave).ok()).toBe(true);
 
@@ -156,7 +157,7 @@ test('a banner is created via the modal (or rolled back on dismiss), and its rol
 
         // Opened to the public, the same visitor now gets it.
         await page.goto('/config/banner', { waitUntil: 'load' });
-        const publicSave = page.waitForResponse((response) => response.url().includes('/config/banner/role-min'));
+        const publicSave = waitForServerResponse(page, (response) => response.url().includes('/config/banner/role-min'));
         await page.locator('#banner-list [data-id]', { hasText: BANNER_TEXT })
             .getByLabel('Visibilité minimale').selectOption('public');
         expect((await publicSave).ok()).toBe(true);

--- a/tests/e2e/specs/calendar-events.spec.js
+++ b/tests/e2e/specs/calendar-events.spec.js
@@ -28,6 +28,7 @@ import { answerCookieBanner } from '../support/cookie-banner.js';
 import { answerConfirmation, autoConfirm } from '../support/confirm-dialog.js';
 import { expectRendersAsAnEventCalendar } from '../support/calendar.js';
 import { loginAsAdmin, loginAsMember } from '../support/admin-login.js';
+import { waitForServerResponse } from '../support/response.js';
 
 const EVENT_TITLE = `Réunion de branche E2E ${Date.now()}`;
 const EVENT_TITLE_EDITED = `${EVENT_TITLE} (reportée)`;
@@ -64,7 +65,7 @@ test('a chief creates, edits and deletes an event through the modal, the grids r
     // (« Vu par »); its accessible name adds the calendar so a page full
     // of them stays navigable — see partials/form_field's `aria_label`.
     const visibilitySelect = page.getByLabel('Vu par — Meute E2E');
-    const visibilitySave = page.waitForResponse((response) => response.url().includes('/config/calendar/visibility'));
+    const visibilitySave = waitForServerResponse(page, (response) => response.url().includes('/config/calendar/visibility'));
     await visibilitySelect.selectOption('public');
     expect((await visibilitySave).ok()).toBe(true);
 
@@ -207,7 +208,7 @@ test('a chief creates, edits and deletes an event through the modal, the grids r
     // And the section calendar goes back to its provisioned visibility,
     // so the calendar surface later scenarios meet is untouched.
     await page.goto('/config/calendar', { waitUntil: 'load' });
-    const visibilityRestore = page.waitForResponse((response) => response.url().includes('/config/calendar/visibility'));
+    const visibilityRestore = waitForServerResponse(page, (response) => response.url().includes('/config/calendar/visibility'));
     await page.getByLabel('Vu par — Meute E2E').selectOption('chief');
     expect((await visibilityRestore).ok()).toBe(true);
 
@@ -219,12 +220,12 @@ test('a chief creates, edits and deletes an event through the modal, the grids r
     // calendar the later scenarios meet keeps its provisioned value.
     // ---------------------------------------------------------------
     const editRoleSelect = page.getByLabel('Modifié par — Meute E2E');
-    const editRoleSave = page.waitForResponse((response) => response.url().includes('/config/calendar/edit-role'));
+    const editRoleSave = waitForServerResponse(page, (response) => response.url().includes('/config/calendar/edit-role'));
     await editRoleSelect.selectOption('admin');
     expect((await editRoleSave).ok()).toBe(true);
     await expect(editRoleSelect).toHaveValue('admin');
 
-    const editRoleRestore = page.waitForResponse((response) => response.url().includes('/config/calendar/edit-role'));
+    const editRoleRestore = waitForServerResponse(page, (response) => response.url().includes('/config/calendar/edit-role'));
     await editRoleSelect.selectOption('chief');
     expect((await editRoleRestore).ok()).toBe(true);
     await expect(editRoleSelect).toHaveValue('chief');

--- a/tests/e2e/specs/config-desk.spec.js
+++ b/tests/e2e/specs/config-desk.spec.js
@@ -26,6 +26,7 @@ import { expect, test } from '@playwright/test';
 
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin, loginAsMember } from '../support/admin-login.js';
+import { waitForServerResponse } from '../support/response.js';
 
 const SECTION_RENAMED = 'Meute E2E (renommée)';
 
@@ -37,7 +38,7 @@ const SECTION_RENAMED = 'Meute E2E (renommée)';
  * @param {string} endpoint
  */
 function nextSave(page, endpoint) {
-    return page.waitForResponse((response) => response.url().includes(endpoint));
+    return waitForServerResponse(page, (response) => response.url().includes(endpoint));
 }
 
 test('config desk auto-saves roles and sections, and a role change reaches the member\'s live session at once', async ({ page, browser }) => {

--- a/tests/e2e/specs/gallery-media.spec.js
+++ b/tests/e2e/specs/gallery-media.spec.js
@@ -32,6 +32,7 @@ import { loginAsAdmin, loginAsMember } from '../support/admin-login.js';
 import { noisePngBuffer, pngBuffer } from '../support/png.js';
 import { runScheduler } from '../support/scheduler.js';
 import { scaled } from '../support/timeouts.js';
+import { waitForServerResponse } from '../support/response.js';
 
 const ALBUM_TITLE = `Camp d'été E2E ${Date.now()}`;
 
@@ -134,7 +135,7 @@ test('a chief uploads plain and chunked, reorders by drag, and a member browses 
         throw new Error('the third tile has no box — the grid did not render');
     }
 
-    const reorderSaved = page.waitForResponse((response) => response.url().includes('/media/reorder'));
+    const reorderSaved = waitForServerResponse(page, (response) => response.url().includes('/media/reorder'));
     await items.first().dragTo(dropTarget, {
         targetPosition: { x: targetBox.width * 0.9, y: targetBox.height / 2 },
     });

--- a/tests/e2e/specs/groups-management.spec.js
+++ b/tests/e2e/specs/groups-management.spec.js
@@ -55,6 +55,7 @@ import { autoConfirm } from '../support/confirm-dialog.js';
 import { loginAsAdmin, loginAsMember } from '../support/admin-login.js';
 // Shared with specs/groups-discussion.spec.js — see support/groups.js.
 import { openComposer, openCreateGroupForm, waitForGroupsJsReady } from '../support/groups.js';
+import { waitForServerResponse } from '../support/response.js';
 
 // Unique per run, so a re-run against a database that somehow survived
 // still matches its own group rather than an older one by name.
@@ -90,7 +91,7 @@ function memberRow(page, name) {
  */
 async function submitAndReload(page, control, route) {
     await Promise.all([
-        page.waitForResponse((response) =>
+        waitForServerResponse(page, (response) =>
             response.url().includes(route) && response.request().method() === 'POST'),
         control.click(),
     ]);
@@ -264,7 +265,7 @@ test('a moderator opens a group, invites somebody, promotes, closes, reopens and
         const pinDialog = page.locator('#groups-detail-modal');
         await expect(pinDialog.getByText('Pendant combien de temps ?')).toBeVisible();
         await Promise.all([
-            page.waitForResponse((response) =>
+            waitForServerResponse(page, (response) =>
                 response.url().includes('/pin') && response.request().method() === 'POST'),
             pinDialog.getByRole('button', { name: '1 semaine' }).click(),
         ]);

--- a/tests/e2e/specs/oncall-grid.spec.js
+++ b/tests/e2e/specs/oncall-grid.spec.js
@@ -27,6 +27,7 @@ import { expect, test } from '@playwright/test';
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { waitForSosJsReady } from '../support/sos.js';
+import { waitForServerResponse } from '../support/response.js';
 
 /**
  * Puts the roster back the way the harness provisioned it — empty.
@@ -129,7 +130,7 @@ test('the duty grid cycles a cell through its three states, saving the month on 
 
     /** Click the cell once and wait for the full-month save to answer. */
     async function clickAndSave() {
-        const saved = page.waitForResponse((response) => response.url().includes('/admin/sos/oncall'));
+        const saved = waitForServerResponse(page, (response) => response.url().includes('/admin/sos/oncall'));
         await cellAgain().click();
         expect((await saved).ok()).toBe(true);
         await expect(saveStatus).toHaveText('Enregistré.');
@@ -289,7 +290,7 @@ test('on a phone the month is a list of days, and one sheet edits any of them', 
 
     /** Press one of the three named buttons and wait for the month to land. */
     async function press(label) {
-        const saved = page.waitForResponse((response) => response.url().includes('/admin/sos/oncall'));
+        const saved = waitForServerResponse(page, (response) => response.url().includes('/admin/sos/oncall'));
         await memberBlock.getByRole('button', { name: label, exact: true }).click();
         expect((await saved).ok()).toBe(true);
         await expect(page.locator('#sos-day-sheet-status')).toHaveText('Enregistré.');
@@ -394,7 +395,7 @@ test('the default-number warning shows only when today has no on-call', async ({
 
     /** Click today's cell once and wait for the full-month save to answer. */
     async function cycleToday() {
-        const saved = page.waitForResponse((response) => response.url().includes('/admin/sos/oncall'));
+        const saved = waitForServerResponse(page, (response) => response.url().includes('/admin/sos/oncall'));
         await cellAgain().click();
         expect((await saved).ok()).toBe(true);
         await expect(page.locator('#oncall-save-status')).toHaveText('Enregistré.');

--- a/tests/e2e/specs/optional-module-dependencies.spec.js
+++ b/tests/e2e/specs/optional-module-dependencies.spec.js
@@ -58,6 +58,7 @@ import { expect, test } from '@playwright/test';
 import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { moduleToggle, toggleModule } from '../support/modules.js';
+import { waitForServerResponse } from '../support/response.js';
 
 const GALLERY = 'Galerie photos et vidéos';
 const GROUPS = 'Groupes de discussion';
@@ -109,7 +110,7 @@ test('a hard dependency is refused both ways, and an optional one degrades and c
     // response is awaited first: asserting any earlier would read an
     // empty screen every time, whatever the server answered.
     await Promise.all([
-        page.waitForResponse((response) => response.url().includes('/config/modules/toggle')),
+        waitForServerResponse(page, (response) => response.url().includes('/config/modules/toggle')),
         moduleToggle(page, GALLERY).uncheck(),
     ]);
 

--- a/tests/e2e/specs/registration-flow.spec.js
+++ b/tests/e2e/specs/registration-flow.spec.js
@@ -56,6 +56,7 @@ import { answerCookieBanner } from '../support/cookie-banner.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { linkFromMail, waitForMail } from '../support/maildrop.js';
 import { waitOutHumanCheckDelay } from '../support/human-check.js';
+import { waitForServerResponse } from '../support/response.js';
 
 /**
  * Opens one of /config/inscriptions' collapsible boxes, asserting on the
@@ -94,7 +95,7 @@ async function openConfigBox(page, name, panelId) {
  */
 async function saveCapacitiesBox(page) {
     await Promise.all([
-        page.waitForResponse((response) =>
+        waitForServerResponse(page, (response) =>
             response.request().method() === 'POST' && response.url().endsWith('/config/inscriptions')),
         page.locator('#registration-capacities-box')
             .getByRole('button', { name: 'Enregistrer', exact: true }).click(),

--- a/tests/e2e/specs/registration-grids.spec.js
+++ b/tests/e2e/specs/registration-grids.spec.js
@@ -41,6 +41,7 @@ import { answerCookieBanner } from '../support/cookie-banner.js';
 import { autoConfirm } from '../support/confirm-dialog.js';
 import { loginAsAdmin } from '../support/admin-login.js';
 import { chooseInSelectBar } from '../support/select-bar.js';
+import { waitForServerResponse } from '../support/response.js';
 
 const MEMBER_NAME = 'Kaa Serpent';
 const DEPARTURE_COMMENT = 'Déménage à Namur cet été.';
@@ -84,7 +85,7 @@ async function openCapacitiesBox(page) {
  */
 async function saveCapacitiesBox(page) {
     await Promise.all([
-        page.waitForResponse((response) =>
+        waitForServerResponse(page, (response) =>
             response.request().method() === 'POST' && response.url().endsWith('/config/inscriptions')),
         page.locator('#registration-capacities-box')
             .getByRole('button', { name: 'Enregistrer', exact: true }).click(),
@@ -146,14 +147,14 @@ test('the departures and passage grids save on change, with no save button anywh
     const leavingBox = page.getByRole('checkbox', { name: `Ne sera plus là l'année prochaine — ${MEMBER_NAME}` });
     await expect(leavingBox).not.toBeChecked();
 
-    const saveOfLeaving = page.waitForResponse((response) => response.url().includes('/departs/') && response.request().method() === 'POST');
+    const saveOfLeaving = waitForServerResponse(page, (response) => response.url().includes('/departs/') && response.request().method() === 'POST');
     await leavingBox.check();
     expect ((await (await saveOfLeaving).json()).success, 'checking the box must save on its own').toBe(true);
 
     const commentField = page.getByLabel(`Note interne — jamais vue par la famille — ${MEMBER_NAME}`);
     await expect(commentField).toBeVisible();
 
-    const saveOfComment = page.waitForResponse((response) => response.url().includes('/departs/') && response.request().method() === 'POST');
+    const saveOfComment = waitForServerResponse(page, (response) => response.url().includes('/departs/') && response.request().method() === 'POST');
     await commentField.fill(DEPARTURE_COMMENT);
     await commentField.blur();
     expect((await (await saveOfComment).json()).success).toBe(true);
@@ -174,7 +175,7 @@ test('the departures and passage grids save on change, with no save button anywh
     // failed in CI under the security scan, whose added latency widens the
     // window (Playwright reports uncheck() done once the DOM reflects it,
     // not once the save has landed).
-    const saveOfReset = page.waitForResponse((response) => response.url().includes('/departs/') && response.request().method() === 'POST');
+    const saveOfReset = waitForServerResponse(page, (response) => response.url().includes('/departs/') && response.request().method() === 'POST');
     await page.getByRole('checkbox', { name: `Ne sera plus là l'année prochaine — ${MEMBER_NAME}` }).uncheck();
     expect((await (await saveOfReset).json()).success, 'unchecking the box must save on its own').toBe(true);
     await page.reload({ waitUntil: 'domcontentloaded' });

--- a/tests/e2e/specs/rental-lifecycle.spec.js
+++ b/tests/e2e/specs/rental-lifecycle.spec.js
@@ -89,6 +89,7 @@ import { openSectionEditor } from '../support/section-editor.js';
 import { pngBuffer } from '../support/png.js';
 import { scaled } from '../support/timeouts.js';
 import { waitOutHumanCheckDelay } from '../support/human-check.js';
+import { waitForServerResponse } from '../support/response.js';
 
 /** A date far enough out to clear any notice period the asset declares. */
 function isoDaysFromNow(days) {
@@ -447,7 +448,7 @@ function bookingUrl(page) {
  * @param {import('@playwright/test').Locator} button the submit to press
  */
 async function submitAndReload(page, action, button) {
-    const posted = page.waitForResponse(
+    const posted = waitForServerResponse(page, 
         (response) => response.url().endsWith(action) && response.request().method() === 'POST',
     );
     await button.click();

--- a/tests/e2e/specs/scout-year-transition.spec.js
+++ b/tests/e2e/specs/scout-year-transition.spec.js
@@ -72,6 +72,7 @@ import { loginAsAdmin } from '../support/admin-login.js';
 // Shared with specs/optional-module-dependencies.spec.js, which switches
 // modules off for the opposite reason — see support/modules.js.
 import { toggleModule } from '../support/modules.js';
+import { waitForServerResponse } from '../support/response.js';
 
 const DESK_FIXTURE = path.join(
     path.dirname(fileURLToPath(import.meta.url)),
@@ -173,7 +174,7 @@ async function toggleStep(page, key) {
     // instantly and assert against the pre-submit DOM. Wait on the request
     // itself, then on the reload it causes.
     await Promise.all([
-        page.waitForResponse((response) =>
+        waitForServerResponse(page, (response) =>
             response.url().includes('/admin/scout-year/step') && response.request().method() === 'POST'),
         step(page, key).getByRole('checkbox').click(),
     ]);

--- a/tests/e2e/support/modules.js
+++ b/tests/e2e/support/modules.js
@@ -13,6 +13,7 @@
 // steps it owns disappear, and specs/optional-module-dependencies.spec.js
 // takes one away to watch another module degrade around its absence.
 import { expect } from '@playwright/test';
+import { waitForServerResponse } from './response.js';
 
 /**
  * The switch for one module, addressed the way the page labels it for
@@ -35,7 +36,7 @@ export async function toggleModule(page, moduleName, enabled) {
 
     const toggle = moduleToggle(page, moduleName);
     await Promise.all([
-        page.waitForResponse((response) => response.url().includes('/config/modules/toggle')),
+        waitForServerResponse(page, (response) => response.url().includes('/config/modules/toggle')),
         enabled ? toggle.check() : toggle.uncheck(),
     ]);
     await page.waitForLoadState('domcontentloaded');

--- a/tests/e2e/support/response.js
+++ b/tests/e2e/support/response.js
@@ -1,0 +1,33 @@
+// Waiting for a RESPONSE is not the same kind of wait as an action.
+//
+// playwright.config.js sets actionTimeout to scaled(10_000), which is the
+// ceiling page.waitForResponse() inherits when it is given none. Ten
+// seconds is generous for clicking a button; it is not generous for the
+// server round trip that click provokes, served by a single-worker PHP
+// built-in server whose other requests queue behind this one. On a
+// contended CI runner that ceiling is genuinely reachable — it is what
+// failed registration-grids.spec.js on main (« waitForResponse: Timeout
+// 10000ms exceeded », 52 of 53 specs green in the same run), and what
+// scout-year-transition.spec.js records having hit before it.
+//
+// navigationTimeout, scaled(30_000), is the config's own ceiling for the
+// closest thing there is: a request going to the server and coming back.
+// That is the number used here.
+//
+// This helper does NOT paper over a race. Every call site registers the
+// wait BEFORE the action that triggers the request, which is what makes
+// the response impossible to miss; where the request may never be made at
+// all, the fix is a marker the page sets — see scout-year-transition.spec.js
+// — and no ceiling, however large, is the right answer.
+import { scaled } from './timeouts.js';
+
+/**
+ * page.waitForResponse() with a ceiling that fits a server round trip.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {(response: import('@playwright/test').Response) => boolean} matcher
+ * @returns {Promise<import('@playwright/test').Response>}
+ */
+export function waitForServerResponse(page, matcher) {
+    return page.waitForResponse(matcher, { timeout: scaled(30_000) });
+}


### PR DESCRIPTION
`registration-grids.spec.js` failed on `main` with **`waitForResponse: Timeout 10000ms exceeded`** while the other 52 specs passed in the same run — blocking the SonarQube job, and with it the 1.0.41 release.

## Not a race

Every one of these waits is registered **before** the action that triggers the request, which is what makes the response impossible to miss. The POST simply did not come back within ten seconds on a contended CI runner.

## Where ten seconds came from

`playwright.config.js` sets `actionTimeout: scaled(10_000)`, and `page.waitForResponse()` adopts it when given no ceiling of its own. That number is sized for **clicking a button**, not for the server round trip the click provokes — served by a single-worker PHP built-in server behind which every other request in the spec queues.

The config's own ceiling for a request going out and coming back is `navigationTimeout: scaled(30_000)`. That is what this uses.

All 23 call sites — 22 across 11 specs, plus `support/modules.js` — now go through `waitForServerResponse()`, so the reasoning lives in one place instead of 23 bare numbers, and it scales with `E2E_TIMEOUT_FACTOR` under the security scan like every other ceiling.

## What this deliberately does not do

It does not widen a window where the request **may never be made at all**. `scout-year-transition.spec.js` hit that shape and fixed it correctly — by waiting on a marker the page sets — and no ceiling, however large, would have been right there. The helper's docblock says so, so the next person reaching for it knows which problem it is for.

53 end-to-end scenarios green locally, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF