### PR TITLE
Fusionner sur une instruction, pas sur une veille

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -273,12 +273,14 @@ want.
 
 Carry it out by **arming auto-merge**, not by watching the checks:
 
-```
+```shell
 gh pr merge <number> --squash --auto
 ```
 
 or, with no GitHub CLI on the box (a session running on the web), the
-GitHub MCP server's `enable_pr_auto_merge` with `mergeMethod: SQUASH`.
+GitHub MCP server's `enable_pr_auto_merge` with `mergeMethod: SQUASH`. If
+your build of that server has neither, say so — **never** substitute
+`merge_pull_request`, which merges on the spot instead of arming.
 
 Confirm first what you would confirm before merging by hand — no open
 thread, the checklist honestly filled, nothing of your own left unfiled —

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -282,11 +282,17 @@ GitHub MCP server's `enable_pr_auto_merge` with `mergeMethod: SQUASH`. If
 your build of that server has neither, say so — **never** substitute
 `merge_pull_request`, which merges on the spot instead of arming.
 
-Confirm first what you would confirm before merging by hand — no open
-thread, the checklist honestly filled, nothing of your own left unfiled —
-because arming it *is* merging. Then GitHub lands it the moment the ruleset
-is satisfied, whether or not you are still here. If everything is already
-green the same command merges immediately.
+Confirm first what you would confirm before merging by hand, because arming
+it *is* merging: **every check green on the current head**, no open thread,
+the checklist honestly filled, nothing of your own left unfiled. Then GitHub
+lands it the moment the ruleset is satisfied, whether or not you are still
+here. If everything is already green the same command merges immediately.
+
+The CI confirmation is not a formality the ruleset would catch for you. Only
+`Claude review` is a required context, and the `code_scanning` rule waits on
+CodeQL and SonarCloud alone — so a red `database-mariadb`, `Authorization
+matrix` or `Dynamic scan (passive)` blocks nothing. Arm on one of those and
+GitHub merges it.
 
 Do not poll the PR instead. That is what cost #152 four CI cycles and three
 interruptions on 2026-09-05, and it is why auto-merge is enabled at all

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -267,8 +267,28 @@ everything finally went green, not because the maintainer seems likely to
 agree. Green and merge-ready is where your work stops and you say so.
 
 When the maintainer explicitly asks you to merge, that instruction is the
-authorization and you carry it out: confirm every check is green on the
-current head, that no thread is open, and that the PR is actually
-mergeable, then merge — matching how this repository merges rather than
-inventing a style. Nothing else substitutes for that instruction: not the
-PR's state, not this file, not your own reading of what they would want.
+authorization and you carry it out. Nothing else substitutes for it: not
+the PR's state, not this file, not your own reading of what they would
+want.
+
+Carry it out by **arming auto-merge**, not by watching the checks:
+
+```
+gh pr merge <number> --squash --auto
+```
+
+or, with no GitHub CLI on the box (a session running on the web), the
+GitHub MCP server's `enable_pr_auto_merge` with `mergeMethod: SQUASH`.
+
+Confirm first what you would confirm before merging by hand — no open
+thread, the checklist honestly filled, nothing of your own left unfiled —
+because arming it *is* merging. Then GitHub lands it the moment the ruleset
+is satisfied, whether or not you are still here. If everything is already
+green the same command merges immediately.
+
+Do not poll the PR instead. That is what cost #152 four CI cycles and three
+interruptions on 2026-09-05, and it is why auto-merge is enabled at all
+(AGENTS.md § Merging a pull request, `docs/quality-pipeline.md`
+§ Auto-merge). Two failure modes to know: auto-merge never updates a branch
+that has fallen behind `main`, and it is disarmed in silence by a change of
+base branch or a push from an account without write access.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -395,15 +395,21 @@ merge-ready is where your work stops and you say so.
 
 With it, arm **auto-merge** rather than watching the pull request:
 
-```
+```shell
 gh pr merge <number> --squash --auto
 ```
 
 Where `gh` is not installed — a Claude Code session running on the web has
