### PR TITLE
ci(review): a second reviewer that nobody has to remember to ask for

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -108,6 +108,7 @@ does not:
 | `Authorization matrix` | `./scripts/dast.sh --profile=standard` |
 | `Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
 | `security` | `composer audit` |
+| `Claude review` | no local equivalent — read the findings on the PR; see below |
 | `SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
 
@@ -130,6 +131,14 @@ cannot show you:
   before scanning anything. CI pulls `ghcr.io/zaproxy/zaproxy:stable` in a
   step of its own; do the same first, or you cannot tell a missing
   prerequisite from the failure you came to reproduce.
+
+**A green `Claude review` does not always mean a review happened.** The
+action refuses to run when `.github/workflows/claude-review.yml` differs
+from the copy on `main` — sound, since a pull request could otherwise
+rewrite the reviewer and use its token — but it then exits *success*. So on
+a pull request that edits that file, the check goes green in about fifteen
+seconds having reviewed nothing. The run's duration is the tell, and the
+job log says so in as many words. Everywhere else, green means reviewed.
 
 **Before believing a green PHPUnit run, check the database was there.** The
 database-backed tests `markTestSkipped` when the server does not answer, so

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-* @xavierdubois
-ARCHITECTURE.md @xavierdubois
-SECURITY.md @xavierdubois
-AGENTS.md @xavierdubois
+* @xdubois-57
+ARCHITECTURE.md @xdubois-57
+SECURITY.md @xdubois-57
+AGENTS.md @xdubois-57

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -98,13 +98,27 @@ jobs:
       # a green check here proves a review ran only when this file is
       # untouched, and the first run after any change to it is a skip.
       #
-      # What closes it is .github/CODEOWNERS plus "require review from code
-      # owners" on main: a human has to approve a change to this file. Both
-      # halves have to actually hold — CODEOWNERS named a user who was not
-      # a collaborator until the commit that added this note, and GitHub
-      # ignores such an entry silently, so the rule matched nothing. If
-      # either half is relaxed or misspelled again, this gap reopens with
-      # no error anywhere.
+      # What would close it is .github/CODEOWNERS plus "require review from
+      # code owners" on main: a human approving any change to this file.
+      # Both halves have to actually hold, and CODEOWNERS named a user who
+      # was not a collaborator until the commit that added this note —
+      # GitHub ignores such an entry in silence, so the rule matched
+      # nothing at all.
+      #
+      # THE SECOND HALF IS NOT ENABLED, and cannot be while this repository
+      # has one collaborator. GitHub forbids approving your own pull
+      # request, so a sole maintainer who is also the sole code owner could
+      # never satisfy the rule: every pull request would be permanently
+      # unmergeable. Adding yourself to the ruleset's bypass list would
+      # restore merging and protect against nobody.
+      #
+      # So the gap is open, and its saving grace is that it currently has
+      # no attacker: opening a pull request here requires write access, and
+      # exactly one account has it. Enable the rule the day a second person
+      # gets write access — that is when a code owner distinct from the
+      # author exists, and when the gap acquires someone who could use it.
+      # Until then the tell is the clock: a green `Claude review` that took
+      # about fifteen seconds reviewed nothing.
       - uses: anthropics/claude-code-action@d9a44dc489924665d246f0fd0508d102211be397 # v1
         with:
           # Authenticates against the maintainer's Claude subscription

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -71,6 +71,22 @@ jobs:
           # Full history: the review reads the branch against its base.
           fetch-depth: 0
 
