### PR TITLE
docs(agents): a steward skill for pull request events, and a CLAUDE.md pointer

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -93,7 +93,7 @@ does not:
 | CI job | Its distinguishing command |
 |---|---|
 | `test` | `vendor/bin/phpstan analyse --memory-limit=512M`, then `vendor/bin/phpunit --coverage-clover coverage.xml --log-junit phpunit-report.xml` |
-| `database-mariadb` | `vendor/bin/phpunit` (the session hook already exports `TEST_DB_*`) |
+| `database-mariadb` | `vendor/bin/phpunit` against a MariaDB 10.11 reachable through `TEST_DB_*` |
 | `javascript-tests` | `npm run typecheck`, then `npm run test:coverage` |
 | `End-to-end (browser)` | `E2E_COVERAGE=1 npm run e2e` |
 | `Authorization matrix` | `./scripts/dast.sh --profile=standard` |
@@ -121,6 +121,16 @@ cannot show you:
   before scanning anything. CI pulls `ghcr.io/zaproxy/zaproxy:stable` in a
   step of its own; do the same first, or you cannot tell a missing
   prerequisite from the failure you came to reproduce.
+
+**Before believing a green PHPUnit run, check the database was there.** The
+database-backed tests `markTestSkipped` when the server does not answer, so
+`vendor/bin/phpunit` reports green on a machine with no MariaDB — having
+skipped precisely the tests the `database-mariadb` job exists to run. In a
+Claude Code *remote* session the SessionStart hook has already started
+MariaDB and exported `TEST_DB_*`; in a local checkout that hook exits at its
+first line (`CLAUDE_CODE_REMOTE` is not `true`), and even remotely it can
+warn and carry on after a failed setup. Confirm the connection instead of
+assuming it — the run's skipped count is the cheapest tell.
 
 ### Four of these rows run on the wrong engine
 

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -15,9 +15,27 @@ have been read.
 `main` requires **conversation resolution before merging**. Every review
 thread must be resolved before the merge button unlocks, so an unanswered
 thread is not a loose end — it is a hard block. Resolving a thread is a
-claim that it was addressed: resolve the ones you fixed, and leave open,
-with a reply, the ones you are deliberately not fixing. Never resolve a
-thread to tidy the page.
+claim that it was addressed. Never resolve one to tidy the page.
+
+Which means resolution is also how an agent hands itself a merge. So:
+
+**Reply in the thread, then resolve it. Every time, including the trivial
+ones.** The reply says what changed and where — "`mb_substr` in
+`excerpt()`, plus an accented case in the test provider" — never a bare
+"fixed" or "done", which tells the maintainer nothing the resolution
+marker didn't. One factual line is the whole requirement; do not restate
+the finding back, and do not thank the reviewer.
+
+This is deliberate overhead, and here is what it buys: the only human on
+this repository is its maintainer, and the reviewer on the other side is a
+bot. Without that line, checking that a fix actually matches its finding
+means reading the diff by hand, on every thread. The line also outlives
+the code — it stays readable in the thread after the diff it describes has
+been rewritten.
+
+A thread you are **not** fixing gets the reply and stays **open**: say why
+in a sentence, and let the maintainer decide. Never resolve a finding you
+disagree with; disagreeing is not addressing.
 
 ## Review comments
 
@@ -106,8 +124,12 @@ gate, and even there an exempt finding is still a finding.
 
 ## What "done" means for a PR
 
-Green CI on the current head, no merge conflict, every review thread either
-resolved or answered, and the PR template's checklist honestly filled. A
-green PR with an open unanswered thread cannot merge, so it is not done.
+Green CI on the current head, no merge conflict, **no thread left without a
+reply**, and the PR template's checklist honestly filled. Threads you fixed
+are replied to and resolved; the ones still open are open on purpose, each
+carrying the sentence that says why, waiting on the maintainer.
+
+A green PR with a silent thread is not done — and a PR whose threads were
+all resolved without a word is worse, because it looks done.
 
 Do not merge. Merging is the maintainer's, always.

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -70,73 +70,84 @@ proposal.
 Identity only breaks a tie. When you cannot size a human reviewer's ask,
 treat it as the larger one.
 