-no GitHub CLI — the same thing is the GitHub MCP server's
-`enable_pr_auto_merge` with `mergeMethod: SQUASH`. It fails with *"Auto-merge
-is not enabled for this repository"* if the setting below ever gets turned
-off, which is the one error worth recognising rather than working around.
+no GitHub CLI — use the GitHub MCP server's `enable_pr_auto_merge` with
+`mergeMethod: SQUASH`, which is what armed #168. Not every build of that
+server exposes it; when it is missing, say so and hand the maintainer the
+`gh` line above.
+
+**`merge_pull_request` is not the fallback.** It merges immediately, which
+is a different act from arming: it lands the pull request whether or not
+the checks have finished. Reaching for it because the auto-merge tool was
+not there would turn "arm this and let the ruleset decide" into "merge it
+now", unreviewed and untested, on an instruction that said neither.
 
 GitHub then merges the moment the ruleset on `main` is satisfied, and the
 instruction is carried out without the maintainer being called back. Polling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -386,6 +386,44 @@ All email sent via `MailService::send()`. Never send email directly. The service
 
 Use `SchedulerService` for any delayed or timed action. Never use `sleep()`, cron-specific code, or ad-hoc timing logic. Declare task handlers in `module.json`.
 
+## Merging a pull request
+
+**The maintainer's instruction is the only authorization to merge**, and
+nothing substitutes for it — not a green pipeline, not this file, not your
+reading of what they would probably want. Without it, green and
+merge-ready is where your work stops and you say so.
+
+With it, arm **auto-merge** rather than watching the pull request:
+
+```
+gh pr merge <number> --squash --auto
+```
+
+Where `gh` is not installed — a Claude Code session running on the web has
+no GitHub CLI — the same thing is the GitHub MCP server's
+`enable_pr_auto_merge` with `mergeMethod: SQUASH`. It fails with *"Auto-merge
+is not enabled for this repository"* if the setting below ever gets turned
+off, which is the one error worth recognising rather than working around.
+
+GitHub then merges the moment the ruleset on `main` is satisfied, and the
+instruction is carried out without the maintainer being called back. Polling
+a pull request for an hour is not diligence — on 2026-09-05 that cost four
+CI cycles and three interruptions on #152, and auto-merge is the answer
+this repository chose (`docs/quality-pipeline.md` § Auto-merge).
+
+Arming it is *merging*, so everything that must be true before a merge must
+be true before you arm it: every review thread replied to and resolved on
+purpose rather than to clear the way, the PR template's checklist honestly
+filled, and no finding of your own left unfiled. What you must never do is
+arm it and walk away from a pull request you have not finished — auto-merge
+does not wait for you to come back.
+
+Two things it does not do, and both have bitten this project. It does
+**not** update a branch that has fallen behind `main` — the ruleset does not
+demand that any more, but the day it does again, an armed pull request just
+sits there. And it is **disarmed in silence** by a change of base branch or
+a push from an account without write access.
+
 ## Releases
 
 When the user asks to release a new version (`scripts/release.sh`), do this **in this order**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,11 +418,23 @@ CI cycles and three interruptions on #152, and auto-merge is the answer
 this repository chose (`docs/quality-pipeline.md` § Auto-merge).
 
 Arming it is *merging*, so everything that must be true before a merge must
