### PR TITLE
chore(issues): French issue forms, and a label taxonomy a script owns

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,140 @@
+# A FORM, not a markdown template. The difference is the whole point: a
+# markdown template ships a body the reporter is free to delete, and they
+# do — what arrives is three lines of prose with no version, no role and no
+# URL. A form renders real fields, and `required: true` is enforced by
+# GitHub before the issue is created at all.
+#
+# Every field here exists because an answer to it changes the verdict, and
+# nothing here asks for something the reporter cannot see. In French,
+# because the people filling it in are unit chiefs and parents — see
+# AGENTS.md § Language: the interface is French, and this form is part of
+# the interface.
+#
+# `labels:` below is what makes triage:pending the default state. Labels
+# are the state (see docs/quality-pipeline.md § Labels), and GitHub applies
+# one from a form ONLY if it already exists on the repository — an unknown
+# name is dropped in silence, with no error on the issue and nothing in any
+# log. scripts/sync-issue-labels.sh is what guarantees it exists.
+#
+# `triage:pending` and nothing else, deliberately. The repository's older
+# `bug` label stays what it has always been: something the maintainer
+# applies by hand. Adding it here would put a label outside the one script
+# that owns this taxonomy, and would sit oddly next to the `bug:not-a-bug`
+# a triage pass can reach.
+name: Signaler un dysfonctionnement
+description: Quelque chose ne fonctionne pas comme prévu sur votre site.
+title: "[Bug] "
+labels: ["triage:pending"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Merci de prendre le temps de signaler ce problème.
+
+        Répondez avec vos propres mots : il n'y a rien de technique à
+        fournir. Les champs marqués d'un astérisque sont obligatoires
+        parce que, sans eux, personne ne peut retrouver ce que vous avez
+        vu.
+
+        > **Une faille de sécurité ne se signale pas ici.** Elle se
+        > transmet en privé au mainteneur — voir `SECURITY.md`.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version du site
+      description: >-
+        Ouvrez l'adresse `/api/version` de votre site (par exemple
+        `https://votre-site.fr/api/version`) et recopiez le numéro
+        affiché. Un « Chef d'Unité » la lit aussi sur Configuration ›
+        Maintenance, ligne « Version installée ».
+      placeholder: "1.0.41"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: role
+    attributes:
+      label: Votre rôle au moment du problème
+      description: >-
+        Le même vocabulaire que la page Configuration › Fonctions. Si vous
+        n'étiez pas connecté, choisissez « Public ».
+      options:
+        - Public (non connecté)
+        - Animé
+        - Intendant
+        - Chef
+        - Chef d'Unité
+        - Administrateur du site
+    validations:
+      required: true
+
+  - type: input
+    id: page
+    attributes:
+      label: Page concernée
+      description: >-
+        Le titre de la page, ou l'adresse affichée dans la barre du
+        navigateur. Retirez-en ce qui identifie une personne si vous en
+        voyez.
+      placeholder: "Trombinoscope, ou /chefs/section/3"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Ce que vous attendiez
+      description: Ce qui aurait dû se passer, selon vous.
+      placeholder: "La liste devait afficher les louveteaux inscrits cette année."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Ce qui s'est passé
+      description: >-
+        Ce que le site a réellement fait ou affiché. Recopiez le message
+        d'erreur s'il y en avait un, ou joignez une capture d'écran —
+        prenez garde à ce qu'elle ne montre pas de données personnelles.
+      placeholder: "La liste est restée vide, avec le message « Aucun membre »."
+    validations:
+      required: true
+
+  - type: input
+    id: browser
+    attributes:
+      label: Navigateur et appareil
+      description: >-
+        Par exemple « Chrome sur Windows », « Safari sur iPhone »,
+        « Firefox sur Android ». Approximatif suffit.
+      placeholder: "Safari sur iPhone"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: reproducible
+    attributes:
+      label: Le problème se reproduit-il ?
+      description: >-
+        C'est la réponse qui départage un défaut d'un incident passager, et
+        c'est souvent la seule que vous puissiez donner et pas nous.
+      options:
+        - À chaque fois
+        - De temps en temps
+        - Une seule fois, jamais revu
+        - Je n'ai pas réessayé
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Autre chose à ajouter ?
+      description: >-
+        Facultatif. Ce que vous veniez de faire juste avant, ou tout ce qui
+        vous paraît lié.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,17 +6,23 @@
 # The cost is real and worth stating — someone with a report that fits
 # neither form has to pick the closer one. That is a better failure than a
 # report nobody can act on.
+#
+# The security link points at SECURITY.md rather than straight at
+# /security/advisories/new, because that form exists only while private
+# vulnerability reporting is enabled in the repository's settings — which
+# nothing in this repository can check. SECURITY.md always renders, and it
+# names the button plus the fallback. One extra hop against a dead end for
+# the one reporter who must not fall back on a public issue.
 blank_issues_enabled: false
 
 contact_links:
   - name: Faille de sécurité
     url: https://github.com/xdubois-57/scoutmagic/blob/main/SECURITY.md
     about: >-
-      Une vulnérabilité ne se signale jamais dans un ticket public. Contactez
-      le mainteneur en privé — la marche à suivre est dans SECURITY.md.
+      Jamais dans un ticket public. Utilisez le bouton « Report a vulnerability »
+      de l'onglet Security ; SECURITY.md explique la marche à suivre.
   - name: Question sur l'utilisation du site
     url: https://github.com/xdubois-57/scoutmagic/blob/main/README.md
     about: >-
