### PR TITLE
chore(review): switch the AI reviewer — an agnostic steward skill, and a CodeRabbit configuration

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -40,7 +40,7 @@ disagree with; disagreeing is not addressing.
 ## Review comments
 
 **A bot finding is a bug report, not an opinion.** An AI reviewer runs on
-every pull request here. *Which* one is a setting the maintainer can change
+every non-draft pull request here. *Which* one is a setting the maintainer can change
 in an afternoon, so read it off the PR — an author whose login ends in
 `[bot]`, posting inline comments — rather than off a vendor name written
 here, which is the kind of detail that goes stale without anyone noticing.

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -39,17 +39,26 @@ disagree with; disagreeing is not addressing.
 
 ## Review comments
 
-**A bot finding is a bug report, not an opinion.** Codex
-(`chatgpt-codex-connector[bot]`) reviews every PR here and posts inline
-comments with a P-badge. Verify the finding against the code, then fix it.
-"It's stylistic" is a conclusion you reach after reading the code, never a
-reason to skip reading it.
+**A bot finding is a bug report, not an opinion.** An AI reviewer runs on
+every pull request here. *Which* one is a setting the maintainer can change
+in an afternoon, so read it off the PR — an author whose login ends in
+`[bot]`, posting inline comments — rather than off a vendor name written
+here, which is the kind of detail that goes stale without anyone noticing.
+Verify what it reports against the code, then fix it. "It's stylistic" is a
+conclusion you reach after reading the code, never a reason to skip reading
+it.
 
-The failure mode this repo has already lived through is the opposite one:
-a finding that reads like a nit and is a real defect. Codex's first review
-on this repo caught `strlen`/`substr` used where every neighbour used
-`mb_strlen`/`mb_substr` — a one-word diff, and invalid UTF-8 in a
-user-facing French label. Judge the consequence, not the size of the patch.
+**Its severity label orders your work; it does not settle anything.**
+Whatever scale the current reviewer emits — P1/P2, high/low, a coloured
+badge — it is that model's guess at importance. Whether a finding is real,
+and what it would actually break, is yours to establish against the code.
+
+The failure mode this repo has already lived through is the opposite of a
+false alarm: a finding that reads like a nit and is a real defect. The
+first bot review on this repository caught `strlen`/`substr` used where
+every neighbour used `mb_strlen`/`mb_substr` — a one-word diff, and invalid
+UTF-8 in a user-facing French label. Judge the consequence, not the size of
+the patch.
 
 **Reply in the language of the thread.** Reviews arrive in English; the
 maintainer writes French. Match whoever you are answering.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -24,9 +24,12 @@ tone_instructions: >-
 reviews:
   profile: assertive
 
-  # A "request changes" review would block the merge button on top of the
-  # branch protection already in force. Findings arrive as comments; the
-  # maintainer decides what blocks.
+  # Left off deliberately. Enabling it lets CodeRabbit submit formal GitHub
+  # review events: it holds a "changes requested" until every thread is
+  # resolved, the checks pass and the newest commit has been reviewed, and
+  # only then submits an approval. That approval could satisfy a required
+  # review on `main`, which is not a decision a reviewer should make here.
+  # Off, findings arrive as comments and the maintainer decides what blocks.
   request_changes_workflow: false
 
   auto_review:
@@ -142,3 +145,17 @@ reviews:
         reproduction table describes. Changing a job's name, its commands,
         its database engine or its environment variables makes that table
         wrong — say so, naming the row that goes stale.
+
+knowledge_base:
+  code_guidelines:
+    # CodeRabbit reads AGENTS.md and CLAUDE.md on its own, and nothing else
+    # by default — so the three files this configuration's header calls the
+    # source of truth were invisible to the reviewer citing them. The
+    # path_instructions above point at `ARCHITECTURE.md 7.5` and
+    # `design.md section 7`; these patterns are what let it follow the
+    # reference instead of guessing at it.
+    filePatterns:
+      - "/ARCHITECTURE.md"
+      - "/SECURITY.md"
+      - "/design.md"
+      - "/CONTRIBUTING.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -148,12 +148,13 @@ reviews:
 
 knowledge_base:
   code_guidelines:
-    # CodeRabbit reads AGENTS.md and CLAUDE.md on its own, and nothing else
-    # by default — so the three files this configuration's header calls the
-    # source of truth were invisible to the reviewer citing them. The
+    # These four supplement CodeRabbit's built-in guideline patterns rather
+    # than replacing them: the defaults already cover AGENTS.md and
+    # CLAUDE.md among others, and none of the four below. Without these
+    # entries, files this configuration's own header calls the source of
+    # truth were invisible to the reviewer citing them — the
     # path_instructions above point at `ARCHITECTURE.md 7.5` and
-    # `design.md section 7`; these patterns are what let it follow the
-    # reference instead of guessing at it.
+    # `design.md section 7`, references it could not follow.
     filePatterns:
       - "/ARCHITECTURE.md"
       - "/SECURITY.md"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,138 @@
+# CodeRabbit — AI review configuration for this repository.
+#
+# The rules themselves live in AGENTS.md, ARCHITECTURE.md, SECURITY.md and
+# design.md. What follows points the reviewer at the ones a diff can violate
+# without any check noticing — it is not a second copy of them, and it must
+# not become one: a duplicated rule drifts from its original, and the
+# original wins.
+#
+# Schema: https://docs.coderabbit.ai/reference/yaml-template
+
+language: en-US
+
+# 250 characters is the documented ceiling for this field.
+tone_instructions: >-
+  Be direct and specific. Name the consequence a defect has, not the rule it
+  breaks. No praise, no preamble, no restating the diff. When you are unsure
+  a finding is real, say so rather than asserting it.
+
+reviews:
+  profile: assertive
+
+  # A "request changes" review would block the merge button on top of the
+  # branch protection already in force. Findings arrive as comments; the
+  # maintainer decides what blocks.
+  request_changes_workflow: false
+
+  auto_review:
+    enabled: true
+
+    # Review once, when the pull request opens — not again on every push.
+    # A PR that answers its own review can take five or six corrective
+    # pushes, and re-reviewing each one buys little while consuming the
+    # free tier's hourly budget. Ask for another pass explicitly with
+    # `@coderabbitai review`, or `@coderabbitai full review` to start over.
+    auto_incremental_review: false
+
+    drafts: false
+
+  path_filters:
+    # Generated or vendored: nothing here is written by hand, so a review
+    # comment on it has no author to reach.
+    - "!composer.lock"
+    - "!package-lock.json"
+    - "!public/assets/vendor/**"
+    # Accepted pre-existing debt, by construction. AGENTS.md § Static
+    # analysis governs what may enter these; a line-by-line review of the
+    # ledger itself is noise.
+    - "!phpstan-baseline.neon"
+    - "!js-typecheck-baseline.json"
+
+  path_instructions:
+    - path: "**/*.php"
+      instructions: >-
+        Identifiers, comments and docblocks are English. Layering is
+        Controller -> Service -> Repository: no SQL in a Controller, no
+        business logic in a Controller or a View, no $_SESSION/$_POST access
+        in a Service. Every SQL statement is prepared; concatenating a value
+        into SQL is a defect regardless of where the value came from.
+        Personal and banking data live in BLOB columns encrypted through
+        EncryptionService, decrypted only in the Repository layer, and never
+        appear in a log line, an exception message or the journal.
+        Flag any string that can reach a visitor unless its exception class
+        implements Core\Exception\UserFacingException; everything else is
+        wrapped through UserFacingMessage::from() with a French fallback.
+
+    - path: "modules/**/*.php"
+      instructions: >-
+        A module is reachable from outside only through its Api\ namespace
+        (ARCHITECTURE.md 7.5). Importing another module's Service\,
+        Repository\ or Task\ class is a build failure with no exceptions, so
+        report it as one. Cross-module capabilities are nullable Api\
+        constructor dependencies that degrade gracefully when the other
+        module is absent or disabled — a hard dependency is a defect even
+        when it currently works.
+
+    - path: "**/module.json"
+      instructions: >-
+        Every route declares role_min. Every route carrying a label declares
+        menu_group. Every cookie the module sets is declared with category,
+        French purpose and duration; every automatic e-mail is declared with
+        a French description of when it goes out. Every setting has a
+        non-null description.
+
+    - path: "**/*.html.twig"
+      instructions: >-
+        All text a user sees is French — an English label is a defect, not a
+        detail. Every form carries a CSRF token. Rich text is sanitised
+        before storage, not at render time. File links go through the
+        file_url() helper rather than a raw path. Check the UI conventions
+        in design.md section 7 (lexicon, back navigation, button variants,
+        empty states) before suggesting a change to structure.
+
+    - path: "public/assets/js/**/*.js"
+      instructions: >-
+        Plain browser JavaScript, loaded by a classic script tag: no import
+        of a bundler, transpiler or framework, and no new runtime
+        dependency. Scrutinise every value reaching src, href, action,
+        formaction, srcdoc, innerHTML, outerHTML, insertAdjacentHTML,
+        location, window.open, eval, or setTimeout/setInterval with a
+        string. A value is not safe for having come from the page's own
+        template — a template renders user-controlled content. Validate at
+        the sink, never at the call sites.
+
+    - path: "**/*.sql"
+      instructions: >-
+        schema.sql is the complete current state, never an incremental
+        migration. Table and column names are English snake_case. Member
+        data carries scout_year_id unless it genuinely is not year-scoped.
+        Personal data columns are BLOB, with a blind index alongside any
+        encrypted field needing exact-match search. A module table must
+        never carry a foreign key into another module's table. Changing an
+        existing index's columns is silently a no-op on installed sites —
+        indexes are matched by name only, so a redefinition needs a new
+        name.
+
+    - path: "tests/**"
+      instructions: >-
+        A new test directory must be registered as a testsuite in
+        phpunit.xml in the same change, or nothing runs it. A bug fix
+        carries a test that reproduces the bug. A new route carries an
+        integration test proving the RBAC boundary: allowed at role_min,
+        denied one level below. Database-backed tests skip rather than fail
+        when no server answers, so a test that can silently skip its whole
+        point is worth flagging.
+
+    - path: ".github/workflows/**"
+      instructions: >-
+        This workflow is the specification that .claude/skills/steward's
+        reproduction table describes. Changing a job's name, its commands,
+        its database engine or its environment variables makes that table
+        wrong — say so, naming the row that goes stale.
+
+tools:
+  # PHPStan is a blocking CI gate here, run with phpstan.neon and the
+  # accepted debt in phpstan-baseline.neon. A second run that does not read
+  # that baseline would report long-accepted findings as new on every PR.
+  phpstan:
+    enabled: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,3 +1,5 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
 # CodeRabbit — AI review configuration for this repository.
 #
 # The rules themselves live in AGENTS.md, ARCHITECTURE.md, SECURITY.md and