-be true before you arm it: every review thread replied to and resolved on
-purpose rather than to clear the way, the PR template's checklist honestly
-filled, and no finding of your own left unfiled. What you must never do is
-arm it and walk away from a pull request you have not finished — auto-merge
-does not wait for you to come back.
+be true before you arm it:
+
+- **Every check green on the current head.** Not "the required one" —
+  every one. The ruleset requires a single context, `Claude review`, so
+  GitHub will happily land a pull request whose `database-mariadb`,
+  `Authorization matrix` or `Dynamic scan (passive)` is red: none of the
+  three is required, and none feeds the `code_scanning` rule that waits on
+  CodeQL and SonarCloud. The gate that stops that is you, before you arm.
+- **Every review thread replied to and resolved on purpose**, rather than
+  resolved to clear the way.
+- **The PR template's checklist honestly filled**, and no finding of your
+  own left unfiled.
+
+What you must never do is arm it and walk away from a pull request you have
+not finished — auto-merge does not wait for you to come back. If a check is
+still running, either wait for it or say you are arming on an incomplete
+pipeline and why.
 
 Two things it does not do, and both have bitten this project. It does
 **not** update a branch that has fallen behind `main` — the ruleset does not

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -419,6 +419,15 @@ a change of base branch, disarms auto-merge silently.** Nothing announces
 it. A pull request that was going to land and then simply did not is the
 first thing to check.
 
+And note what it does *not* wait for. The required-check list is one
+context, `Claude review`, and the `code_scanning` rule above waits on CodeQL
+and SonarCloud — so `database-mariadb`, `Authorization matrix` and
+`Dynamic scan (passive)` gate nothing at all. An armed pull request whose
+`database-mariadb` is red still merges. Widening the required list would fix
+that at the source; until then the gate is the person or agent arming it,
+which is why AGENTS.md § Merging a pull request puts "every check green on
+the current head" first among the things to confirm.
+
 ### Private vulnerability reporting
 
 *Settings → Code security → Private vulnerability reporting*
@@ -525,10 +534,13 @@ a fork. On such a pull request:
   than a workflow — whether it reviews a given fork pull request is its own
   setting, not something this repository controls.
 
-If `Claude review` is ever made a *required* status check, a pull request
-from a fork becomes permanently unmergeable, since the check can never
-report. That is a governance decision about accepting outside
-contributions, not a configuration detail.
+`Claude review` **is** a required status check on `main` — the only one —
+so a pull request from a fork is permanently unmergeable here: the check it
+needs can never report. That is live, not hypothetical, and it is a
+governance decision about accepting outside contributions rather than a
+configuration detail. Reopening the repository to outside contributions
+means revisiting it; `.github/workflows/claude-review.yml` carries the same
+note next to the token it depends on.
 
 ## The failure mode this repository keeps meeting
 

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -365,9 +365,48 @@ an error.
   itself a merge.
 - **Require status checks to pass.** A check only appears in GitHub's list
   after it has run at least once, so add each one after its first run, not
-  before.
+  before. `Claude review` is the one required context.
+- **Require branches to be up to date before merging** — *deliberately off.*
+  It is the sub-option of the rule above, and turning it on again brings back
+  the failure it was turned off for: with it on, a pull request must be even
+  with `main` at the moment of merging, so every push to `main` invalidates
+  every open pull request and each one has to re-run a fifteen-minute CI
+  before it can land. A single agent never notices; a burst does. On
+  2026-09-05 five pull requests landed on `main` within the hour, and #152
+  lost four consecutive CI cycles to it — each time green, each time stale
+  again before the merge call, and each recovery needed a human to be told.
+  GitHub reports that state as `Required status check "Claude review" is
+  expected`, which reads like a check that never ran rather than a branch
+  that fell behind.
+  What it protected against is real and is now caught one step later:
+  two pull requests, each green alone, whose combination is not. CI runs on
+  every push to `main` (`ci.yml`), so that combination is tested — after it
+  lands rather than before. The alternative that keeps the guarantee without
+  the stall is a merge queue, and it is not free here: it needs every
+  gating check to report on `merge_group`, and `Claude review` is bound to a
+  pull request (its prompt names `github.event.pull_request.number`) while
+  CodeQL runs as GitHub-managed default setup that this repository cannot
+  give a trigger to. Revisit it if the combination failure ever actually
+  bites.
 - **Require review from Code Owners** — *not enabled, and not currently
   enableable.* See below.