-      L'aide est intégrée au site : le bouton « ? » de la barre de
-      navigation ouvre l'aide de la page affichée, et /aide en donne la
-      liste complète. Le README décrit l'installation et l'hébergement.
+      L'aide est dans le site : le bouton « ? » ouvre celle de la page affichée,
+      et /aide en donne la liste. Le README décrit l'installation.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,22 @@
+# Blank issues are off, and that is a decision rather than a tidiness
+# preference: a blank issue arrives with no version, no role and no page,
+# so the first exchange on it is always the same three questions. The two
+# forms next to this file collect those before the issue exists.
+#
+# The cost is real and worth stating — someone with a report that fits
+# neither form has to pick the closer one. That is a better failure than a
+# report nobody can act on.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Faille de sécurité
+    url: https://github.com/xdubois-57/scoutmagic/blob/main/SECURITY.md
+    about: >-
+      Une vulnérabilité ne se signale jamais dans un ticket public. Contactez
+      le mainteneur en privé — la marche à suivre est dans SECURITY.md.
+  - name: Question sur l'utilisation du site
+    url: https://github.com/xdubois-57/scoutmagic/blob/main/README.md
+    about: >-
+      L'aide est intégrée au site : le bouton « ? » de la barre de
+      navigation ouvre l'aide de la page affichée, et /aide en donne la
+      liste complète. Le README décrit l'installation et l'hébergement.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,74 @@
+# The need, not the solution. That is the one editorial rule this form
+# exists to enforce, and it is why there is no "proposed implementation"
+# field: a reporter who describes a screen they have imagined has already
+# thrown away the thing that was worth collecting — what they were trying
+# to accomplish, and what they do today instead. The first two fields ask
+# for exactly that, in that order.
+#
+# French, like bug.yml and for the same reason (AGENTS.md § Language).
+name: Proposer une amélioration
+description: Décrire un besoin auquel le site ne répond pas aujourd'hui.
+title: "[Idée] "
+labels: ["triage:pending"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Décrivez **ce que vous cherchez à faire**, pas la solution que
+        vous imaginez. Une solution toute faite se discute mal ; un besoin
+        se comprend, et il arrive qu'on lui trouve une réponse plus simple
+        que celle à laquelle on pensait.
+
+  - type: textarea
+    id: need
+    attributes:
+      label: Le besoin
+      description: >-
+        Qu'essayez-vous d'accomplir, et pour qui ? Décrivez la situation
+        concrète, sans nommer de personne.
+      placeholder: >-
+        En début d'année, je dois vérifier que chaque animé d'une section a
+        bien une fiche sanitaire à jour, et je n'ai aucun moyen de voir en
+        un coup d'œil celles qui manquent.
+    validations:
+      required: true
+
+  - type: textarea
+    id: today
+    attributes:
+      label: Comment faites-vous aujourd'hui ?
+      description: >-
+        Le contournement actuel, même s'il est fastidieux — ou « rien, je
+        ne le fais pas ». C'est ce qui dit à quel point le besoin coûte.
+      placeholder: >-
+        J'ouvre la fiche de chaque animé une par une et je note les
+        manquants sur un papier.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: audience
+    attributes:
+      label: Qui en aurait besoin ?
+      description: >-
+        Le rôle concerné, dans le vocabulaire de la page Configuration ›
+        Fonctions.
+      options:
+        - Moi seul
+        - Les chefs de ma section
+        - Toute l'unité
+        - Les familles / les animés
+        - Je ne sais pas
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Autre chose à ajouter ?
+      description: >-
+        Facultatif. Une échéance, une contrainte de votre unité, ou un
+        exemple vécu.
+    validations:
+      required: false

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,16 @@ This document defines the non-negotiable security requirements for the project. 
 
 ## Reporting a vulnerability
 
-Report security vulnerabilities privately — not via public GitHub issues — by contacting the
-maintainer directly. Include enough detail to reproduce the issue. There is no guaranteed
-response time; this project is maintained on a volunteer basis, and fixes are made as time
-allows.
+Report security vulnerabilities privately — not via public GitHub issues — through **GitHub's
+private vulnerability reporting**: the *Report a vulnerability* button on this repository's
+[Security tab](https://github.com/xdubois-57/scoutmagic/security), which opens an advisory
+visible only to the maintainer. Failing that, contact the maintainer directly. Include enough
+detail to reproduce the issue. There is no guaranteed response time; this project is maintained
+on a volunteer basis, and fixes are made as time allows.
+
+That button exists only while *Private vulnerability reporting* is enabled in the repository's
+settings, and nothing here can check that it is — see `docs/quality-pipeline.md` § The GitHub
+configuration this all depends on.
 
 ## Avertissement
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,8 @@ detail to reproduce the issue. There is no guaranteed response time; this projec
 on a volunteer basis, and fixes are made as time allows.
 
 That button exists only while *Private vulnerability reporting* is enabled in the repository's
-settings, and nothing here can check that it is — see `docs/quality-pipeline.md` § The GitHub
-configuration this all depends on.
+settings. It is enabled today; nothing in this repository would notice if it were turned off —
+see `docs/quality-pipeline.md` § Private vulnerability reporting for how to check.
 
 ## Avertissement
 

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -335,6 +335,20 @@ an error.
 fresh pass without pushing a commit. The workflow's job guard matches this
 name exactly.
 
+The issue triage taxonomy — `triage:*`, `bug:*`, `status:accepted` — is the
+one part of this section that *is* reproducible from the repository:
+`scripts/sync-issue-labels.sh` is its single source, and running it creates
+what is missing and repairs what somebody edited in the UI. It never
+deletes, so `claude-review` and the older `bug` label survive it. Run it
+after any change to that table, and read the summary — a run that reports
+nothing to do is the normal one.
+
+`.github/ISSUE_TEMPLATE/` holds the two issue forms (`bug.yml`,
+`feature.yml`, both French) and `config.yml`, which turns blank issues off.
+A form's `labels:` is what gives a new issue its starting state, and it
+depends on the label existing — see the last section of this document for
+what happens when it does not.
+
 ### CODEOWNERS
 
 `.github/CODEOWNERS` must name an account that actually has write access.
@@ -398,6 +412,12 @@ nothing**:
 - The release **Security gate passes on a permission gap**: denied access to
   the CodeQL or Dependabot alert API is a warning, not a refusal, so a
   release can be published with those two sources never consulted.
+- **An issue form's label is dropped in silence when the label does not
+  exist.** GitHub creates the issue anyway — no error on it, nothing in any
+  log — so a report arrives with no triage state and looks exactly like one
+  nobody has got to yet. `scripts/sync-issue-labels.sh` refuses to run when
+  a form under `.github/ISSUE_TEMPLATE/` names a label outside its own
+  table, which is the only place that pairing is ever checked.
 
 The habit that catches these is cheap: ask what a green result would look
 like if the thing had not run at all. When the answer is "the same", the

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -329,6 +329,19 @@ an error.
 - **Require review from Code Owners** — *not enabled, and not currently
   enableable.* See below.
 
+### Private vulnerability reporting
+
+*Settings → Code security → Private vulnerability reporting*
+
+`SECURITY.md` and `.github/ISSUE_TEMPLATE/config.yml` both send a reporter to
+the *Report a vulnerability* button on the Security tab. That button exists
+only while this setting is on, and when it is off there is no error and no
+check — the reporter simply does not find it, and the alternative on offer
+is "contact the maintainer directly" with no address. Blank issues are
+disabled, so the path that a stuck reporter would otherwise fall back on
+(open a public issue about a vulnerability) is the one thing that must not
+happen.
+
 ### Labels
 
 `claude-review` — adding it to a pull request asks `claude-review.yml` for a

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -333,6 +333,12 @@ an error.
 
 *Settings → Code security → Private vulnerability reporting*
 
+**Enabled** — confirmed against
+`GET /repos/xdubois-57/scoutmagic/private-vulnerability-reporting`, which
+answers `{"enabled": true}` and is readable without a token on a public
+repository. That is the cheapest way to check it, and worth doing rather
+than assuming, because the failure is silent in both directions.
+
 `SECURITY.md` and `.github/ISSUE_TEMPLATE/config.yml` both send a reporter to
 the *Report a vulnerability* button on the Security tab. That button exists
 only while this setting is on, and when it is off there is no error and no

--- a/scripts/sync-issue-labels.sh
+++ b/scripts/sync-issue-labels.sh
@@ -1,0 +1,224 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./scripts/sync-issue-labels.sh [--dry-run] [--repo owner/name]
+#
+# Creates, and thereafter repairs, the issue labels this repository's triage
+# depends on. Idempotent by construction: a second run reports every label
+# as unchanged and writes nothing.
+#
+# WHY THIS IS A SCRIPT AND NOT SIX CLICKS. Labels are the state of a
+# triaged issue — the whole taxonomy below is read by automation and by a
+# human deciding what to work on, and none of it lives in the repository
+# unless something puts it there. A label created by hand exists in exactly
+# one repository, with a colour and a description nobody can diff, and it
+# is gone the day somebody renames it in the UI. This file is that
+# taxonomy's single source: the issue forms declare labels from it, and
+# LABELS below is the only place any of them is spelled out.
+#
+# It never DELETES anything, which matters more than it looks: this
+# repository has labels older than this file (`bug`, `claude-review`), the
+# second of which .github/workflows/claude-review.yml matches by name. A
+# sync that reconciled the repository down to its own table would delete
+# it, and the workflow's manual lever would stop working with nothing
+# saying so.
+#
+# Requires: gh (authenticated — `gh auth login`), jq.
+
+DRY_RUN=0
+REPO=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        --repo) REPO="${2:-}"; shift 2 ;;
+        -h|--help)
+            echo "Usage: ./scripts/sync-issue-labels.sh [--dry-run] [--repo owner/name]"
+            exit 0
+            ;;
+        *)
+            echo "ERROR: unknown argument '$1'." >&2
+            exit 2
+            ;;
+    esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FORM_DIR="${ISSUE_TEMPLATE_DIR:-${SCRIPT_DIR}/../.github/ISSUE_TEMPLATE}"
+
+# The taxonomy. One line per label: name|colour|description.
+#
+# English, like every other label on this repository and like the analysis
+# the triage agent writes into GitHub. AGENTS.md § Language governs the
+# application's interface — what a unit chief reads on the site — and these
+# are read by the maintainer and by automation, never rendered to a user.
+#
+# `status:accepted` is deliberately inert: the agent must never apply or
+# remove it, and no workflow reads it. It is a marker for a human eye,
+# and it is created here so that the one hand-applied label in the set is
+# still described, coloured and reproducible like the rest.
+#
+# The colours are not arbitrary in one respect: `bug:confirmed` is a
+# darker red than the repository's older `bug` label rather than the same
+# one, so a glance at an issue list tells a confirmed defect apart from a
+# report somebody tagged by hand.
+LABELS=(
+    "triage:pending|fbca04|Never analysed — the state every new issue starts in"
+    "triage:done|c5def5|Analysed, verdict posted"
+    "bug:confirmed|b60205|A real defect, understood"
+    "bug:not-a-bug|cfd3d7|Works as designed, or user error"
+    "bug:needs-info|d876e3|Blocked on an answer from the reporter"
+    "status:accepted|0e8a16|The maintainer will do it — applied by hand, read by no automation"
+)
+
+command -v gh &> /dev/null || {
+    echo "ERROR: GitHub CLI (gh) is required — install it and run gh auth login." >&2
+    exit 1
+}
+command -v jq &> /dev/null || {
+    echo "ERROR: jq is required." >&2
+    exit 1
+}
+
+# `gh api` expands {owner}/{repo} from the current checkout's default
+# remote, the same form scripts/release.sh uses. --repo overrides it for a
+# fork or a test repository.
+if [[ -n "${REPO}" ]]; then
+    API_BASE="repos/${REPO}"
+else
+    API_BASE="repos/{owner}/{repo}"
+fi
+
+# ---------------------------------------------------------------------------
+# The check that stops a label being dropped in silence.
+#
+# GitHub applies a label named in an issue form's `labels:` ONLY if it
+# already exists on the repository. An unknown name is discarded when the
+# issue is created: no error on the issue, nothing in any log, and an issue
+# that quietly starts life with no triage state at all. That is the exact
+# shape of failure docs/quality-pipeline.md § "something green that proved
+# nothing" collects, so this refuses before the first API call rather than
+# leaving it to be discovered on a real report.
+# ---------------------------------------------------------------------------
+known_label() {
+    local needle="$1" entry
+    for entry in "${LABELS[@]}"; do
+        [[ "${entry%%|*}" == "${needle}" ]] && return 0
+    done
+    return 1
+}
+
+# The forms write `labels: ["a", "b"]` — YAML's flow sequence, on one line.
+# A block sequence parses to the same thing in YAML and to nothing here, so
+# it is refused rather than skipped: skipping it would leave the check
+# below reporting success over a file it never read, which is the failure
+# mode where a green result and no result look identical.
+#
+# This guard runs in the main shell on purpose. Inside a function called
+# through process substitution, its `exit` would have ended the subshell
+# and left the script running — the check silently disabled by the very
+# input it exists to catch. (It did, until this test caught it.)
+if [[ -d "${FORM_DIR}" ]]; then
+    BLOCK_FORM="$(grep -lE '^labels:[[:space:]]*$' "${FORM_DIR}"/*.yml 2>/dev/null || true)"
+    if [[ -n "${BLOCK_FORM}" ]]; then
+        echo "ERROR: these issue forms declare labels as a block sequence, which this check cannot read:" >&2
+        echo "${BLOCK_FORM}" >&2
+        echo "Write them inline — labels: [\"a\", \"b\"] — or teach this script to parse YAML." >&2
+        exit 1
+    fi
+
+    DECLARED="$(grep -hoE '^labels:[[:space:]]*\[[^]]*\]' "${FORM_DIR}"/*.yml 2>/dev/null \
+        | sed -e 's/^labels:[[:space:]]*\[//' -e 's/\]$//' \
+        | tr ',' '\n' \
+        | sed -e 's/^[[:space:]]*"*//' -e "s/^[[:space:]]*'*//" -e 's/"*[[:space:]]*$//' -e "s/'*[[:space:]]*\$//" \
+        | grep -v '^[[:space:]]*$' \
+        | sort -u || true)"
+else
+    DECLARED=""
+fi
+
+UNKNOWN=""
+while IFS= read -r declared; do
+    [[ -n "${declared}" ]] || continue
+    known_label "${declared}" || UNKNOWN+="  ${declared}"$'\n'
+done <<< "${DECLARED}"
+
+if [[ -n "${UNKNOWN}" ]]; then
+    echo "ERROR: an issue form declares a label this script does not create:" >&2
+    printf '%s' "${UNKNOWN}" >&2
+    echo "GitHub drops an unknown label from a form in silence, so the issue would arrive with no triage state." >&2
+    echo "Add it to LABELS in ${BASH_SOURCE[0]}, or correct the form." >&2
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# The sync itself.
+# ---------------------------------------------------------------------------
+CREATED=0
+UPDATED=0
+UNCHANGED=0
+
+ERR_FILE="$(mktemp)"
+trap 'rm -f "${ERR_FILE}"' EXIT
+
+echo "Syncing ${#LABELS[@]} labels against ${API_BASE}."
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+    echo "(dry run — nothing will be written)"
+fi
+
+for entry in "${LABELS[@]}"; do
+    IFS='|' read -r name colour description <<< "${entry}"
+
+    # A 404 here is the "does not exist yet" answer and the only failure
+    # this loop absorbs. Anything else — a network error, a revoked token,
+    # a rate limit — must stop the run rather than be read as "absent" and
+    # answered with a create that then fails for the same reason. One call,
+    # reading gh's own message: asking twice would double the rate-limit
+    # cost of the read and could get two different answers.
+    existing=""
+    absent=0
+    if ! existing="$(gh api "${API_BASE}/labels/${name}" 2>"${ERR_FILE}")"; then
+        if grep -q 'HTTP 404' "${ERR_FILE}"; then
+            absent=1
+        else
+            echo "ERROR: could not read label '${name}':" >&2
+            cat "${ERR_FILE}" >&2
+            exit 1
+        fi
+    fi
+
+    if [[ "${absent}" -eq 1 ]]; then
+        echo "  + ${name}"
+        if [[ "${DRY_RUN}" -eq 0 ]]; then
+            gh api -X POST "${API_BASE}/labels" \
+                -f "name=${name}" -f "color=${colour}" -f "description=${description}" >/dev/null
+        fi
+        CREATED=$((CREATED + 1))
+        continue
+    fi
+
+    current_colour="$(jq -r '.color // ""' <<< "${existing}")"
+    current_description="$(jq -r '.description // ""' <<< "${existing}")"
+
+    if [[ "${current_colour}" == "${colour}" && "${current_description}" == "${description}" ]]; then
+        echo "  = ${name}"
+        UNCHANGED=$((UNCHANGED + 1))
+        continue
+    fi
+
+    echo "  ~ ${name} (colour ${current_colour} → ${colour})"
+    if [[ "${DRY_RUN}" -eq 0 ]]; then
+        gh api -X PATCH "${API_BASE}/labels/${name}" \
+            -f "new_name=${name}" -f "color=${colour}" -f "description=${description}" >/dev/null
+    fi
+    UPDATED=$((UPDATED + 1))
+done
+
+echo "Done: ${CREATED} created, ${UPDATED} updated, ${UNCHANGED} unchanged."
+
+# The idempotence claim, made checkable. A run that changed nothing is what
+# every run after the first should print; anything else is a label somebody
+# edited in the UI, which is worth seeing rather than absorbing quietly.
+if [[ "${CREATED}" -eq 0 && "${UPDATED}" -eq 0 ]]; then
+    echo "Nothing to do — the repository already matches this file."
+fi