-## A red check — which local command reproduces it
+## A red check — reproducing it locally
 
-Run the one that matches; do not run the whole battery for a lint failure.
+Each row gives the job's **distinguishing command**: what it runs that no
+other job does. That is a starting point, not a transcript. `ci.yml` is the
+only exact account of a job, and when the red step looks like setup rather
+than a test, go read it there before trusting anything below.
 
-| CI job | Reproduce locally with |
+Two things every row assumes, because CI does them and a warm container
+does not:
+
+- **Dependencies installed the way CI installs them** — every PHP job runs
+  `composer install --prefer-dist --no-progress` first, every Node job runs
+  `npm ci`, and the browser jobs also run `npm run e2e:install`. An
+  already-populated `vendor/` or `node_modules/` never exercises any of
+  that, so a manifest/lockfile drift or an unmet platform requirement fails
+  in CI and nowhere else. Run them when the failing step *is* the
+  installation, or when you touched a manifest or a lockfile.
+- **The engine CI hands the job**, which is not the one you have. See
+  below — it applies to four of these rows.
+
+| CI job | Its distinguishing command |
 |---|---|
-| `test` | `vendor/bin/phpstan analyse` then `vendor/bin/phpunit` |
+| `test` | `vendor/bin/phpstan analyse --memory-limit=512M`, then `vendor/bin/phpunit --coverage-clover coverage.xml --log-junit phpunit-report.xml` |
 | `database-mariadb` | `vendor/bin/phpunit` (the session hook already exports `TEST_DB_*`) |
-| `javascript-tests` | `npm ci`, `npm run typecheck`, `npm run test:coverage` |
+| `javascript-tests` | `npm run typecheck`, then `npm run test:coverage` |
 | `End-to-end (browser)` | `E2E_COVERAGE=1 npm run e2e` |
 | `Authorization matrix` | `./scripts/dast.sh --profile=standard` |
 | `Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
-| `security` | `composer install --prefer-dist --no-progress` then `composer audit` |
+| `security` | `composer audit` |
 | `SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
 
-Every row is the job's own commands. The install steps and the flags are
-not ceremony — each one is a failure the shorter command cannot show you:
+The flags are not decoration — each is a failure the shorter command
+cannot show you:
 
-- **`npm ci`** is the only step that fails on a `package.json` and
-  `package-lock.json` that have drifted apart; an already-installed
-  `node_modules/` never exercises it. **`npm run test:coverage`**, not
-  `npm test`, because collection is part of the job — it writes
-  `coverage/js/lcov.info` for `sonarqube`, and it can fail on its own with
-  every spec passing. `npm test` is for iterating, not for concluding.
-- **`composer install --prefer-dist --no-progress`** before `composer
-  audit`, because the job installs first and `composer audit` reports on
-  *installed* packages: a stale local `vendor/` audits a different package
-  set than CI does, and a manifest/lock drift or a platform requirement
-  fails in the install step you skipped. (This job runs no `npm audit` —
-  that one is a release gate, not a CI check.)
+- **`--coverage-clover` / `--log-junit`** on `test`, and
+  **`npm run test:coverage`** rather than `npm test`, because producing the
+  reports is part of the job: they are what `sonarqube` consumes, and
+  report generation can fail with every test passing.
 - **`E2E_COVERAGE=1`** because CI sets it and `scripts/e2e.sh` defaults it
