### PR TITLE
fix(review): read whether Claude ran, instead of timing it

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -154,9 +154,16 @@ seconds having reviewed nothing.
 You no longer have to open the run to find that out: the `Claude review
 status` job posts one comment on the pull request, rewritten on every run,
 saying which of the three happened — reviewed, skipped without reviewing,
-or did not complete. It decides from the review job's duration, since a
-skip and a clean review are both `success` and only the clock separates
-them. Read that comment; it is the answer the check alone cannot give.
+or did not complete. It reads the action's own `conclusion` output, which
+is empty exactly when the action returned before running Claude. Read that
+comment; it is the answer the check alone cannot give.
+
+**Its `Took` row is information, not evidence.** That comment used to
+decide on duration — under a minute meant a skip — and it was wrong
+routinely, because a review with nothing to report finishes in about the
+same time as a refusal. It announced "green without a review" over reviews
+that had read the whole diff (issue #159). If you meet an older comment
+still phrased that way, trust the `Claude ran` row, not the clock.
 
 **Before believing a green PHPUnit run, check the database was there.** The
 database-backed tests `markTestSkipped` when the server does not answer, so

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -120,7 +120,7 @@ does not:
 | `Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
 | `security` | `composer audit` |
 | `Claude review` | no local equivalent — read the findings on the PR; see below |
-| `Claude review status` | no local equivalent — it posts the comment that says what the green above means |
+| `Claude review status` | no local equivalent — it posts the comment that says what the green above means, deciding from the review job's `result` and the `conclusion` output it exports |
 | `SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
 
@@ -162,8 +162,12 @@ comment; it is the answer the check alone cannot give.
 decide on duration — under a minute meant a skip — and it was wrong
 routinely, because a review with nothing to report finishes in about the
 same time as a refusal. It announced "green without a review" over reviews
-that had read the whole diff (issue #159). If you meet an older comment
-still phrased that way, trust the `Claude ran` row, not the clock.
+that had read the whole diff (issue #159).
+
+A comment carrying **no `Claude ran` row at all** predates that fix, so its
+verdict came from the clock and settles nothing either way: open the run
+and read whether Claude ran. One survives only on a pull request that has
+had no run since — every run rewrites the comment in place.
 
 **Before believing a green PHPUnit run, check the database was there.** The
 database-backed tests `markTestSkipped` when the server does not answer, so

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,6 +62,24 @@ jobs:
     # takes a few minutes; this is a ceiling, not a target.
     timeout-minutes: 20
 
+    # THE ONE FACT THE STATUS JOB BELOW NEEDS, and it comes from the action
+    # rather than from a guess. In anthropics/claude-code-action's
+    # src/entrypoints/run.ts, the workflow-validation refusal does
+    #
+    #     core.setOutput("skipped_due_to_workflow_validation_mismatch", "true");
+    #     return;                                    // line 182
+    #     ...
+    #     core.setOutput("conclusion", claudeResult.conclusion);   // line 315
+    #
+    # so `conclusion` is EMPTY when the action declined to run and carries
+    # `success`/`failure` once Claude has actually run. (The mismatch output
+    # itself is internal to the action — action.yml does not re-export it —
+    # which is why this reads the presence of `conclusion` instead.)
+    #
+    # Empty therefore means "nothing was reviewed", with no clock involved.
+    outputs:
+      conclusion: ${{ steps.claude.outputs.conclusion }}
+
     permissions:
       contents: read
       pull-requests: read
@@ -117,9 +135,14 @@ jobs:
       # exactly one account has it. Enable the rule the day a second person
       # gets write access — that is when a code owner distinct from the
       # author exists, and when the gap acquires someone who could use it.
-      # Until then the tell is the clock: a green `Claude review` that took
-      # about fifteen seconds reviewed nothing.
+      # Until then the tell is the `Claude review status` comment below,
+      # which reads the action's own `conclusion` output and says outright
+      # whether Claude ran. It used to read the clock, and got it wrong
+      # often enough to warrant issue #159 — see that job for why.
       - uses: anthropics/claude-code-action@d9a44dc489924665d246f0fd0508d102211be397 # v1
+        # The id is load-bearing: it is what lets the job above export
+        # this step's `conclusion` output to the status job.
+        id: claude
         with:
           # Authenticates against the maintainer's Claude subscription
           # rather than a metered API key. Generated with `claude
@@ -165,10 +188,26 @@ jobs:
   # Claude, and its comment is authored by the workflow rather than by
   # Claude, so it cannot trip that rule.
   #
-  # The duration is the load-bearing part. A workflow-mismatch skip exits
-  # `success` in about fifteen seconds; a real review takes minutes. Reading
-  # the clock is what turns "green" into a statement about whether anything
-  # was read, without anyone opening the run log.
+  # HOW IT TELLS THE TWO APART, and why it no longer reads the clock.
+  #
+  # This job used to decide on the review job's duration: under 60 seconds
+  # meant a skip, over it meant a review. That was wrong often enough to be
+  # worse than useless, and issue #159 is the report. The premise — "a real
+  # review takes minutes" — only holds when the review has findings to
+  # write. A clean review posts nothing and finishes in about 20 seconds of
+  # model time; measured across twelve consecutive runs on this repository,
+  # those land between 55 and 70 seconds of job time, straddling the
+  # threshold. So the verdict on a review that found nothing was close to a
+  # coin flip, and it announced "green without a review" over a review that
+  # had genuinely run, cost real subscription usage, and read the whole diff.
+  #
+  # The signal it uses now is the action's own `conclusion` output, which is
+  # empty exactly when the action returned before running Claude — see the
+  # review job's `outputs:` block for the two lines of run.ts that make that
+  # true. Deterministic, and it stays right whatever a review costs.
+  #
+  # The duration is still reported. It is informative — a reader can see
+  # what the run spent — but it decides nothing.
   status:
     name: Claude review status
     needs: review
@@ -197,6 +236,9 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REVIEW_RESULT: ${{ needs.review.result }}
+          # Empty when the action declined to run at all; `success` or
+          # `failure` once Claude has run. This is the verdict's source.
+          REVIEW_CONCLUSION: ${{ needs.review.outputs.conclusion }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # The marker identifies this workflow's own comment so each run
           # rewrites it instead of adding another. It is invisible in the
@@ -221,19 +263,25 @@ jobs:
             elapsed="unknown"
           fi
 
-          # A skip and a clean review are both `success`; only the clock
-          # separates them. 60 s is far above the ~15 s a skip takes and far
-          # below the minutes a review takes, so neither case lands near it.
+          # A skip and a clean review are both `success`, so the job result
+          # alone cannot separate them — but the action's `conclusion` can:
+          # it is set only after Claude has run. An empty value is read as
+          # "not reviewed", which is the safe direction: this comment must
+          # never claim a review that did not happen.
           if [[ "${REVIEW_RESULT}" != "success" ]]; then
             verdict="**The review did not complete** (\`${REVIEW_RESULT}\`). Nothing was reviewed — treat this pull request as unread by Claude."
-          elif [[ "${seconds}" -ge 0 && "${seconds}" -lt 60 ]]; then
-            verdict="**Green without a review.** The job succeeded in ${elapsed}, which is the signature of the action declining to run — it does that when this workflow file differs from the copy on \`main\`. Read the diff yourself, or merge the workflow change first and re-run."
+          elif [[ -z "${REVIEW_CONCLUSION}" ]]; then
+            verdict="**Green without a review.** The job succeeded without the action ever running Claude — it declines when this workflow file differs from the copy on \`main\`. Read the diff yourself, or merge the workflow change first and re-run."
           else
             verdict="**Reviewed, nothing to report.** Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran."
           fi
 
-          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. See `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
-            "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${elapsed}" "${RUN_URL}")"
+          # `-` rather than an empty cell: a blank there reads as a
+          # rendering accident, and this row is the one the verdict rests on.
+          conclusion_cell="${REVIEW_CONCLUSION:--}"
+
+          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Claude ran | `%s` |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. The verdict is read from the action'"'"'s own `conclusion` output, not from the duration — see `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
+            "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${conclusion_cell}" "${elapsed}" "${RUN_URL}")"
 
           jq -n --arg body "${body}" '{body: $body}' > payload.json
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -280,7 +280,7 @@ jobs:
           # rendering accident, and this row is the one the verdict rests on.
           conclusion_cell="${REVIEW_CONCLUSION:--}"
 
-          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Claude ran | `%s` |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. The verdict is read from the action'"'"'s own `conclusion` output, not from the duration — see `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
+          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Claude ran | `%s` |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. The verdict comes from the job'"'"'s result and the action'"'"'s own `conclusion` output, never from the duration. See `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
             "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${conclusion_cell}" "${elapsed}" "${RUN_URL}")"
 
           jq -n --arg body "${body}" '{body: $body}' > payload.json

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -385,11 +385,18 @@ nothing**:
 - Database-backed tests **skip** rather than fail without a server, so
   `phpunit` is green having tested none of them.
 - `Claude review` exits **success** when it refuses to run over a
-  workflow-file mismatch, so the check is green in about fifteen seconds
-  having reviewed nothing — and that happens precisely on a pull request
-  editing the reviewer. This is the one on the list with a reader attached:
-  the `Claude review status` comment names which of the two a green check
-  was, judged on the run's duration.
+  workflow-file mismatch, so the check is green having reviewed nothing —
+  and that happens precisely on a pull request editing the reviewer. This
+  is the one on the list with a reader attached: the `Claude review status`
+  comment names which of the two a green check was, reading the action's
+  own `conclusion` output, which is set only once Claude has run.
+  **The reader itself was the next instance of this failure mode**: it
+  first judged on the run's duration, on the premise that a real review
+  takes minutes. A review that finds nothing takes about as long as a
+  refusal, so the verdict was near random on exactly the pull requests it
+  was meant to reassure — green checks reported as unread, and no way to
+  tell a true report from a false one (issue #159). A heuristic standing in
+  for a fact is the same defect one level up.
 - A `CODEOWNERS` entry naming a non-collaborator is **ignored silently**, so
   a protection rule can be enabled, appear active, and match nothing.
 - A local reproduction that runs on the wrong database engine, or without


### PR DESCRIPTION
## Description

Closes #159.

### What was wrong

`Claude review status` decided between *"reviewed"* and *"green without a review"* by **timing the review job**: under 60 s meant the action had declined to run. The premise written next to that threshold — *"a real review takes minutes"* — only holds when the review has findings to write. A clean review posts nothing and finishes in about **20 s of model time**; measured across the last twelve runs of `claude-review.yml` on this repository, those land between **55 and 70 s of job time**, straddling the threshold. On a pull request the reviewer read and passed, the verdict was close to a coin flip.

It fired on the first run of #161. The run log:

```json
{ "type": "result", "subtype": "success", "is_error": false,
  "duration_ms": 22164, "num_turns": 6, "total_cost_usd": 0.1787 }
```
```
No buffered inline comments
```

A real review, 6 turns, real subscription usage, the whole diff read — reported to the maintainer as having read nothing.

### The fix

The action already emits an exact signal. In `anthropics/claude-code-action` at the pinned SHA, `src/entrypoints/run.ts`:

```ts
core.setOutput("skipped_due_to_workflow_validation_mismatch", "true");
console.log("Exiting due to workflow validation skip");
return;                                                   // line 182
...
core.setOutput("conclusion", claudeResult.conclusion);    // line 315
```

The `return` precedes line 315, so **`conclusion` is empty when the action declined and carries `success`/`failure` once Claude has actually run.** (The mismatch output itself is internal — `action.yml` does not re-export it — which is why this reads the presence of `conclusion` instead.)

So: the action step gets an `id`, the `review` job exports that output, and `status` decides on it. An empty value is read as *not reviewed* — the safe direction, since this comment must never claim a review that did not happen.

The duration stays in the table beside a new `Claude ran` row. Worth seeing; decides nothing.

### Verification

The `status` script was extracted from the finished workflow and run against a stubbed `gh` for all three branches:

| `REVIEW_RESULT` | `REVIEW_CONCLUSION` | Verdict |
|---|---|---|
| `success` | `success` | **Reviewed, nothing to report.** ← the case that used to misfire |
| `success` | *(empty)* | **Green without a review.** |
| `failure` | *(empty)* | **The review did not complete.** |

### Known consequence

This pull request edits `claude-review.yml`, so the action will decline to run on it and `Claude review` will be green without a review — the documented gap. With this change in place the status comment will say so **for the right reason and deterministically**, which is as close to a live demonstration as the fix can get. Read the diff by hand.

### Documentation

`docs/quality-pipeline.md` and `.claude/skills/steward/SKILL.md` both asserted the clock; `AGENTS.md` § Pipeline documentation maintenance says both or neither, so both are corrected. The pipeline map keeps the episode rather than tidying it away: the reader built to catch *"something green that proved nothing"* had itself become an instance of it, which is the same defect one level up.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French — not applicable, nothing user-facing
- [x] Automated tests are written/updated for this change — no test layer covers a workflow file; the three branches were exercised directly against the extracted script (table above)
- [x] Tests pass locally (`vendor/bin/phpunit`) — no PHP touched
- [x] PHPStan passes (`vendor/bin/phpstan analyse`) — no PHP touched
- [x] If this PR changes `public/assets/js/` behavior — not applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ReJw9KFV8QHeK2YfE2j64

---
_Generated by [Claude Code](https://claude.ai/code/session_013ReJw9KFV8QHeK2YfE2j64)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Review status comments now accurately indicate whether the automated review ran, was skipped, or completed.
  - Status comments display the review outcome directly, while elapsed time is shown only as informational detail.
  - Workflows now distinguish configuration mismatches from completed reviews more reliably.

- **Documentation**
  - Updated guidance explains how to interpret review status and outcomes.
  - Clarified that duration alone does not confirm whether a review occurred.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->