--- a/scripts/sync-issue-labels.sh
+++ b/scripts/sync-issue-labels.sh
@@ -108,33 +108,47 @@ known_label() {
     return 1
 }
 
-# The forms write `labels: ["a", "b"]` — YAML's flow sequence, on one line.
-# A block sequence parses to the same thing in YAML and to nothing here, so
-# it is refused rather than skipped: skipping it would leave the check
-# below reporting success over a file it never read, which is the failure
-# mode where a green result and no result look identical.
+# This is a `grep`, not a YAML parser, and GitHub's schema accepts more
+# shapes than a grep can read: a block sequence (`labels:` then indented
+# `- ` items), a flow sequence broken over several lines, and a plain
+# comma-delimited string are all valid `labels:` and all mean something.
 #
-# This guard runs in the main shell on purpose. Inside a function called
+# So rather than try to read each shape, every `labels:` line is required
+# to be the ONE shape this can read — a complete flow sequence, opened and
+# closed on its own line — and anything else is refused by name. Refusing
+# is the whole point: a shape this skips leaves the check below reporting
+# success over a declaration it never saw, which is the failure mode where
+# a green result and no result look identical. A multiline flow sequence
+# did exactly that until CodeRabbit found it on this pull request — the
+# sync ran, and an unknown label went unreported.
+#
+# The guard runs in the main shell on purpose. Inside a function called
 # through process substitution, its `exit` would have ended the subshell
 # and left the script running — the check silently disabled by the very