-  off, and the difference is behavioural rather than cosmetic: coverage
-  makes every request slow enough to change timing. The comment at
-  `tests/e2e/specs/rental-management.spec.js` (the Calendrier click)
-  documents a failure that surfaced *only* under coverage. It needs pcov
-  or Xdebug loaded — this container already has pcov.
+  off, and the difference is behavioural: coverage slows every request
+  enough to change timing. The Calendrier comment in
+  `tests/e2e/specs/rental-management.spec.js` documents a failure that
+  surfaced *only* under it. Needs pcov or Xdebug — this container has pcov.
+- **`composer audit`** reports on *installed* packages, so a stale local
+  `vendor/` audits a different set than CI's freshly installed one. (This
+  job runs no `npm audit`; that one is a release gate, not a CI check.)
+- **`./scripts/dast.sh`** refuses to download a missing ZAP image and exits
+  before scanning anything. CI pulls `ghcr.io/zaproxy/zaproxy:stable` in a
+  step of its own; do the same first, or you cannot tell a missing
+  prerequisite from the failure you came to reproduce.
 
-### These three reproducers run on the wrong engine
+### Four of these rows run on the wrong engine
 
-`e2e-tests`, `authorization-matrix` and `dast-passive` each provision
-**MySQL 8** in CI and pass the job its own `E2E_DB_*` / `DAST_DB_*`
-variables. Locally both scripts fall back to `TEST_DB_*` when those are
-unset — which the session hook points at **MariaDB**. So the three commands
-above reproduce the *scenario* but not the *engine*, and a MySQL-only
-failure in any of them will sit there staying green.
+`test`, `e2e-tests`, `authorization-matrix` and `dast-passive` are each
+handed **MySQL 8** by CI, which passes the last three their own
+`E2E_DB_*` / `DAST_DB_*` variables. Locally all four fall back to
+`TEST_DB_*` — the **MariaDB 10.11** this container's session hook starts,
+and what production runs. So the commands above reproduce the *scenario*
+and not the *engine*, and a MySQL-only failure in any of those four jobs
+will sit there staying green.
 
-To actually reproduce one, point the job's own variables at a MySQL 8
-server before running — `E2E_DB_HOST`/`E2E_DB_PORT`/`E2E_DB_USER`/
-`E2E_DB_PASSWORD` for `npm run e2e`, the `DAST_DB_*` equivalents for
-`scripts/dast.sh`. Both scripts prefer those over `TEST_DB_*`, and both
-start a throwaway `mysql:8.0` container when no server answers at all.
+That is the mirror image of the danger `AGENTS.md` § Database describes for
+production, and it bites hardest exactly when you do not yet know what a
+red job means. So:
 
-### The engine trap, which runs the opposite way locally
+- **`test` red while `database-mariadb` is green** is an engine divergence
+  until proven otherwise, and `npm run test:engines` — which runs the suite
+  against both — is its reproducer, not plain `vendor/bin/phpunit`.
+- **For the browser and scanner jobs**, point the job's own variables at a
+  MySQL 8 server before running: `E2E_DB_HOST`/`E2E_DB_PORT`/`E2E_DB_USER`/
+  `E2E_DB_PASSWORD` for `npm run e2e`, the `DAST_DB_*` equivalents for
+  `scripts/dast.sh`. Both scripts prefer those over `TEST_DB_*`, and both
+  start a throwaway `mysql:8.0` container when nothing answers at all.
 
