### PR TITLE
ci(review): say what a green Claude review actually means

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -109,6 +109,7 @@ does not:
 | `Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
 | `security` | `composer audit` |
 | `Claude review` | no local equivalent — read the findings on the PR; see below |
+| `Claude review status` | no local equivalent — it posts the comment that says what the green above means |
 | `SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
 
@@ -137,8 +138,14 @@ action refuses to run when `.github/workflows/claude-review.yml` differs
 from the copy on `main` — sound, since a pull request could otherwise
 rewrite the reviewer and use its token — but it then exits *success*. So on
 a pull request that edits that file, the check goes green in about fifteen
-seconds having reviewed nothing. The run's duration is the tell, and the
-job log says so in as many words. Everywhere else, green means reviewed.
+seconds having reviewed nothing.
+
+You no longer have to open the run to find that out: the `Claude review
+status` job posts one comment on the pull request, rewritten on every run,
+saying which of the three happened — reviewed, skipped without reviewing,
+or did not complete. It decides from the review job's duration, since a
+skip and a clean review are both `success` and only the clock separates
+them. Read that comment; it is the answer the check alone cannot give.
 
 **Before believing a green PHPUnit run, check the database was there.** The
 database-backed tests `markTestSkipped` when the server does not answer, so

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -146,3 +146,96 @@ jobs:
           # frontmatter: the action starts the inline-comment MCP server
           # only when claude_args names that tool.
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+
+  # WHY THIS JOB EXISTS. The review above posts inline comments when it finds
+  # something and stays silent when it does not — so a green `Claude review`
+  # with no comments is ambiguous between "read the diff, found nothing" and
+  # "declined to read the diff", which is exactly the gap documented at
+  # length on the job above. Silence read as approval is the failure mode
+  # docs/quality-pipeline.md exists to record.
+  #
+  # The code-review skill would say so itself: given `--comment` and no
+  # findings it posts "No issues found" through `gh pr comment`. That needs
+  # `pull-requests: write`, and the review job deliberately does not have it.
+  # Granting it there would be worse than the silence: the same skill stops
+  # early when "Claude has already commented on this PR", so its own summary
+  # comment would suppress the review of every later push — undoing the
+  # per-push guarantee `synchronize` was added for. This job is therefore a
+  # separate one, so the write permission never reaches the step that runs
+  # Claude, and its comment is authored by the workflow rather than by
+  # Claude, so it cannot trip that rule.
+  #
+  # The duration is the load-bearing part. A workflow-mismatch skip exits
+  # `success` in about fifteen seconds; a real review takes minutes. Reading
+  # the clock is what turns "green" into a statement about whether anything
+  # was read, without anyone opening the run log.
+  status:
+    name: Claude review status
+    needs: review
+    # `always()` so a failed or cancelled review still says so rather than
+    # leaving the previous run's comment standing. A draft pull request
+    # skips the review job, and this one goes with it.
+    if: always() && needs.review.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Post or update the review status comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          REVIEW_RESULT: ${{ needs.review.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          # The marker identifies this workflow's own comment so each run
+          # rewrites it instead of adding another. It is invisible in the
+          # rendered comment.
+          MARKER: "<!-- claude-review-status -->"
+        run: |
+          set -euo pipefail
+
+          # One run, at most two jobs — no pagination needed.
+          jobs_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs")"
+          started="$(jq -r '[.jobs[] | select(.name == "Claude review")][0].started_at // ""' <<< "${jobs_json}")"
+          finished="$(jq -r '[.jobs[] | select(.name == "Claude review")][0].completed_at // ""' <<< "${jobs_json}")"
+
+          seconds=-1
+          if [[ -n "${started}" && -n "${finished}" && "${finished}" != "null" ]]; then
+            seconds=$(( $(date -u -d "${finished}" +%s) - $(date -u -d "${started}" +%s) ))
+          fi
+
+          if [[ "${seconds}" -ge 0 ]]; then
+            elapsed="$(printf '%dm %02ds' $((seconds / 60)) $((seconds % 60)))"
+          else
+            elapsed="unknown"
+          fi
+
+          # A skip and a clean review are both `success`; only the clock
+          # separates them. 60 s is far above the ~15 s a skip takes and far
+          # below the minutes a review takes, so neither case lands near it.
+          if [[ "${REVIEW_RESULT}" != "success" ]]; then
+            verdict="**The review did not complete** (\`${REVIEW_RESULT}\`). Nothing was reviewed — treat this pull request as unread by Claude."
+          elif [[ "${seconds}" -ge 0 && "${seconds}" -lt 60 ]]; then
+            verdict="**Green without a review.** The job succeeded in ${elapsed}, which is the signature of the action declining to run — it does that when this workflow file differs from the copy on \`main\`. Read the diff yourself, or merge the workflow change first and re-run."
+          else
+            verdict="**Reviewed, nothing to report.** Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran."
+          fi
+
+          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. See `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
+            "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${elapsed}" "${RUN_URL}")"
+
+          jq -n --arg body "${body}" '{body: $body}' > payload.json
+
+          existing="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -n 1 || true)"
+
+          if [[ -n "${existing}" ]]; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing}" --input payload.json >/dev/null
+            echo "Updated status comment ${existing}."
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --input payload.json >/dev/null
+            echo "Created the status comment."
+          fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -180,7 +180,15 @@ jobs:
     timeout-minutes: 5
 
     permissions:
+      # Posting and rewriting the status comment. This is the permission the
+      # review job above deliberately does not have.
       pull-requests: write
+      # Reading the review job's timestamps through
+      # /actions/runs/{run_id}/jobs. That endpoint answers without this on a
+      # public repository, which is why the job worked before this line was
+      # added — but the day this repository turns private it would stop, and
+      # a dependency on being public is not one to leave undeclared.
+      actions: read
 
     steps:
       - name: Post or update the review status comment

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -158,7 +158,11 @@ the installable artifact and attaches it to a rolling **prerelease** tagged
 `releases/latest`, which excludes prereleases, and that single fact is what
 keeps the two update channels apart.
 
-`.github/workflows/claude-review.yml` is the AI reviewer; see below.
+`.github/workflows/claude-review.yml` is the AI reviewer; see below. It
+carries two jobs: `Claude review`, which reads the diff, and `Claude review
+status`, which posts the comment saying what that check's green means. They
+are separate jobs so that the write permission the second one needs never
+reaches the step that runs Claude.
 
 The steward skill (`.claude/skills/steward/SKILL.md`) maps each job to the
 local command that reproduces it, and records which ones cannot be
@@ -189,6 +193,13 @@ via `CLAUDE_CODE_OAUTH_TOKEN`. Runs on open, ready-for-review, reopen and
 **every push**; the `claude-review` label asks for a pass without one. Read
 the header of that file before changing it: it documents a gap that matters
 and is not obvious.
+
+It reports findings as inline comments and says nothing when it finds
+nothing, so a second job, **`Claude review status`**, posts one comment per
+pull request — rewritten in place on every run — stating whether the review
+ran, was skipped, or failed. Without it, a green check and no comment means
+either "read it, found nothing" or "declined to read it", and only the run
+log tells you which.
 
 **SonarQube Cloud** — posts a Quality Gate on each pull request. It is
 skipped entirely on pull requests from forks, because `SONAR_TOKEN` is not
@@ -376,7 +387,9 @@ nothing**:
 - `Claude review` exits **success** when it refuses to run over a
   workflow-file mismatch, so the check is green in about fifteen seconds
   having reviewed nothing — and that happens precisely on a pull request
-  editing the reviewer.
+  editing the reviewer. This is the one on the list with a reader attached:
+  the `Claude review status` comment names which of the two a green check
+  was, judged on the run's duration.
 - A `CODEOWNERS` entry naming a non-collaborator is **ignored silently**, so
   a protection rule can be enabled, appear active, and match nothing.
 - A local reproduction that runs on the wrong database engine, or without


### PR DESCRIPTION
## Description

`Claude review` posts inline comments when it finds something and stays **silent when it finds nothing**. So a green check with no comments means one of two opposite things — *"read the diff, found nothing"* or *"declined to read the diff"* — and the only way to tell them apart today is opening the run log.

That is not a hypothetical. The action refuses to run when this workflow file differs from the copy on `main`, and it exits **`success`** when it does. It happened on #155: green in **14 s**, nothing reviewed. The real review on #156 took **2 m 23 s**. Both are green checks with no comment.

A second job now posts **one comment per pull request, rewritten in place on every run**, saying which of three things happened:

| Situation | What the comment says |
|---|---|
| Review ran, found nothing | **Reviewed, nothing to report** — findings arrive as inline comments, this is the proof the reviewer ran |
| Review job succeeded in under a minute | **Green without a review** — the signature of the action declining to run; read the diff yourself |
| Job failed or was cancelled | **The review did not complete** — treat the pull request as unread |

It decides on the review job's **duration**, because a skip and a clean review are both `success` and nothing else separates them. The 60 s threshold sits far above the ~15 s a skip takes and far below the minutes a review takes, so neither case lands near it.

### Why a second job rather than letting Claude say it itself

The `code-review` skill already wants to: given `--comment` and no findings, it posts *"No issues found"* through `gh pr comment`. That needs `pull-requests: write`, which the review job deliberately does not have.

**Granting it there would be worse than the silence.** The same skill stops early when *"Claude has already commented on this PR"* — so its own summary comment would suppress the review of every later push to that pull request, undoing exactly what `synchronize` was added for in #155.

Splitting it in two solves both halves: the write permission never reaches the step that runs Claude, and the comment is authored by the workflow rather than by Claude, so it cannot trip that rule.

### Verification

The three branches were exercised locally against the **recorded timestamps of the two real runs** (#155's 14 s skip, #156's 2 m 23 s review) plus a failure and a no-timestamp cancellation, checking both the chosen verdict and that the `jq` payload builds. The workflow YAML was parsed, and the review job re-checked as still `pull-requests: read`.

Adding a CI job obliges updating both `docs/quality-pipeline.md` and the steward skill's reproduction table — `AGENTS.md` says *"both, or neither"*. Both are in this change.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist — the new job takes `pull-requests: write` and nothing else, holds no secret, checks out no code, and runs in a separate job so that permission never reaches the step holding the Claude token
- [x] All code and comments are in English
- [x] All UI-facing text is in French — no user-facing text in this change
- [ ] Automated tests are written/updated for this change — **n/a**: a CI workflow; its shell logic was exercised against recorded real timestamps, as described above
- [x] Tests pass locally — no application code touched
- [x] PHPStan passes (`vendor/bin/phpstan analyse`) — no PHP touched
- [ ] If this PR changes `public/assets/js/` behavior — **n/a**, no JS touched

Note for reviewers: because this pull request edits `claude-review.yml`, `Claude review` will go green in about fifteen seconds having reviewed nothing — the very gap described above. The new status comment should say so in as many words, which is this change's own first test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uyca22uE97be6f4PHeKsXV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an automated pull request comment showing Claude review status, including completed, skipped, failed, or canceled outcomes.
  - Status updates include review result, duration, commit information, and a link to the workflow run.
  - The comment is updated automatically to keep the latest review status visible in one place.

- **Documentation**
  - Updated quality pipeline guidance to explain review statuses and how to interpret successful no-op runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->