### PR TITLE
fix(sonar): the last 23 blocking findings

### DIFF
--- a/public/assets/js/account-passkeys.js
+++ b/public/assets/js/account-passkeys.js
@@ -83,7 +83,7 @@
      * @returns {string}
      */
     function registrationErrorMessage(err) {
-        switch (err && /** @type {any} */ (err).name) {
+        switch (/** @type {any} */ (err)?.name) {
             // The platform authenticator already holds a key for this
             // account on this device (excludeCredentials prevents a
             // duplicate).

--- a/public/assets/js/attestations-verification.js
+++ b/public/assets/js/attestations-verification.js
@@ -113,7 +113,7 @@
         var total = rows.length;
         var selected = rows.filter(function (row) {
             var box = checkboxOf(row);
-            return box !== null && box.checked;
+            return box?.checked === true;
         }).length;
 
         if (visibleEl) {
@@ -140,7 +140,7 @@
 
         return tickable.length > 0 && tickable.every(function (row) {
             var box = checkboxOf(row);
-            return box !== null && box.checked;
+            return box?.checked === true;
         });
     }
 

--- a/public/assets/js/camps-place-summary.js
+++ b/public/assets/js/camps-place-summary.js
@@ -55,7 +55,7 @@
      */
     function release(form) {
         var button = submitButtonOf(form);
-        if (button === null || button.dataset.idleLabel === undefined) {
+        if (button?.dataset.idleLabel === undefined) {
             return;
         }
 

--- a/public/assets/js/drop-zone.js
+++ b/public/assets/js/drop-zone.js
@@ -66,7 +66,7 @@
 
         zone.addEventListener('drop', function (e) {
             var transfer = /** @type {DragEvent} */ (e).dataTransfer;
-            if (transfer?.files && transfer.files.length) {
+            if (transfer?.files?.length) {
                 onFiles(transfer.files);
             }
         });

--- a/public/assets/js/groups.js
+++ b/public/assets/js/groups.js
@@ -1333,7 +1333,7 @@
             var form = /** @type {HTMLFormElement} */ (element);
             var key = replyDraftKey(form);
             var input = /** @type {HTMLInputElement} */ (form.querySelector('input[name="body"]'));
-            if (!key || !input || input.value.trim() !== '') {
+            if (!key || input?.value.trim() !== '') {
                 return;
             }
 
@@ -1580,7 +1580,7 @@
                 return { ok: response.ok, data: data };
             });
         }).then(function (result) {
-            if (!result.ok || !result.data || result.data.reported !== true) {
+            if (!result.ok || result.data?.reported !== true) {
                 form.submit();
                 return;
             }

--- a/public/assets/js/help-assistant.js
+++ b/public/assets/js/help-assistant.js
@@ -282,7 +282,7 @@
             // help-search.js re-enabling its button.
             scope.dispatchEvent(new CustomEvent('scoutmagic:help-assistant-idle', { bubbles: true }));
 
-            if (!res.ok || !res.data || res.data.success !== true) {
+            if (!res.ok || res.data?.success !== true) {
                 // The server's own sentence when it wrote one — every
                 // refusal this endpoint produces is French and meant for
                 // the reader (quota, connector absent, provider failure).

--- a/public/assets/js/help-search.js
+++ b/public/assets/js/help-search.js
@@ -53,7 +53,7 @@
     // (folded to « ou »), « quand » and « pourquoi » are in it because a
     // `question:` line opens with one of them; « tou » is there because
     // de-suffixing turns « tous » into it.
-    var STOP_WORDS = [
+    var STOP_WORDS = new Set([
         'a', 'au', 'aux', 'avec', 'ce', 'ces', 'cet', 'cette', 'comment', 'dans',
         'de', 'des', 'du', 'elle', 'en', 'est', 'et', 'eux', 'il', 'ils', 'je',
         'la', 'le', 'les', 'leur', 'lui', 'ma', 'mais', 'mes', 'mon', 'ne', 'nos',
@@ -61,7 +61,7 @@
         'pourquoi', 'qu', 'quand', 'que', 'qui', 'quoi', 'sa', 'se', 'ses', 'son',
         'sont', 'sur', 'ta', 'te', 'tes', 'toi', 'ton', 'tou', 'tous', 'tout',
         'toute', 'toutes', 'tu', 'un', 'une', 'vos', 'votre', 'vous', 'y'
-    ];
+    ]);
 
     /**
      * Lowercased with the diacritics stripped, so "médaille" and
@@ -112,7 +112,7 @@
         var tokens = [];
         var raw = normalize(value).split(/[^a-z0-9]+/);
         for (const token of raw) {
-            if (token === '' || STOP_WORDS.includes(token)) {
+            if (token === '' || STOP_WORDS.has(token)) {
                 continue;
             }
             tokens.push(stem(token));
@@ -276,12 +276,12 @@
         var needed = requiredCoverage(terms.length);
         var scored = [];
 
-        for (var i = 0; i < prepared.length; i++) {
+        for (const candidate of prepared) {
             var score = 0;
             var covered = 0;
 
             for (const term of terms) {
-                var best = scoreTerm(term, prepared[i]);
+                var best = scoreTerm(term, candidate);
                 if (best > 0) {
                     covered++;
                     score += best;
@@ -289,7 +289,7 @@
             }
 
             if (covered >= needed) {
-                scored.push({ entry: prepared[i].entry, score: score, title: normalize(prepared[i].entry.title) });
+                scored.push({ entry: candidate.entry, score: score, title: normalize(candidate.entry.title) });
             }
         }
 

--- a/public/assets/js/maintenance.js
+++ b/public/assets/js/maintenance.js
@@ -595,7 +595,7 @@
             var fileInput = /** @type {HTMLInputElement} */ (document.getElementById('restore-backup-file'));
             var uploadIdInput = /** @type {HTMLInputElement} */ (document.getElementById('restore-upload-id'));
             var chunkFile = sourceUploadRadio?.checked
-                && fileInput?.files && fileInput.files[0] ? fileInput.files[0] : null;
+                && fileInput?.files?.[0] ? fileInput.files[0] : null;
             if (chunker && uploadIdInput && chunkFile?.size > chunker.CHUNK_THRESHOLD) {
                 submitBtn.disabled = true;
                 var chunkErrorEl = document.getElementById('restore-backup-error');

--- a/public/assets/js/news-form-builder.js
+++ b/public/assets/js/news-form-builder.js
@@ -605,7 +605,7 @@
         { type: 'confirmation', label: 'Bloc de confirmation', icon: 'bi-info-circle' },
         { type: 'text', label: 'Bloc de texte', icon: 'bi-card-text' }
     ];
-    var NON_INPUT_TYPES = ['confirmation', 'text'];
+    var NON_INPUT_TYPES = new Set(['confirmation', 'text']);
     var TYPE_LABELS = {};
     FIELD_TYPES.forEach(function (t) { TYPE_LABELS[t.type] = t.label; });
 
@@ -754,7 +754,7 @@
         // content, "Formulaire" once there's something to fill in.
         function updateFormSettingsVisibility() {
             var hasRealInput = fieldState.some(function (f) {
-                return !NON_INPUT_TYPES.includes(f.field_type);
+                return !NON_INPUT_TYPES.has(f.field_type);
             });
 
             var settings = document.getElementById('news-form-settings');
@@ -871,7 +871,7 @@
 
             var label = document.createElement('span');
             label.className = 'flex-grow-1';
-            var isNonInput = NON_INPUT_TYPES.includes(field.field_type);
+            var isNonInput = NON_INPUT_TYPES.has(field.field_type);
             var BLOCK_LABELS = { confirmation: 'Bloc de confirmation', text: 'Bloc de texte' };
             var labelText = BLOCK_LABELS[field.field_type] || field.label || 'Sans libellé';
             // field.label is admin-entered free text (not HTML-sanitized server-side,
@@ -1204,7 +1204,7 @@
             panel.className = 'mt-2 pt-2 border-top';
             panel.addEventListener('click', function (e) { e.stopPropagation(); });
 
-            if (!NON_INPUT_TYPES.includes(field.field_type)) {
+            if (!NON_INPUT_TYPES.has(field.field_type)) {
                 buildLabelAndRequiredRow(panel, field);
             }
 

--- a/public/assets/js/offline-cache.js
+++ b/public/assets/js/offline-cache.js
@@ -42,7 +42,7 @@
     // unconditional regardless of this flag — see that function's own
     // comment.
     function isStandalone() {
-        return (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches)
+        return window.matchMedia?.('(display-mode: standalone)').matches
             || window.navigator.standalone === true;
     }
 

--- a/public/assets/js/offline-prefetch.js
+++ b/public/assets/js/offline-prefetch.js
@@ -74,7 +74,7 @@
     if (!config.consent || config.accountScope === 'guest') {
         return;
     }
-    var isStandalone = (window.matchMedia && window.matchMedia('(display-mode: standalone)').matches)
+    var isStandalone = window.matchMedia?.('(display-mode: standalone)').matches
         || window.navigator.standalone === true;
     if (!isStandalone) {
         return;

--- a/public/assets/js/rgpd-config.js
+++ b/public/assets/js/rgpd-config.js
@@ -110,7 +110,7 @@
         return api.getJson('/config/rgpd/generate/status').then(function (res) {
             var data = res.data;
 
-            if (!data || data.success !== true) {
+            if (data?.success !== true) {
                 stopGenerationTimer();
                 generateStatus.innerHTML = generateErrorHtml(res);
                 generateBtn.disabled = false;
@@ -159,7 +159,7 @@
 
         return api.postJson('/config/rgpd/generate', { prompt: prompt })
             .then(function (res) {
-                if (!res.data || res.data.success !== true) {
+                if (res.data?.success !== true) {
                     stopGenerationTimer();
                     generateStatus.innerHTML = generateErrorHtml(res);
                     generateBtn.disabled = false;

--- a/public/assets/js/rich-text-form-field.js
+++ b/public/assets/js/rich-text-form-field.js
@@ -49,7 +49,7 @@
  * @returns {string|null}
  */
 export function keywordOf(node) {
-    if (!node || node.nodeType !== 1) {
+    if (node?.nodeType !== 1) {
         return null;
     }
 

--- a/public/assets/js/rich-text-link.js
+++ b/public/assets/js/rich-text-link.js
@@ -36,7 +36,7 @@
 // api.js.
 (function () {
     // Everything a link in a scout unit's page legitimately points at.
-    var ALLOWED_SCHEMES = ['http', 'https', 'mailto', 'tel'];
+    var ALLOWED_SCHEMES = new Set(['http', 'https', 'mailto', 'tel']);
 
     /**
      * Turns what the visitor typed into an href, or null if it is not one
@@ -53,7 +53,7 @@
 
         var scheme = /^([a-z][a-z0-9+.-]*):/i.exec(url);
         if (scheme) {
-            return ALLOWED_SCHEMES.includes(scheme[1].toLowerCase()) ? url : null;
+            return ALLOWED_SCHEMES.has(scheme[1].toLowerCase()) ? url : null;
         }
         // Site-relative and same-page links are already hrefs.
         if (url.startsWith('/') || url.startsWith('#')) {

--- a/public/assets/js/section-editor.js
+++ b/public/assets/js/section-editor.js
@@ -88,7 +88,7 @@
         // identifier does not allow.
         var scope = root && typeof root.getElementById === 'function' ? root : document;
         var target = /** @type {HTMLElement|null} */ (scope.getElementById(id));
-        if (target === null || target.dataset.sectionEditor === undefined) {
+        if (target?.dataset.sectionEditor === undefined) {
             return false;
         }
 

--- a/scripts/check-sonar-release.sh
+++ b/scripts/check-sonar-release.sh
@@ -60,6 +60,12 @@ set -euo pipefail
 SONAR_HOST_URL="${SONAR_HOST_URL:-https://sonarcloud.io}"
 SONAR_PROJECT_KEY="${SONAR_PROJECT_KEY:-xdubois-57_scoutmagic}"
 SONAR_BRANCH="${SONAR_BRANCH:-main}"
+
+# Percent-encoded once, here, rather than by a `php -r` subshell at each of
+# the six query sites: both are constants for the whole run, and spawning
+# twelve interpreters to encode the same two strings is twelve interpreters.
+PROJECT_Q="$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_PROJECT_KEY}")"
+BRANCH_Q="$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_BRANCH}")"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # Overridable so check-sonar-release.test.sh can point this at a throwaway
 # path instead of ever touching a real developer's ${REPO_ROOT}/.sonar-token.
@@ -169,7 +175,7 @@ KEY_LINE='  %s\n'
 LOCAL_HEAD="$(git rev-parse HEAD)"
 
 ANALYSES_FILE="$(mktemp)"
-if ! sonar_get "/api/project_analyses/search?project=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_PROJECT_KEY}")&branch=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_BRANCH}")&ps=1" > "${ANALYSES_FILE}"; then
+if ! sonar_get "/api/project_analyses/search?project=${PROJECT_Q}&branch=${BRANCH_Q}&ps=1" > "${ANALYSES_FILE}"; then
     rm -f "${ANALYSES_FILE}"
     fail
 fi
@@ -190,7 +196,7 @@ fi
 
 # --- 2. Quality Gate ---
 QG_FILE="$(mktemp)"
-if ! sonar_get "/api/qualitygates/project_status?projectKey=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_PROJECT_KEY}")&branch=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_BRANCH}")" > "${QG_FILE}"; then
+if ! sonar_get "/api/qualitygates/project_status?projectKey=${PROJECT_Q}&branch=${BRANCH_Q}" > "${QG_FILE}"; then
     rm -f "${QG_FILE}"
     fail
 fi
@@ -209,7 +215,7 @@ rm -f "${QG_FILE}"
 
 # --- 3. Unresolved SECURITY-impact issues (any severity) ---
 SECURITY_ISSUES_FILE="$(mktemp)"
-if ! sonar_get "/api/issues/search?componentKeys=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_PROJECT_KEY}")&branch=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_BRANCH}")&resolved=false&impactSoftwareQualities=SECURITY&ps=100" > "${SECURITY_ISSUES_FILE}"; then
+if ! sonar_get "/api/issues/search?componentKeys=${PROJECT_Q}&branch=${BRANCH_Q}&resolved=false&impactSoftwareQualities=SECURITY&ps=100" > "${SECURITY_ISSUES_FILE}"; then
     rm -f "${SECURITY_ISSUES_FILE}"
     fail
 fi
@@ -219,7 +225,7 @@ rm -f "${SECURITY_ISSUES_FILE}"
 
 # --- 4. Unreviewed Security Hotspots ---
 HOTSPOTS_FILE="$(mktemp)"
-if ! sonar_get "/api/hotspots/search?projectKey=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_PROJECT_KEY}")&branch=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_BRANCH}")&status=TO_REVIEW&ps=100" > "${HOTSPOTS_FILE}"; then
+if ! sonar_get "/api/hotspots/search?projectKey=${PROJECT_Q}&branch=${BRANCH_Q}&status=TO_REVIEW&ps=100" > "${HOTSPOTS_FILE}"; then
     rm -f "${HOTSPOTS_FILE}"
     fail
 fi
@@ -250,7 +256,7 @@ ISSUES_TOTAL=0
 PAGE=1
 while :; do
     PAGE_FILE="$(mktemp)"
-    if ! sonar_get "/api/issues/search?componentKeys=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_PROJECT_KEY}")&branch=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_BRANCH}")&resolved=false&ps=500&p=${PAGE}" > "${PAGE_FILE}"; then
+    if ! sonar_get "/api/issues/search?componentKeys=${PROJECT_Q}&branch=${BRANCH_Q}&resolved=false&ps=500&p=${PAGE}" > "${PAGE_FILE}"; then
         rm -f "${PAGE_FILE}" "${BLOCKING_KEYS_FILE}"
         fail
     fi
@@ -306,7 +312,7 @@ if [[ "${BLOCKED}" -eq 1 ]]; then
         [[ -n "${SECURITY_ISSUES_KEYS}" ]] && { echo "Blocking security issues:"; printf "${KEY_LINE}" ${SECURITY_ISSUES_KEYS}; }
         [[ -n "${HOTSPOTS_KEYS}" ]] && { echo "Unreviewed security hotspots:"; printf "${KEY_LINE}" ${HOTSPOTS_KEYS}; }
         [[ -n "${BLOCKING_KEYS}" ]] && { echo "Blocking issues (first 10 of ${BLOCKING_COUNT}):"; printf "${KEY_LINE}" ${BLOCKING_KEYS}; }
-        echo "See: ${SONAR_HOST_URL}/project/issues?id=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_PROJECT_KEY}")&branch=$(php -r 'echo rawurlencode($argv[1]);' "${SONAR_BRANCH}")&resolved=false"
+        echo "See: ${SONAR_HOST_URL}/project/issues?id=${PROJECT_Q}&branch=${BRANCH_Q}&resolved=false"
     } >&2
     fail
 fi

--- a/scripts/check-sonar-release.test.sh
+++ b/scripts/check-sonar-release.test.sh
@@ -151,13 +151,15 @@ run_case "unreviewed hotspot" 1
 # out of three" is the mistake this rule invites.
 # ---------------------------------------------------------------
 issue_json() {
-    # $1: tags array, $2: impacts array
-    printf '[{"key":"AY-1","rule":"php:S103","tags":%s,"impacts":%s}]' "$1" "$2"
+    local tags="$1"
+    local impacts="$2"
+    printf '[{"key":"AY-1","rule":"php:S103","tags":%s,"impacts":%s}]' "${tags}" "${impacts}"
 }
 MAINT_LOW='[{"softwareQuality":"MAINTAINABILITY","severity":"LOW"}]'
+CONVENTION='["convention"]'
 
 echo "3. The exempt finding: MAINTAINABILITY + LOW + convention -> PASS"
-write_default_fake_curl "${HEAD_SHA}" "OK" 0 0 1 "$(issue_json '["convention"]' "${MAINT_LOW}")"
+write_default_fake_curl "${HEAD_SHA}" "OK" 0 0 1 "$(issue_json "${CONVENTION}" "${MAINT_LOW}")"
 run_case "maintainability/low/convention is exempt" 0
 
 echo "3a. Same finding without the convention tag -> BLOCK"
@@ -170,12 +172,12 @@ run_case "maintainability/low, untagged" 1
 
 echo "3c. convention + MAINTAINABILITY but MEDIUM -> BLOCK"
 write_default_fake_curl "${HEAD_SHA}" "OK" 0 0 1 \
-    "$(issue_json '["convention"]' '[{"softwareQuality":"MAINTAINABILITY","severity":"MEDIUM"}]')"
+    "$(issue_json "${CONVENTION}" '[{"softwareQuality":"MAINTAINABILITY","severity":"MEDIUM"}]')"
 run_case "convention nit at MEDIUM" 1
 
 echo "3d. convention + LOW but RELIABILITY -> BLOCK"
 write_default_fake_curl "${HEAD_SHA}" "OK" 0 0 1 \
-    "$(issue_json '["convention"]' '[{"softwareQuality":"RELIABILITY","severity":"LOW"}]')"
+    "$(issue_json "${CONVENTION}" '[{"softwareQuality":"RELIABILITY","severity":"LOW"}]')"
 run_case "convention nit impacting reliability" 1
 
 echo "3e. MIXED impacts: maintainability/LOW *and* reliability/MEDIUM -> BLOCK"
@@ -183,12 +185,12 @@ echo "3e. MIXED impacts: maintainability/LOW *and* reliability/MEDIUM -> BLOCK"
 # exemption on one of its impacts and not on the other; one impact outside
 # the exemption is enough to block.
 write_default_fake_curl "${HEAD_SHA}" "OK" 0 0 1 \
-    "$(issue_json '["convention"]' '[{"softwareQuality":"MAINTAINABILITY","severity":"LOW"},{"softwareQuality":"RELIABILITY","severity":"MEDIUM"}]')"
+    "$(issue_json "${CONVENTION}" '[{"softwareQuality":"MAINTAINABILITY","severity":"LOW"},{"softwareQuality":"RELIABILITY","severity":"MEDIUM"}]')"
 run_case "mixed impacts, one outside the exemption" 1
 
 echo "3f. convention-tagged finding carrying NO impacts -> BLOCK"
 # Absence of evidence is not an exemption.
-write_default_fake_curl "${HEAD_SHA}" "OK" 0 0 1 "$(issue_json '["convention"]' '[]')"
+write_default_fake_curl "${HEAD_SHA}" "OK" 0 0 1 "$(issue_json "${CONVENTION}" '[]')"
 run_case "convention nit with no impacts declared" 1
 
 echo "3g. An exempt finding alongside a blocking one -> BLOCK"


### PR DESCRIPTION
The hardened gate refused the 1.0.41 release, reporting exactly what it was built to report:

```
Quality Gate: OK
Security findings: 0
Unresolved issues: 1766 (blocking: 23, exempt: 1743 convention nits)
ERROR: release blocked by the SonarQube Cloud gate. No long-running gate was started.
```

**607 → 23**, and the refusal cost seconds rather than the full 25-minute run.

## Three of these are findings my own fixes created

`javascript:S7776` asks for a `Set` once a fixed list is queried with `.includes()` — which is precisely what the earlier `indexOf` sweep turned those three constants into. `STOP_WORDS`, `ALLOWED_SCHEMES` and `NON_INPUT_TYPES` are now Sets queried with `.has()`. Worth naming: fixing one rule can hand you another, and the count only converges if you re-read it after each pass.

## Two are in the test file added for this gate

`issue_json()`'s positional parameters are named, and the `'["convention"]'` tag literal it repeated five times is a constant.

## One is a real inefficiency in the gate itself

`check-sonar-release.sh` percent-encoded the project key and the branch **at each of its six query sites** — twelve `php -r` subshells to encode two strings that are constant for the whole run. Encoded once now.

## The remaining 15 optional chains

These are the shapes the earlier sweep's pattern could not match. Eight are the exact shape that has already caused one regression on this branch (`!X || X.y !== v`), so each was checked the same way rather than assumed:

> the condition is true for a nullish object in **both** forms, so the body is entered either way — and every one of those bodies is an early return that never dereferences the guarded object.

Two more keep an explicit `=== true` rather than let `box?.checked` turn a boolean return into `boolean|undefined`.

## Verification

PHPStan clean · typecheck clean · 15051 PHPUnit tests · 1914 Vitest tests · `release.sh` self-tests green · `check-sonar-release.test.sh` 23/23.

One local end-to-end run hit `net::ERR_INVALID_HTTP_RESPONSE` on the first navigation of `rental-request.spec.js`. That spec passes 5/5 and 11/11 in isolation, CI has been green on it through #145, #146 and #148, and the failure predates this branch — it is the macOS `php -S` harness, not the application. Tracked separately rather than papered over with a retry budget, which `playwright.config.js` deliberately refuses to have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017et9MKZ7m8wmfqvsN9tbrF