-`test` runs on **MySQL 8**. `database-mariadb` runs on **MariaDB 10.11**,
-which is what production runs — and it is also what this container's session
-hook starts. So a green local suite is a **MariaDB**-green suite, and the
-divergence you can miss here is a MySQL-only failure in the `test` job. That
-is the mirror image of the danger `AGENTS.md` § Database describes for
-production. `npm run test:engines` runs both; use it whenever a change
-touches schema introspection, column defaults, or type normalisation.
-
-`database-mariadb` red while `test` is green (or the reverse) is an engine
-divergence until proven otherwise. Do not paper over it with a test that
-accepts both outputs — `SchemaIntrospector` reads the server version for
-exactly this reason, and that is where the branch belongs.
+Do not paper over a divergence with a test that accepts both outputs —
+`SchemaIntrospector` reads the server version for exactly this reason, and
+that is where the branch belongs.
 
 ### Before you push a fix
 

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: steward
+description: How to handle a pull request event on this repository — a review comment (human or bot), a red CI job, a SonarCloud gate. Covers which local command reproduces which CI job, what to validate before pushing, and what to escalate to the author rather than fix. Read this before acting on any PR event; AGENTS.md and CONTRIBUTING.md remain the source of truth for the conventions themselves.
+---
+
+# Stewarding a pull request
+
+`AGENTS.md` says what the code must look like. `CONTRIBUTING.md` says how to
+submit it. This file says what to do when a PR **comes back at you** — a
+review comment, a red check, a quality gate — and it assumes both of those
+have been read.
+
+## The rule that outranks everything here
+
+`main` requires **conversation resolution before merging**. Every review
+thread must be resolved before the merge button unlocks, so an unanswered
+thread is not a loose end — it is a hard block. Resolving a thread is a
+claim that it was addressed: resolve the ones you fixed, and leave open,
+with a reply, the ones you are deliberately not fixing. Never resolve a
+thread to tidy the page.
+
+## Review comments
+
+**A bot finding is a bug report, not an opinion.** Codex
+(`chatgpt-codex-connector[bot]`) reviews every PR here and posts inline
+comments with a P-badge. Verify the finding against the code, then fix it.
+"It's stylistic" is a conclusion you reach after reading the code, never a
+reason to skip reading it.
+
+The failure mode this repo has already lived through is the opposite one:
+a finding that reads like a nit and is a real defect. Codex's first review
+on this repo caught `strlen`/`substr` used where every neighbour used
+`mb_strlen`/`mb_substr` — a one-word diff, and invalid UTF-8 in a
+user-facing French label. Judge the consequence, not the size of the patch.
+
+**Reply in the language of the thread.** Reviews arrive in English; the
+maintainer writes French. Match whoever you are answering.
+
+Fix and push: nits, renames, a missing test, a one-function correction,
+anything a bot found. Reply with a proposal instead of pushing, and let the
+author decide: multi-file refactors, a schema or `Api\` contract change,
+open-ended design feedback from a human. When you cannot tell which a human
+reviewer's ask is, treat it as the larger one.
+
+## A red check — which local command reproduces it
+
+Run the one that matches; do not run the whole battery for a lint failure.
+
+| CI job | Reproduce locally with |
+|---|---|
+| `test` | `vendor/bin/phpstan analyse` then `vendor/bin/phpunit` |
+| `database-mariadb` | `vendor/bin/phpunit` (the session hook already exports `TEST_DB_*`) |
+| `javascript-tests` | `npm run typecheck` then `npm test` |
+| `End-to-end (browser)` | `npm run e2e` |
+| `Authorization matrix` | `./scripts/dast.sh --profile=standard` |
+| `Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
+| `security` | `composer audit` (this job runs that alone — `npm audit` is a release gate, not a CI check) |
+| `SonarQube Cloud` | no local equivalent — read the bot's PR comment |
+| `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
+
+### The engine trap, which runs the opposite way locally
+
+`test` runs on **MySQL 8**. `database-mariadb` runs on **MariaDB 10.11**,
+which is what production runs — and it is also what this container's session
+hook starts. So a green local suite is a **MariaDB**-green suite, and the
+divergence you can miss here is a MySQL-only failure in the `test` job. That
+is the mirror image of the danger `AGENTS.md` § Database describes for
+production. `npm run test:engines` runs both; use it whenever a change
+touches schema introspection, column defaults, or type normalisation.
+
+`database-mariadb` red while `test` is green (or the reverse) is an engine
+divergence until proven otherwise. Do not paper over it with a test that
+accepts both outputs — `SchemaIntrospector` reads the server version for
+exactly this reason, and that is where the branch belongs.
+
+### Before you push a fix
+
+1. Reproduce the failure locally first. A fix you never saw fail is a guess.
+2. Run the checks matching the paths you touched — the same gating
+   `CONTRIBUTING.md` steps 4-8 describe.
+3. Re-read your own diff for what CI would reject.
+4. Keep it minimal. A CI fix does not widen the PR.
+
+A push that turns CI red costs a full cycle here: the confidence E2E tier
+alone is ~8 minutes, and `Dynamic scan (passive)` is slower still.
+
+## Things that are never the fix
+
+- Skipping, disabling, or `@full`-tagging a test to get green. A slow
+  scenario gets fixed; a flaky one gets fixed or deleted.
+- Adding your own new finding to `phpstan-baseline.neon` or
+  `js-typecheck-baseline.json`. Those accept *pre-existing* debt only.
+- An empty commit, or closing and reopening the PR, to re-trigger CI.
+- Bypassing a `scripts/release.sh` gate.
+- Force-pushing or rebasing a branch you did not create. Merge `main` into
+  the PR head to resolve a conflict; the merge commit keeps the author's
+  checkout valid.
+
+## SonarCloud on a PR
+
+The `sonarqubecloud[bot]` comment carries the PR's Quality Gate, and it must
+pass before merge. New issues it reports are this PR's to fix, whatever
+their severity — the `MAINTAINABILITY`/`LOW`/`convention` exemption in
+`AGENTS.md` § SonarQube Cloud release gate governs *releases*, not the PR
+gate, and even there an exempt finding is still a finding.
+
+## What "done" means for a PR
+
+Green CI on the current head, no merge conflict, every review thread either
+resolved or answered, and the PR template's checklist honestly filled. A
+green PR with an open unanswered thread cannot merge, so it is not done.
+
+Do not merge. Merging is the maintainer's, always.

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -79,21 +79,49 @@ Run the one that matches; do not run the whole battery for a lint failure.
 | `test` | `vendor/bin/phpstan analyse` then `vendor/bin/phpunit` |
 | `database-mariadb` | `vendor/bin/phpunit` (the session hook already exports `TEST_DB_*`) |
 | `javascript-tests` | `npm ci`, `npm run typecheck`, `npm run test:coverage` |
-| `End-to-end (browser)` | `npm run e2e` |
+| `End-to-end (browser)` | `E2E_COVERAGE=1 npm run e2e` |
 | `Authorization matrix` | `./scripts/dast.sh --profile=standard` |
 | `Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