+      # KNOWN GAP, verified on this workflow's own pull request. The action
+      # refuses to run when this file differs from the copy on the default
+      # branch — a sound precaution, since otherwise a pull request could
+      # rewrite the reviewer and do as it liked with the token. But it exits
+      # `success`, not `neutral` or failure.
+      #
+      # As a REQUIRED check that inverts the guarantee in one case: a pull
+      # request that edits this file gets a green `Claude review` without any
+      # review having happened — and that is the pull request you would most
+      # want read. Two consequences worth knowing rather than rediscovering:
+      # a green check here proves a review ran only when this file is
+      # untouched, and the first run after any change to it is a skip.
+      #
+      # What closes it is .github/CODEOWNERS plus "require review from code
+      # owners" on main: a human has to approve a change to this file. If
+      # that rule is ever relaxed, this gap reopens.
       - uses: anthropics/claude-code-action@v1
         with:
           # Authenticates against the maintainer's Claude subscription

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -12,6 +12,11 @@
 
 name: Claude review
 
+# Deny by default at the workflow level; the one job below grants itself
+# exactly what it needs. Without this, a job that ever forgets its own
+# `permissions:` block silently inherits the repository default.
+permissions: {}
+
 on:
   pull_request:
     # `opened` catches a pull request created ready for review;
@@ -66,10 +71,19 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v6
+      # Both actions are pinned to a commit rather than a tag, the
+      # convention ci.yml already uses for setup-php, setup-node and the
+      # SonarQube scanner. A tag moves; this job holds a Claude
+      # subscription token and `id-token: write`, so code arriving through
+      # a moved tag would run with both.
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           # Full history: the review reads the branch against its base.
           fetch-depth: 0
+          # The review only reads. Leaving the checkout credential in
+          # .git/config would hand it to every later step and into any
+          # artifact built from the workspace.
+          persist-credentials: false
 
       # KNOWN GAP, verified on this workflow's own pull request. The action
       # refuses to run when this file differs from the copy on the default
@@ -87,7 +101,7 @@ jobs:
       # What closes it is .github/CODEOWNERS plus "require review from code
       # owners" on main: a human has to approve a change to this file. If
       # that rule is ever relaxed, this gap reopens.
-      - uses: anthropics/claude-code-action@v1
+      - uses: anthropics/claude-code-action@d9a44dc489924665d246f0fd0508d102211be397 # v1
         with:
           # Authenticates against the maintainer's Claude subscription
           # rather than a metered API key. Generated with `claude

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,85 @@
+# Second-opinion review by Claude on every pull request, alongside the
+# CodeRabbit review that runs from .coderabbit.yaml.
+#
+# Nobody has to remember to ask for it: GitHub runs this on the pull_request
+# event, so it happens whether or not anyone thinks of it. That is the whole
+# point — a reviewer you have to summon is a reviewer you forget to summon
+# on the pull request that needed it.
+#
+# Each run spends the Claude subscription behind CLAUDE_CODE_OAUTH_TOKEN.
+
+name: Claude review
+
+on:
+  pull_request:
+    # `opened` catches a pull request created ready for review;
+    # `ready_for_review` catches one that started as a draft; `reopened`
+    # catches one brought back. `labeled` is not an automatic trigger — it
+    # is the manual lever below, for asking again.
+    #
+    # `synchronize` is deliberately absent: it would run a fresh review on
+    # every push, which is the setting we turned off for CodeRabbit in
+    # .coderabbit.yaml for the same reason. Add it here only if you want a
+    # review per push and are willing to pay for it.
+    types: [opened, ready_for_review, reopened, labeled]
+
+# A second trigger while a run is in flight replaces it rather than paying
+# for both.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: Claude review
+    # Two guards, and the second is what keeps `labeled` from turning every
+    # label into a review: on a label event, only `claude-review` qualifies.
+    # Adding that label to an already-reviewed pull request is how you ask
+    # for a fresh pass without pushing.
+    #
+    # Drafts are skipped — the diff is still moving, and CodeRabbit skips
+    # them too. `ready_for_review` picks the pull request up the moment it
+    # stops being one.
+    if: >-
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' || github.event.label.name == 'claude-review')
+    runs-on: ubuntu-latest
+
+    # A runaway run costs subscription usage for nothing. The review itself
+    # takes a few minutes; this is a ceiling, not a target.
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      # Required by the action's default GitHub App authentication — it is
+      # what lets it post inline comments without a token of its own.
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Full history: the review reads the branch against its base.
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          # Authenticates against the maintainer's Claude subscription
+          # rather than a metered API key. Generated with `claude
+          # setup-token` and stored as a repository secret.
+          #
+          # GitHub withholds secrets from runs triggered by a pull request
+          # from a fork, so this job cannot review an outside contribution
+          # — the same hole SonarCloud has here, and it is recorded in
+          # .claude/skills/steward/SKILL.md.
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+          prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          # --comment is what puts the findings on the pull request; without
+          # it they are written to the run log and nobody reads them. The
+          # --allowedTools line is not redundant with the skill's own
+          # frontmatter: the action starts the inline-comment MCP server
+          # only when claude_args names that tool.
+          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -99,8 +99,12 @@ jobs:
       # untouched, and the first run after any change to it is a skip.
       #
       # What closes it is .github/CODEOWNERS plus "require review from code