+
+### Auto-merge
+
+*Settings → General → Pull Requests*
+
+**Allow auto-merge — enabled.** It is what lets an agent carry out
+"merge this" without sitting on the pull request: GitHub merges the moment
+the ruleset above is satisfied, and nothing has to be watched or asked
+again. It grants nothing — a pull request with auto-merge armed still
+merges only when every rule passes — so the checklist in AGENTS.md
+§ Merging a pull request is about *when an agent may arm it*, never about
+what it lets through.
+
+Note what turns it off again: **a push by someone without write access, or
+a change of base branch, disarms auto-merge silently.** Nothing announces
+it. A pull request that was going to land and then simply did not is the
+first thing to check.
 
 ### Private vulnerability reporting
 
@@ -509,6 +548,9 @@ nothing**:
 - The release **Security gate passes on a permission gap**: denied access to
   the CodeQL or Dependabot alert API is a warning, not a refusal, so a
   release can be published with those two sources never consulted.
+- **Auto-merge is disarmed in silence** by a push from someone without write
+  access or by a change of base branch. The pull request simply stops being
+  on its way to `main`, looking exactly like one nobody has merged yet.
 - **An issue form's label is dropped in silence when the label does not
   exist.** GitHub creates the issue anyway — no error on it, nothing in any
   log — so a report arrives with no triage state and looks exactly like one

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -381,8 +381,19 @@ an error.
   What it protected against is real and is now caught one step later:
   two pull requests, each green alone, whose combination is not. CI runs on
   every push to `main` (`ci.yml`), so that combination is tested — after it
-  lands rather than before. The alternative that keeps the guarantee without
-  the stall is a merge queue, and it is not free here: it needs every
+  lands rather than before, which means somebody has to answer for the
+  window in between. **The maintainer does**, on the failure notification
+  GitHub sends for a red run on `main`, and the answer is forward: the
+  second pull request's author fixes it in a new pull request, the way any
+  other red `main` is handled here. Not a revert by default — the two
+  changes are both wanted, and reverting the one that merged second
+  punishes an ordering nobody chose. Revert only when the fix is not
+  quick and `main` has to be green for a release. The window is small by
+  construction: it opens only when two pull requests are in flight at once,
+  which on a repository with one maintainer means a burst, and it closes at
+  the next push.
+  The alternative that keeps the guarantee without the stall is a merge
+  queue, and it is not free here: it needs every
   gating check to report on `merge_group`, and `Claude review` is bound to a
   pull request (its prompt names `github.event.pull_request.number`) while
   CodeQL runs as GitHub-managed default setup that this repository cannot

--- a/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
+++ b/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
@@ -133,6 +133,37 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
     }
 
     /**
+     * The step that stops auto-merge from landing a red pull request.
+     *
+     * Only `Claude review` is a required context, and the `code_scanning`
+     * rule waits on CodeQL and SonarCloud — so `database-mariadb`,
+     * `Authorization matrix` and `Dynamic scan (passive)` gate nothing.
+     * A first draft of this rule listed the thread and checklist items and
+     * left CI out, which would have let an agent arm a pull request whose
+     * database job was red and walk away. The ruleset will not catch that;
+     * only the instruction will.
+     */
+    public function testTheRuleRequiresGreenChecksBeforeArming(): void
+    {
+        foreach (['AGENTS.md', '.claude/skills/steward/SKILL.md'] as $file) {
+            $contents = self::read($file);
+
+            $this->assertStringContainsString(
+                'every check green on the current head',
+                strtolower($contents),
+                $file . ' no longer tells an agent to confirm CI before arming auto-merge'
+            );
+            // The reason, without which the step reads as belt-and-braces
+            // and gets dropped by the next person tightening the prose.
+            $this->assertStringContainsString(
+                'database-mariadb',
+                $contents,
+                $file . ' no longer names a check the ruleset does not require'
+            );
+        }
+    }
+
+    /**
      * The setting lives in the repository's settings, where no diff shows
      * it — the category docs/quality-pipeline.md exists to carry.
      */