-| `security` | `composer audit` (this job runs that alone — `npm audit` is a release gate, not a CI check) |
+| `security` | `composer install --prefer-dist --no-progress` then `composer audit` |
 | `SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
 
-The `javascript-tests` row is CI's own three steps, in order, and the two
-easy ones to drop both hide a real failure. `npm ci` is what fails on a
-`package.json` and `package-lock.json` that have drifted apart — an
-already-installed `node_modules/` never exercises that, so run it whenever
-you touched either file. `npm run test:coverage` rather than `npm test`
-because collection is part of the job: it is what writes
-`coverage/js/lcov.info` for the `sonarqube` job, and it can fail on its own
-with every spec passing. `npm test` is for iterating, not for concluding.
+Every row is the job's own commands. The install steps and the flags are
+not ceremony — each one is a failure the shorter command cannot show you:
+
+- **`npm ci`** is the only step that fails on a `package.json` and
+  `package-lock.json` that have drifted apart; an already-installed
+  `node_modules/` never exercises it. **`npm run test:coverage`**, not
+  `npm test`, because collection is part of the job — it writes
+  `coverage/js/lcov.info` for `sonarqube`, and it can fail on its own with
+  every spec passing. `npm test` is for iterating, not for concluding.
+- **`composer install --prefer-dist --no-progress`** before `composer
+  audit`, because the job installs first and `composer audit` reports on
+  *installed* packages: a stale local `vendor/` audits a different package
+  set than CI does, and a manifest/lock drift or a platform requirement
+  fails in the install step you skipped. (This job runs no `npm audit` —
+  that one is a release gate, not a CI check.)
+- **`E2E_COVERAGE=1`** because CI sets it and `scripts/e2e.sh` defaults it
+  off, and the difference is behavioural rather than cosmetic: coverage
+  makes every request slow enough to change timing. The comment at
+  `tests/e2e/specs/rental-management.spec.js` (the Calendrier click)
+  documents a failure that surfaced *only* under coverage. It needs pcov
+  or Xdebug loaded — this container already has pcov.
+
+### These three reproducers run on the wrong engine
+
+`e2e-tests`, `authorization-matrix` and `dast-passive` each provision
+**MySQL 8** in CI and pass the job its own `E2E_DB_*` / `DAST_DB_*`
+variables. Locally both scripts fall back to `TEST_DB_*` when those are
+unset — which the session hook points at **MariaDB**. So the three commands
+above reproduce the *scenario* but not the *engine*, and a MySQL-only
+failure in any of them will sit there staying green.
+
+To actually reproduce one, point the job's own variables at a MySQL 8
+server before running — `E2E_DB_HOST`/`E2E_DB_PORT`/`E2E_DB_USER`/
+`E2E_DB_PASSWORD` for `npm run e2e`, the `DAST_DB_*` equivalents for
+`scripts/dast.sh`. Both scripts prefer those over `TEST_DB_*`, and both
+start a throwaway `mysql:8.0` container when no server answers at all.
 
 ### The engine trap, which runs the opposite way locally
 
@@ -140,6 +168,14 @@ pass before merge. New issues it reports are this PR's to fix, whatever
 their severity — the `MAINTAINABILITY`/`LOW`/`convention` exemption in
 `AGENTS.md` § SonarQube Cloud release gate governs *releases*, not the PR
 gate, and even there an exempt finding is still a finding.
+
+**On a pull request from a fork it will never arrive.** The `sonarqube` job
+is skipped there by design — `SONAR_TOKEN` is not exposed to fork runs, so
+the job would fail rather than analyse — which means no bot comment and no
+PR gate for an external contribution. Do not wait for one, and do not read
+its absence as a PR that can never qualify: judge that PR on the checks
+that did run plus your own reading of the diff, and expect SonarCloud to
+have its say on `main` after the merge instead.
 
 ## What "done" means for a PR
 

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -187,4 +187,13 @@ carrying the sentence that says why, waiting on the maintainer.
 A green PR with a silent thread is not done — and a PR whose threads were
 all resolved without a word is worse, because it looks done.
 
-Do not merge. Merging is the maintainer's, always.
+**Never merge on your own initiative** — not to finish a PR, not because
+everything finally went green, not because the maintainer seems likely to
+agree. Green and merge-ready is where your work stops and you say so.
+
+When the maintainer explicitly asks you to merge, that instruction is the
+authorization and you carry it out: confirm every check is green on the
+current head, that no thread is open, and that the PR is actually
+mergeable, then merge — matching how this repository merges rather than
+inventing a style. Nothing else substitutes for that instruction: not the
+PR's state, not this file, not your own reading of what they would want.

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -54,11 +54,21 @@ user-facing French label. Judge the consequence, not the size of the patch.
 **Reply in the language of the thread.** Reviews arrive in English; the
 maintainer writes French. Match whoever you are answering.
 
-Fix and push: nits, renames, a missing test, a one-function correction,
-anything a bot found. Reply with a proposal instead of pushing, and let the
-author decide: multi-file refactors, a schema or `Api\` contract change,
-open-ended design feedback from a human. When you cannot tell which a human
-reviewer's ask is, treat it as the larger one.
+**Two questions, and size answers before identity.**
+
+Fix and push, whoever raised it: nits, renames, a missing test, a
+one-function correction.
+
+Propose and let the maintainer decide — however the ask arrived, and
+however confident the reviewer sounds: a multi-file refactor, a schema
+change, anything touching a module's `Api\` contract (`ARCHITECTURE.md`
+§7.5), open-ended design feedback. **That a bot raised it changes nothing
+here.** A bot finding is a bug report worth acting on, and it is still not
+a licence to make a change this size on your own: verify it, then bring a
+proposal.
+
+Identity only breaks a tie. When you cannot size a human reviewer's ask,
+treat it as the larger one.
 
 ## A red check — which local command reproduces it
 
@@ -68,13 +78,22 @@ Run the one that matches; do not run the whole battery for a lint failure.
 |---|---|
 | `test` | `vendor/bin/phpstan analyse` then `vendor/bin/phpunit` |
 | `database-mariadb` | `vendor/bin/phpunit` (the session hook already exports `TEST_DB_*`) |
-| `javascript-tests` | `npm run typecheck` then `npm test` |
+| `javascript-tests` | `npm ci`, `npm run typecheck`, `npm run test:coverage` |
 | `End-to-end (browser)` | `npm run e2e` |
 | `Authorization matrix` | `./scripts/dast.sh --profile=standard` |
 | `Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
 | `security` | `composer audit` (this job runs that alone — `npm audit` is a release gate, not a CI check) |
 | `SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
+
+The `javascript-tests` row is CI's own three steps, in order, and the two
+easy ones to drop both hide a real failure. `npm ci` is what fails on a
+`package.json` and `package-lock.json` that have drifted apart — an
+already-installed `node_modules/` never exercises that, so run it whenever
+you touched either file. `npm run test:coverage` rather than `npm test`
+because collection is part of the job: it is what writes
+`coverage/js/lcov.info` for the `sonarqube` job, and it can fail on its own
+with every spec passing. `npm test` is for iterating, not for concluding.
 
 ### The engine trap, which runs the opposite way locally
 

--- a/.gitignore
+++ b/.gitignore
@@ -71,11 +71,14 @@ release-*.zip
 
 # Claude Code: the SessionStart hook and the shared settings that register it
 # are versioned (they are what makes `composer install`, phpunit and phpstan
-# work in a Claude Code on the web session); everything else under .claude/,
-# including per-developer settings.local.json, stays local.
+# work in a Claude Code on the web session), and so are the skills under
+# .claude/skills/, which are project guidance every contributor's agent
+# should read rather than one developer's local preference; everything else
+# under .claude/, including per-developer settings.local.json, stays local.
 .claude/*
 !.claude/hooks/
 !.claude/settings.json
+!.claude/skills/
 .claude/settings.local.json
 
 # Dynamic security scan output (scripts/dast.sh) — the HTML report a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,10 @@ review comments, a red CI job, which local command reproduces which check.
 
 ## This container
 
-The `SessionStart` hook has already installed dependencies and started
-**MariaDB** with `TEST_DB_*` exported — so `vendor/bin/phpunit` runs against
-the production engine, while CI's `test` job runs MySQL 8. See the steward
-skill for what that asymmetry hides.
+In a Claude Code **remote** session, the `SessionStart` hook has already
+installed dependencies and started **MariaDB** with `TEST_DB_*` exported —
+so `vendor/bin/phpunit` runs against the production engine, while CI's
+`test` job runs MySQL 8. In a local checkout that hook exits immediately and
+you manage your own dependencies and database; the database-backed tests
+then *skip* rather than fail, so a green run there proves less than it
+looks. See the steward skill for both traps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# ScoutMagic — agent instructions
+
+The rules for this repository live in **[`AGENTS.md`](AGENTS.md)**, which
+applies to every contributor, human or AI. **Read it before making any
+change**, along with [`ARCHITECTURE.md`](ARCHITECTURE.md) (layering, the
+`Api\` module contract, the schema model) and [`SECURITY.md`](SECURITY.md).
+They are not summarised here — a summary would drift from them.
+
+[`CONTRIBUTING.md`](CONTRIBUTING.md) has the submission steps, including
+which checks to run for which kind of change.
+
+`.claude/skills/steward/SKILL.md` covers pull request events specifically:
+review comments, a red CI job, which local command reproduces which check.
+
+## The three that catch people out
+
+- **English code, French interface.** A French variable name or an English
+  UI label is a bug, never a detail.
+- **Tests are mandatory**, written alongside the code. A new PHP test
+  directory must be registered in `phpunit.xml` in the same change, or
+  nothing runs it.
+- **`vendor/bin/phpstan analyse` before every commit touching PHP**, and
+  `npm run typecheck` before every commit touching `public/assets/js/`.
+  Passing tests is a different guarantee. Never silence a finding of your
+  own by adding it to a baseline.
+
+## This container
+
+The `SessionStart` hook has already installed dependencies and started
+**MariaDB** with `TEST_DB_*` exported — so `vendor/bin/phpunit` runs against
+the production engine, while CI's `test` job runs MySQL 8. See the steward
+skill for what that asymmetry hides.


### PR DESCRIPTION
## Description

Codex now reviews every pull request on this repository, and `main` requires conversation resolution before merging. Neither of those says anything about what an agent should *do* when a review comment or a red check comes back — so this writes it down where an agent actually looks.

### `.claude/skills/steward/SKILL.md`

Scoped deliberately: PR events only. `AGENTS.md` and `CONTRIBUTING.md` stay the source of truth for the conventions themselves, and the file says so in its first paragraph rather than restating them.

- **A table mapping each CI job to the local command that reproduces it** — `Authorization matrix` → `./scripts/dast.sh --profile=standard`, `Dynamic scan (passive)` → `--profile=passive`, and so on. The two jobs with no local equivalent (SonarQube Cloud, CodeQL) are marked as such, so an agent cannot claim to have checked them locally.
- **The engine asymmetry, in the direction it actually runs in a session container.** `AGENTS.md` § Database warns that code correct on MySQL and wrong on MariaDB reaches production. Inside a Claude Code container the `SessionStart` hook starts MariaDB, so a green local suite is a *MariaDB*-green suite and the blind spot is the mirror image: a MySQL-only failure in the `test` job. `npm run test:engines` is named as the parade.
- **Thread closure.** Reply in the thread saying what changed and where, then resolve it — every time, including trivial ones, and never a bare "fixed". A thread not being fixed gets its reason and stays open for the maintainer. Rationale is written into the file: with resolution required before merge, an agent resolving silently is handing itself a merge, and the only human here is the maintainer while the reviewer on the other side is a bot.
- **What is never the fix**: baselining your own new finding, tagging a scenario `@full` to get a flaky test out of CI's way, an empty commit to re-trigger a run, force-pushing someone else's branch.
- **A bot finding is a bug report, not an opinion** — with this repository's own example: `strlen`/`substr` where every neighbour used `mb_strlen`/`mb_substr`, a one-word diff and invalid UTF-8 in a French label.

### `CLAUDE.md`

A pointer, not a summary — a summary of `AGENTS.md` would drift from it. It carries only the three rules newcomers trip on (English code / French interface, mandatory tests plus the `phpunit.xml` registration, PHPStan and `npm run typecheck` before committing) and a note on what the `SessionStart` hook has already provisioned.

### `.gitignore`

`.claude/*` was ignored except the hook and `settings.json`, on the stated grounds that everything else is per-developer. `!.claude/skills/` is added and the comment extended: a skill is project guidance every contributor's agent should read, not one developer's local preference. **This widens a deliberate policy — say the word and the content moves to `docs/` instead**, at the cost of losing automatic loading.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French — no user-facing text in this change
- [ ] Automated tests are written/updated for this change — **n/a**: documentation only, no behavior to test
- [x] Tests pass locally (`vendor/bin/phpunit tests/Architecture`, 105 tests, OK — the full suite was not re-run for a docs-only change)
- [x] PHPStan passes (`vendor/bin/phpstan analyse`)
- [ ] If this PR changes `public/assets/js/` behavior — **n/a**, no JS touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV)_