-# input it exists to catch. (It did, until this test caught it.)
+# input it exists to catch. (It did, until the test caught it.)
+DECLARED=""
 if [[ -d "${FORM_DIR}" ]]; then
-    BLOCK_FORM="$(grep -lE '^labels:[[:space:]]*$' "${FORM_DIR}"/*.yml 2>/dev/null || true)"
-    if [[ -n "${BLOCK_FORM}" ]]; then
-        echo "ERROR: these issue forms declare labels as a block sequence, which this check cannot read:" >&2
-        echo "${BLOCK_FORM}" >&2
-        echo "Write them inline — labels: [\"a\", \"b\"] — or teach this script to parse YAML." >&2
-        exit 1
-    fi
+    for form in "${FORM_DIR}"/*.yml; do
+        [[ -e "${form}" ]] || continue
 
-    DECLARED="$(grep -hoE '^labels:[[:space:]]*\[[^]]*\]' "${FORM_DIR}"/*.yml 2>/dev/null \
-        | sed -e 's/^labels:[[:space:]]*\[//' -e 's/\]$//' \
-        | tr ',' '\n' \
-        | sed -e 's/^[[:space:]]*"*//' -e "s/^[[:space:]]*'*//" -e 's/"*[[:space:]]*$//' -e "s/'*[[:space:]]*\$//" \
-        | grep -v '^[[:space:]]*$' \
-        | sort -u || true)"
-else
-    DECLARED=""
+        # Every top-level `labels:` in the file. A form field's own key is
+        # `label:` and is indented, so `^labels:` matches only this one.
+        while IFS= read -r line; do
+            if [[ ! "${line}" =~ ^labels:[[:space:]]*\[[^][]*\][[:space:]]*$ ]]; then
+                echo "ERROR: ${form} declares labels in a shape this check cannot read:" >&2
+                echo "  ${line}" >&2
+                echo "Write the whole list inline on one line — labels: [\"a\", \"b\"] — so the check below can see it." >&2
+                echo "A block sequence, a flow sequence split over several lines and a comma-delimited string are all valid YAML that this would silently skip." >&2
+                exit 1
+            fi
+
+            DECLARED+="$(sed -e 's/^labels:[[:space:]]*\[//' -e 's/\][[:space:]]*$//' <<< "${line}" \
+                | tr ',' '\n' \
+                | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e 's/^"//' -e 's/"$//' -e "s/^'//" -e "s/'\$//" \
+                | grep -v '^[[:space:]]*$' || true)"$'\n'
+        done < <(grep -E '^labels:' "${form}" || true)
+    done
+    DECLARED="$(sort -u <<< "${DECLARED}")"
 fi
 
 UNKNOWN=""