--- a/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
+++ b/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
@@ -69,7 +69,7 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
         $rules = self::agentRules();
 
         $this->assertStringContainsString(
-            'only authorization to merge',
+            "The maintainer's instruction is the only authorization to merge",
             $rules,
             'the sentence that keeps auto-merge from becoming a self-service merge button is gone'
         );
@@ -82,12 +82,22 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
     public function testTheRuleNamesTheCommandThatArmsIt(): void
     {
         foreach (['AGENTS.md', '.claude/skills/steward/SKILL.md'] as $file) {
+            // The whole line, not its pieces: `gh pr merge` without
+            // `--auto` is the command that merges on the spot, and an
+            // assertion satisfied by either one would not notice the
+            // difference.
             $this->assertStringContainsString(
-                'gh pr merge',
+                'gh pr merge <number> --squash --auto',
                 self::read($file),
                 $file . ' no longer names the command that arms auto-merge'
             );
-            $this->assertStringContainsString('--auto', self::read($file), $file);
+            // The trap the same files warn about, pinned here because it
+            // is the mistake an agent makes when the tool is missing.
+            $this->assertStringContainsString(
+                'merge_pull_request',
+                self::read($file),
+                $file . ' no longer warns that merge_pull_request merges instead of arming'
+            );
         }
     }
 
@@ -106,10 +116,18 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
                 $contents,
                 $file . ' no longer records that auto-merge can be turned off with no notice'
             );
+            // Both halves. A push from an account without write access is
+            // the one nobody expects, so an assertion that only covered
+            // the base-branch change would let it go.
             $this->assertStringContainsString(
                 'base branch',
                 $contents,
-                $file . ' no longer names what disarms it'
+                $file . ' no longer names the base-branch change as disarming it'
+            );
+            $this->assertStringContainsString(
+                'without write access',
+                $contents,
+                $file . ' no longer names the non-write push as disarming it'
             );
         }
     }
@@ -124,6 +142,9 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
 
         $this->assertStringContainsString('### Auto-merge', $map);
         $this->assertStringContainsString('Settings → General → Pull Requests', $map);