-      # owners" on main: a human has to approve a change to this file. If
-      # that rule is ever relaxed, this gap reopens.
+      # owners" on main: a human has to approve a change to this file. Both
+      # halves have to actually hold — CODEOWNERS named a user who was not
+      # a collaborator until the commit that added this note, and GitHub
+      # ignores such an entry silently, so the rule matched nothing. If
+      # either half is relaxed or misspelled again, this gap reopens with
+      # no error anywhere.
       - uses: anthropics/claude-code-action@d9a44dc489924665d246f0fd0508d102211be397 # v1
         with:
           # Authenticates against the maintainer's Claude subscription

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,12 +1,14 @@
-# Second-opinion review by Claude on every pull request, alongside the
-# CodeRabbit review that runs from .coderabbit.yaml.
+# Second-opinion review by Claude on every pull request and every push to
+# one, alongside the CodeRabbit review that runs from .coderabbit.yaml.
 #
 # Nobody has to remember to ask for it: GitHub runs this on the pull_request
 # event, so it happens whether or not anyone thinks of it. That is the whole
 # point — a reviewer you have to summon is a reviewer you forget to summon
 # on the pull request that needed it.
 #
-# Each run spends the Claude subscription behind CLAUDE_CODE_OAUTH_TOKEN.
+# Each run spends the Claude subscription behind CLAUDE_CODE_OAUTH_TOKEN,
+# and `synchronize` below means one run per push rather than one per pull
+# request. That is the deliberate price of a review that is never stale.
 
 name: Claude review
 
@@ -14,17 +16,23 @@ on:
   pull_request:
     # `opened` catches a pull request created ready for review;
     # `ready_for_review` catches one that started as a draft; `reopened`
-    # catches one brought back. `labeled` is not an automatic trigger — it
-    # is the manual lever below, for asking again.
+    # catches one brought back; `synchronize` catches every push to an open
+    # one. `labeled` is not an automatic trigger — it is the manual lever
+    # below, for asking again without pushing.
     #
-    # `synchronize` is deliberately absent: it would run a fresh review on
-    # every push, which is the setting we turned off for CodeRabbit in
-    # .coderabbit.yaml for the same reason. Add it here only if you want a
-    # review per push and are willing to pay for it.
-    types: [opened, ready_for_review, reopened, labeled]
+    # `synchronize` is what makes the review current rather than a snapshot
+    # of the pull request's first commit: a diff reviewed at open and then
+    # pushed to five times is a diff nobody read. It differs from the
+    # CodeRabbit side on purpose — that one reviews once, because it is the
+    # permanent reviewer and its free tier has an hourly ceiling; this one
+    # is the gate, and a gate that checks a stale diff is not a gate.
+    types: [opened, ready_for_review, reopened, labeled, synchronize]
 
 # A second trigger while a run is in flight replaces it rather than paying