@@ -6,7 +8,10 @@
 # not become one: a duplicated rule drifts from its original, and the
 # original wins.
 #
-# Schema: https://docs.coderabbit.ai/reference/yaml-template
+# The schema line above is load-bearing, not decoration: an editor with the
+# YAML language server validates against it, and a key CodeRabbit does not
+# recognise is otherwise ignored in silence — `tools` sat at the root here
+# for one commit, doing nothing, until a review said so.
 
 language: en-US
 
@@ -47,6 +52,14 @@ reviews:
     # ledger itself is noise.
     - "!phpstan-baseline.neon"
     - "!js-typecheck-baseline.json"
+
+  tools:
+    # PHPStan is a blocking CI gate here, run with phpstan.neon and the
+    # accepted debt in phpstan-baseline.neon. A second run that does not
+    # read that baseline would report long-accepted findings as new on
+    # every PR.
+    phpstan:
+      enabled: false
 
   path_instructions:
     - path: "**/*.php"
@@ -129,10 +142,3 @@ reviews:
         reproduction table describes. Changing a job's name, its commands,
         its database engine or its environment variables makes that table
         wrong — say so, naming the row that goes stale.
-
-tools:
-  # PHPStan is a blocking CI gate here, run with phpstan.neon and the
-  # accepted debt in phpstan-baseline.neon. A second run that does not read
-  # that baseline would report long-accepted findings as new on every PR.
-  phpstan:
-    enabled: false


### PR DESCRIPTION
## Description

Two halves of the same move: this repository is switching AI reviewer, so stop naming the old one and configure the new one.

### `.claude/skills/steward/SKILL.md` — name the role, not the vendor