+        // The state, not just the location: the section is worth nothing
+        // to a reader who cannot tell whether the box is meant to be on.
+        $this->assertStringContainsString('Allow auto-merge — enabled', $map);
     }
 
     /**
@@ -140,5 +161,8 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
         // What replaces the guarantee, without which the entry is just a
         // preference rather than a trade somebody made.
         $this->assertStringContainsString('every push to `main`', $map);
+        // And who answers when that later run goes red, without which the
+        // trade names a safety net nobody is holding.
+        $this->assertStringContainsString('**The maintainer does**', $map);
     }
 }

--- a/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
+++ b/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The merge rule has two halves, and dropping either one is a real failure.
+ *
+ * On 2026-09-05 the ruleset on `main` still required a pull request to be
+ * even with the base branch at the moment of merging. Five pull requests
+ * landed within the hour, so #152 went green, fell behind, went green
+ * again — four times — and each recovery needed a human to be told, because
+ * the agent holding the instruction to merge was polling the pull request
+ * rather than arming anything. GitHub reports that state as
+ * `Required status check "Claude review" is expected`, which reads like a
+ * check that never ran rather than a branch that fell behind, so the hour
+ * went into diagnosing the wrong thing.
+ *
+ * The fix was a repository setting (auto-merge, now enabled) plus an
+ * instruction, and the instruction is the fragile half: a setting that
+ * nothing tells an agent to use buys nothing, and `gh pr merge --auto` is
+ * exactly the line an editing pass shortens away as an implementation
+ * detail.
+ *
+ * The other half is the sentence that keeps auto-merge from becoming a
+ * self-service merge button. Arming it IS merging — GitHub lands the pull
+ * request without asking again — so the rule that only the maintainer's
+ * instruction authorises a merge has to survive next to it, in the same
+ * file, or the convenience quietly repeals the guard.
+ *
+ * Like Tests\Architecture\CodeQlRuleIsWrittenDownTest, this checks only
+ * that the rule is still there to obey. No test can check that anybody
+ * obeyed it.
+ */
+final class AutoMergeRuleIsWrittenDownTest extends TestCase
+{
+    private static function read(string $relativePath): string
+    {
+        $path = dirname(__DIR__, 2) . '/' . $relativePath;
+        $contents = file_get_contents($path);
+        self::assertIsString($contents, $relativePath . ' is unreadable');
+
+        return $contents;
+    }
+
+    private static function agentRules(): string
+    {
+        return self::read('AGENTS.md');
+    }
+
+    public function testTheRuleHasItsOwnSection(): void
+    {
+        $this->assertStringContainsString(
+            '## Merging a pull request',
+            self::agentRules(),
+            'AGENTS.md no longer tells an agent how to carry out an instruction to merge'
+        );
+    }
+
+    /**
+     * The guard, kept verbatim. Without it the section below reads as
+     * permission to merge whatever is green.
+     */
+    public function testOnlyTheMaintainersInstructionAuthorisesAMerge(): void
+    {
+        $rules = self::agentRules();
+
+        $this->assertStringContainsString(
+            'only authorization to merge',
+            $rules,
+            'the sentence that keeps auto-merge from becoming a self-service merge button is gone'
+        );
+    }
+
+    /**
+     * The command itself. "Enable auto-merge" without it sends the next
+     * agent to the web UI, which is where the polling started.
+     */
+    public function testTheRuleNamesTheCommandThatArmsIt(): void
+    {
+        foreach (['AGENTS.md', '.claude/skills/steward/SKILL.md'] as $file) {
+            $this->assertStringContainsString(
+                'gh pr merge',
+                self::read($file),
+                $file . ' no longer names the command that arms auto-merge'
+            );
+            $this->assertStringContainsString('--auto', self::read($file), $file);
+        }
+    }
+
+    /**
+     * Both are silent failures, which is why they are written down rather
+     * than left to be rediscovered: an armed pull request that stops being
+     * on its way to `main` looks exactly like one nobody has merged yet.
+     */
+    public function testTheTwoSilentFailuresAreRecorded(): void
+    {
+        foreach (['AGENTS.md', 'docs/quality-pipeline.md'] as $file) {
+            $contents = self::read($file);
+
+            $this->assertStringContainsString(
+                'disarmed in silence',
+                $contents,
+                $file . ' no longer records that auto-merge can be turned off with no notice'
+            );
+            $this->assertStringContainsString(
+                'base branch',
+                $contents,
+                $file . ' no longer names what disarms it'
+            );
+        }
+    }
+
+    /**
+     * The setting lives in the repository's settings, where no diff shows
+     * it — the category docs/quality-pipeline.md exists to carry.
+     */
+    public function testThePipelineMapCarriesTheSetting(): void
+    {
+        $map = self::read('docs/quality-pipeline.md');
+
+        $this->assertStringContainsString('### Auto-merge', $map);
+        $this->assertStringContainsString('Settings → General → Pull Requests', $map);
+    }
+
+    /**
+     * The sub-option is off on purpose, and "on purpose" is the whole
+     * content: it looks like an obvious safety improvement to anyone who
+     * finds it off and does not know what it cost.
+     */
+    public function testTheMapSaysWhyBranchesNeedNotBeUpToDate(): void
+    {
+        $map = self::read('docs/quality-pipeline.md');
+
+        $this->assertStringContainsString('Require branches to be up to date before merging', $map);
+        $this->assertStringContainsString('deliberately off', $map);
+        // What replaces the guarantee, without which the entry is just a
+        // preference rather than a trade somebody made.
+        $this->assertStringContainsString('every push to `main`', $map);
+    }
+}


### PR DESCRIPTION
## Description

PR #152 a passé une heure et demie à ne pas fusionner, et rien de tout cela n'était la review que tout le monde regardait.

