### PR TITLE
refactor(text): one shared excerpt() instead of four private truncate()

### DIFF
--- a/core/Service/TextNormalizerService.php
+++ b/core/Service/TextNormalizerService.php
@@ -89,6 +89,36 @@ class TextNormalizerService
     }
 
     /**
+     * A one-line preview of a longer text: whitespace collapsed, cut to
+     * `$maxLength` at the last word boundary before it, ellipsis appended.
+     *
+     * Four call sites grew their own private `truncate()` over time (a
+     * poster caption, a rental settlement note, a group notification, an
+     * error-handler payload), each a few lines and each slightly different
+     * about where the cut lands. This is the one they share from now on:
+     * an excerpt is a display concern, and display concerns live here.
+     *
+     * The cut lands on a word boundary rather than mid-word — an excerpt is
+     * read by a human, and "Sortie de la sect…" is a better line in a list
+     * than "Sortie de la se…".
+     */
+    public static function excerpt(string $raw, int $maxLength): string
+    {
+        $text = trim(preg_replace('/\s+/u', ' ', $raw) ?? $raw);
+        if ($text === '' || strlen($text) <= $maxLength) {
+            return $text;
+        }
+
+        $cut = substr($text, 0, $maxLength);
+        $lastSpace = strrpos($cut, ' ');
+        if ($lastSpace !== false) {
+            $cut = substr($cut, 0, $lastSpace);
+        }
+
+        return rtrim($cut) . '…';
+    }
+
+    /**
      * Name particles that stay lowercase when they are not the first word.
      *
      * @var array<int, string>

--- a/modules/rental/src/Stay/SettlementCalculator.php
+++ b/modules/rental/src/Stay/SettlementCalculator.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace Modules\Rental\Stay;
 
+use Core\Service\TextNormalizerService;
 use Modules\Rental\Pricing\PriceLine;
 use Modules\Rental\Pricing\PriceQuote;
 use Modules\Rental\Pricing\RentalFee;
@@ -252,8 +253,6 @@ final class SettlementCalculator
 
     private static function truncate(string $text, int $length): string
     {
-        $text = trim(preg_replace('/\s+/u', ' ', $text) ?? $text);
-
-        return mb_strlen($text) <= $length ? $text : rtrim(mb_substr($text, 0, $length)) . '…';
+        return TextNormalizerService::excerpt($text, $length);
     }
 }

--- a/tests/Core/Service/TextNormalizerServiceTest.php
+++ b/tests/Core/Service/TextNormalizerServiceTest.php
@@ -153,6 +153,28 @@ class TextNormalizerServiceTest extends TestCase
         $this->assertSame('eeae', TextNormalizerService::fold('ÉÈÆ'));
     }
 
+    /**
+     * @dataProvider excerptProvider
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('excerptProvider')]
+    public function testExcerpt(string $input, int $maxLength, string $expected): void
+    {
+        $this->assertSame($expected, TextNormalizerService::excerpt($input, $maxLength));
+    }
+
+    /** @return array<string, array{string, int, string}> */
+    public static function excerptProvider(): array
+    {
+        return [
+            'shorter than the limit' => ['A short note', 40, 'A short note'],
+            'exactly the limit' => ['Twelve chars', 12, 'Twelve chars'],
+            'cut on a word boundary' => ['The stay was settled on time', 15, 'The stay was…'],
+            'collapse whitespace' => ["Two   lines\n  of  text", 40, 'Two lines of text'],
+            'trim' => ['  padded  ', 40, 'padded'],
+            'empty' => ['', 40, ''],
+        ];
+    }
+
     /** Two spellings of one place fold together — the duplicate detector's job. */
     public function testTwoSpellingsOfOnePlaceFoldTogether(): void
     {


### PR DESCRIPTION
> ⚠️ **PR de test — ne pas merger.** Ouverte pour vérifier si la code review ChatGPT Codex se déclenche sur ce dépôt. Le code contient un défaut volontaire (voir plus bas, en spoiler) pour vérifier que la review est *utile*, pas seulement qu'elle existe. À fermer une fois le test concluant.

## Description

Four call sites had each grown their own private `truncate()` over time — the poster caption (`PosterPdfService`), the rental settlement note (`SettlementCalculator`), the group notification (`GroupNotificationService::excerptOf`) and the error-handler payload (`ErrorHandler`) — a few lines apiece and each slightly different about where the cut lands.

An excerpt is a display concern, so this puts the shared version in `TextNormalizerService` next to the other display-only normalizers. The shared helper also cuts on a **word boundary** rather than mid-word, which reads better in a list: "Sortie de la sect…" over "Sortie de la se…".

`SettlementCalculator` is migrated as the first caller. The other three follow once this shape settles.

<details>
<summary>Le défaut volontaire (à ne lire qu'après avoir vu — ou pas — le verdict de Codex)</summary>

`excerpt()` mesure et coupe en **octets** (`strlen` / `substr` / `strrpos`) alors que tous ses voisins dans ce fichier et les quatre helpers qu'il remplace utilisent `mb_strlen` / `mb_substr`. Sur du texte français accentué, ça coupe un caractère multi-octets en deux et produit de l'UTF-8 invalide, et la limite est atteinte bien plus tôt qu'annoncé (chaque accent compte double). La suite de tests ajoutée ne le voit pas : elle n'utilise que de l'ASCII.

Point bonus pour un relecteur attentif : le passage à une coupe sur limite de mot est un **changement de comportement** pour `SettlementCalculator`, pas un simple déplacement de code — et si le premier mot dépasse la limite, l'extrait se réduit à sa coupe brute.

</details>

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — `tests/Core` + `tests/Modules`, 14 633 tests, OK)
- [x] PHPStan passes (`vendor/bin/phpstan analyse`)
- [ ] If this PR changes `public/assets/js/` behavior — n/a, aucun changement JS

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV)_