The file hardcoded Codex and `chatgpt-codex-connector[bot]` as *the* reviewer. Which reviewer runs here is a setting, and a vendor name in a skill file goes stale silently — leaving an agent looking for a bot that no longer comments.

It now says **how to identify the reviewer** rather than **who it is**: an author whose login ends in `[bot]`, posting inline comments on the pull request at hand. It also adds the rule the switch makes load-bearing:

> **Its severity label orders your work; it does not settle anything.** Whatever scale the current reviewer emits — P1/P2, high/low, a coloured badge — it is that model's guess at importance. Whether a finding is real, and what it would actually break, is yours to establish against the code.

Two reviewers do not grade the same way, and the previous wording ("posts inline comments with a P-badge") quietly assumed one scale. The repository's own `mb_substr` example stays — it happened — but attributed to "the first bot review on this repository" rather than to a product. `sonarqubecloud[bot]` is deliberately left named: SonarCloud is a specific CI tool, not the swappable reviewer slot.

### `.coderabbit.yaml` — a reviewer that knows this repository

An unconfigured AI reviewer reviews generic PHP. This points it at the rules a diff can break here without any check noticing, per path:

| Path | What it is told to watch |
|---|---|
| `**/*.php` | English identifiers, the Controller → Service → Repository layering, prepared statements, `BLOB` + `EncryptionService` for personal and banking data, the `UserFacingException` marker |
| `modules/**/*.php` | The `Api\` boundary (ARCHITECTURE.md §7.5) — reported as the build failure it is |
| `**/module.json` | `role_min`, `menu_group`, declared cookies and e-mails, non-null setting descriptions |
| `**/*.html.twig` | French UI text, CSRF, sanitised rich text, `file_url()`, design.md §7 |
| `public/assets/js/**/*.js` | No build step, and every DOM sink CodeQL found a live XSS in — including that a value is not safe for having come from the page's own template |
| `**/*.sql` | Complete-state schema, `scout_year_id`, no cross-module foreign key, and the index-rename trap |
| `tests/**` | `phpunit.xml` registration, RBAC boundary tests, and tests that can silently skip their whole point |
| `.github/workflows/**` | That it is the specification the steward skill's reproduction table describes — changing a job makes a row stale |

**It points rather than copies.** `AGENTS.md`, `ARCHITECTURE.md`, `SECURITY.md` and `design.md` stay the source of truth, and the file's header says so: a duplicated rule drifts from its original, and the original wins.

Three settings worth their comment in the file:

- **`auto_incremental_review: false`** — review once, on open. PR #151 took seven corrective pushes and burned eleven reviews of the previous provider's quota in an hour; re-reviewing each push buys little and would hit the free tier's 4-reviews-per-hour limit. `@coderabbitai review` asks for a pass when one is wanted.
- **`request_changes_workflow: false`** — `main` already requires conversation resolution. Findings arrive as comments; the maintainer decides what blocks.
- **`tools.phpstan.enabled: false`** — PHPStan is already a blocking CI gate here, run with `phpstan-baseline.neon`. A second run that does not read that baseline would report years of accepted debt as new findings on every PR. The two baselines and the lockfiles are filtered out of review for the same reason: nothing there has an author a comment could reach.

Two judgement calls flagged for you rather than buried: `language: en-US` follows AGENTS.md's English rule and suits a public repository, though `fr-FR` is a one-line change if you would rather read reviews in French; and `profile: assertive` matches how the ten findings on #151 were handled, but `chill` is the calmer setting if it proves noisy.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French — no user-facing text in this change
- [ ] Automated tests are written/updated for this change — **n/a**: documentation and third-party tool configuration, no behavior to test
- [x] Tests pass locally — no application code touched; the YAML was parsed and its `tone_instructions` verified against the documented 250-character ceiling
- [x] PHPStan passes (`vendor/bin/phpstan analyse`)
- [ ] If this PR changes `public/assets/js/` behavior — **n/a**, no JS touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Added configurable automated code review settings, including English-language guidance, targeted file filters, and path-specific review instructions.
  - Configured non-blocking change requests and automatic reviews for eligible pull requests.
  - Disabled PHPStan analysis within automated review checks.

- **Documentation**
  - Updated review guidance to separate severity labels from the assessed correctness and impact of findings.
  - Clarified how the configured AI reviewer is identified and evaluated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->