Le ruleset `Main` exigeait qu'une PR soit à jour avec la base **au moment de la fusion** (`strict_required_status_checks_policy: true`). Cinq PR ont atterri sur `main` dans cette heure-là — #161, #162, #164, #165, #166 — et #152 est passée au vert, a pris du retard, et est repassée au vert quatre fois de suite. GitHub rapporte cet état comme `Required status check "Claude review" is expected`, ce qui se lit comme un check qui n'a jamais tourné plutôt que comme une branche en retard : le diagnostic est parti du mauvais côté, et chaque reprise a demandé qu'on prévienne le mainteneur.

Deux changements, et aucun n'est du code.

### La sous-option « branche à jour » est retirée

Ce qu'elle protégeait est réel — deux PR vertes chacune de son côté dont la combinaison ne l'est pas — et c'est désormais attrapé par la CI sur chaque push vers `main`, après l'atterrissage plutôt qu'avant. `docs/quality-pipeline.md` l'écrit comme un arbitrage et non comme une préférence, parce que « Require branches to be up to date » ressemble à un gain de sûreté gratuit pour qui la trouvera décochée sans savoir ce qu'elle a coûté.

La file d'attente de fusion garde la garantie sans le blocage, et c'était le premier choix ici. Elle est consignée comme écartée-pour-l'instant avec sa raison : elle exige que **chaque** contrôle bloquant sache se déclencher sur `merge_group`, et deux des trois ne le peuvent pas — `Claude review` est lié à une PR (son prompt nomme `github.event.pull_request.number`) et CodeQL tourne en *default setup* géré par GitHub, auquel ce dépôt ne peut pas ajouter de déclencheur.

### L'auto-merge est activé

C'est la moitié qu'un réglage ne porte pas tout seul. Un agent qui détient une instruction de fusionner **arme** l'auto-merge au lieu de surveiller la PR, et l'instruction s'exécute sans qu'on rappelle le mainteneur. `AGENTS.md` § Merging a pull request nomme la commande, son équivalent MCP là où `gh` n'existe pas, et ses deux modes de défaillance silencieux — l'auto-merge ne met jamais à jour une branche en retard, et il est désarmé sans un mot par un changement de base ou par une poussée d'un compte sans droit d'écriture.

À côté, la phrase qui l'empêche de devenir un bouton de fusion en libre-service : **armer l'auto-merge, c'est fusionner**, donc l'instruction du mainteneur reste la seule chose qui l'autorise. Le skill `steward` porte la même règle dans sa section « what done means ».

### Le test

`tests/Architecture/AutoMergeRuleIsWrittenDownTest.php`, sur le modèle de `CodeQlRuleIsWrittenDownTest` : il ne peut pas vérifier que quelqu'un a obéi à la règle, seulement qu'elle est toujours là pour être obéie. Une instruction que rien ne défend est une instruction qu'une passe de relecture supprime sans que personne ne la voie partir — et `gh pr merge --auto` est exactement la ligne qu'on abrège en « détail d'implémentation ». Vérifié rouge avec la section retirée (quatre de ses six échouent), vert avec elle.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`) — 15 457 tests, 54 952 assertions, 0 échec
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`) — no errors
- [x] If this PR changes `public/assets/js/` behavior: aucun changement sous `public/assets/js/`

## Les deux réglages que cette PR suppose

Ils vivent dans les paramètres du dépôt, où aucun diff ne les montre — la catégorie que `docs/quality-pipeline.md` existe pour porter :

1. **Settings → General → Pull Requests → « Allow auto-merge »** — coché.
2. **Ruleset `Main` → « Require status checks to pass » → « Require branches to be up to date before merging »** — décoché. Le check requis `Claude review` reste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbQrctJzTazTgkpT3cppTG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbQrctJzTazTgkpT3cppTG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated merge guidance to require explicit maintainer authorization before enabling automatic merging.
  - Added instructions for checking prerequisites, enabling auto-merge, and handling silent disarming or stale branches.
  - Clarified branch rules, including why branches do not need to be up to date and how this affects CI and merge queues.
  - Documented auto-merge behavior and related repository failure modes.

- **Tests**
  - Added automated checks to ensure the auto-merge policy remains consistently documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->