-# for both.
+# for both — which matters more with `synchronize`: pushing three commits in
+# a minute pays for one review of the last state, not three of intermediate
+# ones. The cancelled run belongs to the superseded commit, so it never
+# leaves a red check on the commit that matters.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -73,6 +81,13 @@ jobs:
           # from a fork, so this job cannot review an outside contribution
           # — the same hole SonarCloud has here, and it is recorded in
           # .claude/skills/steward/SKILL.md.
+          #
+          # This check is REQUIRED on main, which turns that hole into a
+          # hard consequence: a pull request from a fork cannot merge,
+          # because the check it needs can never report. Accepted
+          # deliberately — there are no forks today, and an unreviewed
+          # merge is the worse failure. Reopening the repository to outside
+          # contributions means revisiting it.
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"


### PR DESCRIPTION
## Description

CodeRabbit reviews every pull request here and costs nothing on a public repository. This adds Claude alongside it, through `anthropics/claude-code-action`, as a **required gate** rather than a second opinion.

It is a workflow rather than a habit on purpose: **a reviewer you have to summon is one you forget to summon on the pull request that needed it.** GitHub runs this on the `pull_request` event, so it happens whether or not anyone thinks of it — the same reasoning as the branch protection already in force on `main`.

### What it does

| | |
|---|---|
| **Runs on** | `opened`, `ready_for_review`, `reopened`, **`synchronize`** — every non-draft pull request, and every push to one |
| **Authentication** | `CLAUDE_CODE_OAUTH_TOKEN`, which spends the maintainer's existing Claude subscription rather than a metered API key |
| **Cost** | Subscription usage per push, plus GitHub Actions minutes — free on a public repository |
| **Manual re-request** | Add the `claude-review` label to ask for a fresh pass without pushing a commit |
| **Guards** | `concurrency` with `cancel-in-progress`, so three commits in a minute pay for one review of the last state; `timeout-minutes: 20` as a ceiling on a runaway run |

**`synchronize` is what makes the review current rather than a snapshot of the pull request's first commit**: a diff reviewed at open and then pushed to five times is a diff nobody read. This deliberately differs from the CodeRabbit side, which reviews once — that one is the permanent reviewer and its free tier has an hourly ceiling; this one is the gate, and a gate that checks a stale diff is not a gate.

Drafts are skipped, matching `drafts: false` on the CodeRabbit side. `ready_for_review` picks the pull request up the moment it stops being one.

### The setting that is not in this file

`Claude review` is to become a **required status check** on `main`. That is what turns this from a reviewer into a guarantee: a pull request cannot merge unless the check has passed, so a failed run — expired token, quota, a network blip — blocks the merge instead of passing unnoticed.

**The price, stated plainly.** GitHub withholds secrets from runs triggered by a pull request from a fork, so this job structurally cannot run on one. Made required, that means **a pull request from a fork can never merge**, because the check it needs can never report. On a public AGPL repository that accepts contributions, that is a real door being closed — there are no forks today, and the maintainer has weighed an unreviewed merge as the worse failure. The trade is recorded in the workflow next to the token, with a note that reopening to outside contributions means revisiting it.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist — the token is a repository secret, never in source; the job takes read-only repository permissions
- [x] All code and comments are in English
- [x] All UI-facing text is in French — no user-facing text in this change
- [ ] Automated tests are written/updated for this change — **n/a**: a CI workflow, exercised by running it
- [x] Tests pass locally — no application code touched; the workflow YAML was parsed and its triggers and job guard verified
- [x] PHPStan passes (`vendor/bin/phpstan analyse`)
- [ ] If this PR changes `public/assets/js/` behavior — **n/a**, no JS touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated Claude reviews for pull requests across key lifecycle events, with inline feedback and safeguards against duplicate reviews.
  - Reviews use restricted permissions and skip draft or unrelated activity.

- **Documentation**
  - Documented how to interpret skipped Claude reviews and identify them through workflow results and logs.

- **Chores**
  - Updated repository code ownership assignments to reflect current maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->