--- a/scripts/sync-issue-labels.test.sh
+++ b/scripts/sync-issue-labels.test.sh
@@ -199,10 +199,14 @@ if grep -q '^PATCH bug:confirmed b60205' "${WRITE_LOG}"; then
 else
     fail "the colour is put back"
 fi
-if grep -q '^PATCH triage:done ' "${WRITE_LOG}"; then
-    pass "the description is put back"
+# The value, not just the fact of a write: a PATCH that sent an empty or
+# wrong description would satisfy "a PATCH happened" and leave the label
+# exactly as broken as it was.
+managed_description="$(grep -oE '"triage:done\|[^|]*\|[^"]*"' "${SYNC_SCRIPT}" | sed -e 's/^"//' -e 's/"$//' | cut -d'|' -f3)"
+if [[ "$(jq -r '.["triage:done"].description' "${LABEL_STATE}")" == "${managed_description}" ]]; then
+    pass "the description is put back, to the value the table carries"
 else
-    fail "the description is put back"
+    fail "the description is put back, to the value the table carries"
 fi
 
 # ---------------------------------------------------------------------------
@@ -243,22 +247,36 @@ assert_eq "$(wc -c < "${WRITE_LOG}" | tr -d ' ')" "0" "it refused before writing
 
 # ---------------------------------------------------------------------------
 echo
-echo "A form declaring labels as a YAML block sequence is refused, not skipped"
+echo "Every labels: shape the check cannot read is refused, not skipped"
 # ---------------------------------------------------------------------------
-# Silently skipping it would leave the cross-check above reporting success
-# over a file it never read — the failure mode where a green result and no
-# result look identical.
-printf 'name: Bug\nlabels:\n  - triage:pending\n' > "${FORMS}/bug.yml"
-if output="$(run_sync)"; then
-    fail "the run should have refused"
-else
-    pass "the run refuses"
-fi
-if grep -q 'block sequence' <<< "${output}"; then
-    pass "it says why, naming the file"
-else
-    fail "it says why, naming the file"
-fi
+# GitHub's schema accepts more than the one-line flow sequence this script
+# greps for, and each extra shape is a way to smuggle a label past the
+# cross-check above: it would report success over a declaration it never
+# saw — the failure mode where a green result and no result look identical.
+#
+# The multiline flow sequence is not hypothetical. It slipped through, the
+# sync ran, and `priority:high` went unreported; CodeRabbit found it on the
+# pull request that introduced this file.
+for shape in "block sequence:name: Bug\nlabels:\n  - triage:pending\n" \
+             "multiline flow sequence:name: Bug\nlabels: [\n  \"triage:pending\",\n  \"priority:high\"\n]\n" \
+             "comma-delimited string:name: Bug\nlabels: triage:pending, priority:high\n"; do
+    shape_name="${shape%%:*}"
+    # shellcheck disable=SC2059
+    printf "${shape#*:}" > "${FORMS}/bug.yml"
+    : > "${WRITE_LOG}"
+
+    if output="$(run_sync)"; then
+        fail "a ${shape_name} is refused"
+    else
+        pass "a ${shape_name} is refused"
+    fi
+    if grep -q 'cannot read' <<< "${output}"; then
+        pass "  it says why, naming the file"
+    else
+        fail "  it says why, naming the file"
+    fi
+    assert_eq "$(wc -c < "${WRITE_LOG}" | tr -d ' ')" "0" "  it refused before writing anything"
+done
 
 # ---------------------------------------------------------------------------
 echo

--- a/scripts/sync-issue-labels.test.sh
+++ b/scripts/sync-issue-labels.test.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./scripts/sync-issue-labels.test.sh
+#
+# Exercises scripts/sync-issue-labels.sh against a fake `gh` — a script in
+# a temp directory prepended to PATH that answers from a JSON file standing
+# in for the repository's label set, and records every write. No network,
+# no token, no real repository touched.
+#
+# Same shape and same reasoning as scripts/build-artifact.test.sh and
+# scripts/check-sonar-release.test.sh: what is under test is the script's
+# DECISIONS — create, patch, leave alone, refuse — not whether GitHub
+# works. Run manually; nothing in CI runs it, and the label sync itself is
+# a maintainer command rather than a build step.
+#
+# The case that matters most is the third: a second run against the state
+# the first run produced must write nothing at all. "Re-running the label
+# script changes nothing" is the whole claim the script makes, and it is
+# the kind of claim that is true right up until somebody adds a field to
+# the comparison and forgets to send it on create.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SYNC_SCRIPT="${SCRIPT_DIR}/sync-issue-labels.sh"
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+FAKE_BIN_DIR="${WORK_DIR}/bin"
+mkdir -p "${FAKE_BIN_DIR}"
+
+# The fake repository: a JSON object of name → {color, description}.
+export LABEL_STATE="${WORK_DIR}/labels.json"
+# Every write the script attempts, one per line.
+export WRITE_LOG="${WORK_DIR}/writes.log"
+
+cat > "${FAKE_BIN_DIR}/gh" <<'EOF'
+#!/bin/bash
+# Answers the three calls sync-issue-labels.sh makes, from LABEL_STATE.
+# Anything else is a test bug rather than a script bug, so it is loud.
+set -uo pipefail
+
+method="GET"
+args=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        api) shift ;;
+        -X) method="$2"; shift 2 ;;
+        -f) args+=("$2"); shift 2 ;;
+        --include) shift ;;
+        *) args+=("$1"); shift ;;
+    esac
+done
+
+path="${args[0]}"
+fields=("${args[@]:1}")
+
+field_value() {
+    local key="$1" f
+    for f in "${fields[@]}"; do
+        [[ "${f}" == "${key}="* ]] && { printf '%s' "${f#*=}"; return 0; }
+    done
+    printf ''
+}
+
+if [[ "${GH_FAIL_HARD:-0}" == "1" ]]; then
+    echo "gh: Bad credentials (HTTP 401)" >&2
+    exit 1
+fi
+
+case "${method}" in
+    GET)
+        name="${path##*/labels/}"
+        if jq -e --arg n "${name}" 'has($n)' "${LABEL_STATE}" >/dev/null; then
+            jq -c --arg n "${name}" '.[$n] + {name: $n}' "${LABEL_STATE}"
+            exit 0
+        fi
+        echo "gh: Not Found (HTTP 404)" >&2
+        exit 1
+        ;;
+    POST)
+        name="$(field_value name)"
+        echo "POST ${name} $(field_value color) $(field_value description)" >> "${WRITE_LOG}"
+        jq --arg n "${name}" --arg c "$(field_value color)" --arg d "$(field_value description)" \
+            '.[$n] = {color: $c, description: $d}' "${LABEL_STATE}" > "${LABEL_STATE}.tmp"
+        mv "${LABEL_STATE}.tmp" "${LABEL_STATE}"
+        echo '{}'
+        exit 0
+        ;;
+    PATCH)
+        name="${path##*/labels/}"
+        echo "PATCH ${name} $(field_value color) $(field_value description)" >> "${WRITE_LOG}"
+        jq --arg n "${name}" --arg c "$(field_value color)" --arg d "$(field_value description)" \
+            '.[$n] = {color: $c, description: $d}' "${LABEL_STATE}" > "${LABEL_STATE}.tmp"
+        mv "${LABEL_STATE}.tmp" "${LABEL_STATE}"
+        echo '{}'
+        exit 0
+        ;;
+esac
+
+echo "fake gh: unexpected call: ${method} ${path}" >&2
+exit 99
+EOF
+chmod +x "${FAKE_BIN_DIR}/gh"
+export PATH="${FAKE_BIN_DIR}:${PATH}"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() {
+    echo "  ✅ $1"
+    PASS_COUNT=$((PASS_COUNT + 1))
+    return 0
+}
+
+fail() {
+    echo "  ❌ $1"
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+    return 0
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [[ "${actual}" == "${expected}" ]]; then
+        pass "${label}"
+    else
+        fail "${label} (expected '${expected}', got '${actual}')"
+    fi
+    return 0
+}
+
+reset_state() {
+    echo "${1:-{\}}" > "${LABEL_STATE}"
+    : > "${WRITE_LOG}"
+    return 0
+}
+
+# A fixture issue-form directory, so the form/label cross-check runs
+# against something this test controls rather than against the real
+# .github/ISSUE_TEMPLATE (which would make these cases pass or fail for
+# reasons that have nothing to do with the script).
+FORMS="${WORK_DIR}/forms"
+mkdir -p "${FORMS}"
+
+run_sync() {
+    ISSUE_TEMPLATE_DIR="${FORMS}" "${SYNC_SCRIPT}" --repo "acme/widgets" "$@" 2>&1
+    return $?
+}
+
+echo "sync-issue-labels.sh"
+
+# ---------------------------------------------------------------------------
+echo
+echo "A first run on a repository with no labels creates them all"
+# ---------------------------------------------------------------------------
+printf 'name: Bug\nlabels: ["triage:pending"]\n' > "${FORMS}/bug.yml"
+reset_state
+output="$(run_sync)" || fail "the first run exited non-zero"
+
+expected_count="$(grep -cE '^\s+"[a-z:-]+\|' "${SYNC_SCRIPT}")"
+assert_eq "$(wc -l < "${WRITE_LOG}" | tr -d ' ')" "${expected_count}" \
+    "one POST per label in the table (${expected_count})"
+assert_eq "$(grep -c '^POST ' "${WRITE_LOG}")" "${expected_count}" "every write was a create, none a patch"
+if grep -q "Done: ${expected_count} created, 0 updated, 0 unchanged." <<< "${output}"; then
+    pass "the summary counts them as created"
+else
+    fail "the summary counts them as created"
+fi
+if grep -q 'POST triage:pending fbca04' "${WRITE_LOG}"; then
+    pass "triage:pending is created with its colour"
+else
+    fail "triage:pending is created with its colour"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "A second run against that state writes nothing — the idempotence claim"
+# ---------------------------------------------------------------------------
+: > "${WRITE_LOG}"
+output="$(run_sync)" || fail "the second run exited non-zero"
+assert_eq "$(wc -c < "${WRITE_LOG}" | tr -d ' ')" "0" "no write of any kind"
+if grep -q 'Nothing to do' <<< "${output}"; then
+    pass "it says so rather than reporting silence"
+else
+    fail "it says so rather than reporting silence"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "A colour or description edited in the UI is repaired, and only that one"
+# ---------------------------------------------------------------------------
+jq '.["bug:confirmed"].color = "ffffff"' "${LABEL_STATE}" > "${LABEL_STATE}.tmp" && mv "${LABEL_STATE}.tmp" "${LABEL_STATE}"
+jq '.["triage:done"].description = "something somebody typed"' "${LABEL_STATE}" > "${LABEL_STATE}.tmp" && mv "${LABEL_STATE}.tmp" "${LABEL_STATE}"
+: > "${WRITE_LOG}"
+output="$(run_sync)" || fail "the repair run exited non-zero"
+assert_eq "$(wc -l < "${WRITE_LOG}" | tr -d ' ')" "2" "exactly two labels rewritten"
+assert_eq "$(grep -c '^PATCH ' "${WRITE_LOG}")" "2" "both writes were patches, not creates"
+if grep -q '^PATCH bug:confirmed b60205' "${WRITE_LOG}"; then
+    pass "the colour is put back"
+else
+    fail "the colour is put back"
+fi
+if grep -q '^PATCH triage:done ' "${WRITE_LOG}"; then
+    pass "the description is put back"
+else
+    fail "the description is put back"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "A label the script does not own is left alone"
+# ---------------------------------------------------------------------------
+: > "${WRITE_LOG}"
+jq '.["claude-review"] = {color: "111111", description: "asks for a fresh Claude pass"}' \
+    "${LABEL_STATE}" > "${LABEL_STATE}.tmp" && mv "${LABEL_STATE}.tmp" "${LABEL_STATE}"
+run_sync >/dev/null || fail "the run exited non-zero"
+assert_eq "$(wc -c < "${WRITE_LOG}" | tr -d ' ')" "0" "no write at all"
+if jq -e 'has("claude-review")' "${LABEL_STATE}" >/dev/null; then
+    pass "claude-review still exists — nothing is ever deleted"
+else
+    fail "claude-review still exists — nothing is ever deleted"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "A form declaring a label the script does not create is refused"
+# ---------------------------------------------------------------------------
+# The failure this guards against is GitHub dropping an unknown form label
+# in silence, which produces an issue with no triage state and no trace of
+# why. The refusal must come BEFORE any write.
+printf 'name: Bug\nlabels: ["triage:pending", "priority:high"]\n' > "${FORMS}/bug.yml"
+: > "${WRITE_LOG}"
+if output="$(run_sync)"; then
+    fail "the run should have refused"
+else
+    pass "the run refuses"
+fi
+if grep -q 'priority:high' <<< "${output}"; then
+    pass "it names the offending label"
+else
+    fail "it names the offending label"
+fi
+assert_eq "$(wc -c < "${WRITE_LOG}" | tr -d ' ')" "0" "it refused before writing anything"
+
+# ---------------------------------------------------------------------------
+echo
+echo "A form declaring labels as a YAML block sequence is refused, not skipped"
+# ---------------------------------------------------------------------------
+# Silently skipping it would leave the cross-check above reporting success
+# over a file it never read — the failure mode where a green result and no
+# result look identical.
+printf 'name: Bug\nlabels:\n  - triage:pending\n' > "${FORMS}/bug.yml"
+if output="$(run_sync)"; then
+    fail "the run should have refused"
+else
+    pass "the run refuses"
+fi
+if grep -q 'block sequence' <<< "${output}"; then
+    pass "it says why, naming the file"
+else
+    fail "it says why, naming the file"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "An API error that is not a 404 aborts instead of being read as absent"
+# ---------------------------------------------------------------------------
+printf 'name: Bug\nlabels: ["triage:pending"]\n' > "${FORMS}/bug.yml"
+reset_state
+: > "${WRITE_LOG}"
+if output="$(GH_FAIL_HARD=1 run_sync)"; then
+    fail "the run should have aborted"
+else
+    pass "the run aborts"
+fi
+assert_eq "$(wc -c < "${WRITE_LOG}" | tr -d ' ')" "0" "it created nothing on the way out"
+if grep -q 'could not read label' <<< "${output}"; then
+    pass "it reports the API error rather than the label"
+else
+    fail "it reports the API error rather than the label"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "--dry-run reports what it would do and writes nothing"
+# ---------------------------------------------------------------------------
+reset_state
+: > "${WRITE_LOG}"
+output="$(run_sync --dry-run)" || fail "the dry run exited non-zero"
+assert_eq "$(wc -c < "${WRITE_LOG}" | tr -d ' ')" "0" "no write"
+if grep -q "Done: ${expected_count} created" <<< "${output}"; then
+    pass "it still reports the ${expected_count} labels it would create"
+else
+    fail "it still reports the ${expected_count} labels it would create"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "The real issue forms declare only labels this script creates"
+# ---------------------------------------------------------------------------
+# The one case that reads the repository rather than a fixture: it is the
+# assertion that .github/ISSUE_TEMPLATE and this script have not drifted
+# apart, and it is worth having precisely because nothing else notices.
+reset_state
+if "${SYNC_SCRIPT}" --repo "acme/widgets" --dry-run >/dev/null 2>&1; then
+    pass ".github/ISSUE_TEMPLATE and LABELS agree"
+else
+    fail ".github/ISSUE_TEMPLATE and LABELS agree"
+fi
+
+echo
+echo "─────────────────────────────────────────"
+echo "  ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+echo "─────────────────────────────────────────"
+[[ "${FAIL_COUNT}" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Description

**IT-01 of the issue triage agent roadmap.** No AI, no workflow, nothing that runs on its own — this is the substrate the three later iterations read and write.

### Issue forms, not markdown templates

`.github/ISSUE_TEMPLATE/` did not exist. It now holds `bug.yml` and `feature.yml` as GitHub issue **forms**, plus `config.yml` turning blank issues off. Forms rather than markdown templates because a markdown template ships a body the reporter is free to delete, and they do — what arrives is three lines of prose with no version, no role, no page. A form renders real fields and GitHub enforces `required: true` before the issue is created at all.

Both are in French: the people filling them in are unit chiefs and parents (`AGENTS.md` § Language).

**One thing in the roadmap does not match the code, and I did not follow it.** The roadmap says the reporter reads the version off the "site footer / `VERSION`". The footer (`core/View/templates/base.html.twig:142`) shows the unit name and the legal links; the installed version is on Configuration › Maintenance, whose route is `role_min: admin` (`public/index.php:2427`) — so a section chief reporting a bug cannot read it there. The form points at `GET /api/version` instead, which is `role_min: public` and exists precisely so a version can be read without signing in, and mentions the Maintenance page as the alternative for a « Chef d'Unité ».

`feature.yml` asks for the need and the current workaround, and deliberately has no "proposed solution" field.

### Labels, from a script

`scripts/sync-issue-labels.sh` creates the six labels of the roadmap's table and is the single place any of them is spelled out. Re-running it reports every label unchanged and writes nothing; a colour or description edited in the UI is repaired.

It never **deletes**. `bug` and `claude-review` predate it, and `claude-review.yml`'s job guard matches the second by name — a sync that reconciled the repository down to its own table would delete it and break that lever in silence.

`bug:confirmed` is `b60205` rather than the `d73a4a` the existing `bug` label already uses, so a confirmed defect is distinguishable at a glance from a report tagged by hand.

`status:accepted` is created but inert, as the roadmap specifies: no workflow reads it and the agent must never apply or remove it.

### The check with no other home

The script refuses to run when a form under `.github/ISSUE_TEMPLATE/` declares a label its table does not carry. **GitHub drops an unknown form label in silence** — no error on the issue, nothing in any log — so the report is created with no triage state and looks exactly like one nobody has got to yet. That is the failure mode `docs/quality-pipeline.md`'s last section collects, and it is now recorded there alongside the others, with § Labels updated to point at the script and the forms.

### Tests

`scripts/sync-issue-labels.test.sh`, the same shape as `build-artifact.test.sh` and `check-sonar-release.test.sh`: a fake `gh` in a temp `PATH` answering from a JSON file, no network, no token, no real repository. 23 assertions, currently green — first run creates, second run writes nothing, drift is repaired and only the drifted label, an unowned label survives, both refusal paths refuse *before* writing, a non-404 API error aborts rather than being read as "absent", and the real `.github/ISSUE_TEMPLATE` agrees with `LABELS`.

It already earned its keep: the block-sequence guard originally called `exit` from inside a process substitution, which ended the subshell and left the run going — the check silently disabled by exactly the input it exists to catch.

### After merging

`./scripts/sync-issue-labels.sh` has to be run once (it needs an authenticated `gh`, which is not available in the session that wrote this). Until it is, the forms' `triage:pending` is dropped on arrival and IT-02 has no state to read.

**Done when**, per the roadmap: a new issue shows the French form ✅ (after merge — issue templates are read from the default branch), blank issues are refused ✅, re-running the label script changes nothing ✅ (covered by the test; unverifiable against the live repository from here).

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`) — unchanged by this PR (no PHP touched); `./scripts/sync-issue-labels.test.sh` is the test for what it does change, 23/23 green
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`) — no PHP touched
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — not applicable, no JavaScript touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ReJw9KFV8QHeK2YfE2j64

---
_Generated by [Claude Code](https://claude.ai/code/session_013ReJw9KFV8QHeK2YfE2j64)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added French-language forms for reporting bugs and requesting features, with structured prompts to provide more useful details.
  * Added guidance for private security reports and site-usage questions.
  * Added validation and synchronization for issue labels to keep support workflows consistent.

* **Documentation**
  * Updated quality-process documentation with issue-label management and validation guidance.

* **Tests**
  * Added automated coverage for issue-label creation, updates, validation, preservation, and preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->