### PR TITLE
Attendre que la ligne du calendrier soit disposée, pas seulement lisible

### DIFF
--- a/tests/e2e/specs/calendar-check-waits-for-layout.spec.js
+++ b/tests/e2e/specs/calendar-check-waits-for-layout.spec.js
@@ -1,0 +1,78 @@
+// The one spec in this suite whose subject is the harness rather than the
+// application, and it earns the place: ../support/calendar.js is what every
+// calendar assertion in the other specs delegates to, and when it reads a
+// transient state as a failure it turns a green application red at random.
+//
+// That happened twice. #145 fixed the half where two rectangles came from
+// two different renders; #171 the half where one render was measured before
+// the browser had laid it out — both cells still at x = 0, stacked at the
+// left edge, and `two days of one week must sit side by side / Expected:
+// > 0 / Received: 0` on a calendar that was perfectly fine. Both surfaced
+// only under scripts/dast.sh, where ZAP and a TLS terminator widen every
+// window, and both were invisible to `npm run e2e` in the same run.
+//
+// Reproducing that by driving the real application would mean racing the
+// browser on purpose and hoping to lose. The state is reproduced here
+// instead: a grid that HAS `display: grid` — so the check's first poll is
+// satisfied at once — and has not yet received its columns, which is
+// exactly the window the geometry poll has to sit through.
+import { test, expect } from '@playwright/test';
+
+import { expectRendersAsACalendar } from '../support/calendar.js';
+
+/**
+ * The markup `partials/month_day_grid.html.twig` emits, reduced to what
+ * expectRendersAsACalendar() actually reads, with the real rule from
+ * public/assets/css/components.css.
+ *
+ * `body.not-laid-out-yet` is the transient: `display: grid` is already in
+ * force — the check's `expectWeekIsAGridRow()` poll passes immediately —
+ * while the seven columns are not, so every cell shares one column and
+ * every cell has the same x. That is the state measured on c818e3c.
+ *
+ * @param {boolean} stacked whether the grid starts without its columns
+ */
+function gridPage(stacked) {
+    const days = Array.from({ length: 7 }, (_, i) => `<div class="daygrid-day">${i + 1}</div>`).join('');
+
+    return `<!doctype html>
+<style>
+  .daygrid-week { display: grid; grid-template-columns: repeat(7, 1fr); }
+  .daygrid-day { min-height: 44px; }
+  body.not-laid-out-yet .daygrid-week { grid-template-columns: none; }
+</style>
+<body class="${stacked ? 'not-laid-out-yet' : ''}">
+  <div class="daygrid"><div class="daygrid-week">${days}</div></div>
+</body>`;
+}
+
+test('the calendar check waits for the row to be laid out instead of measuring the stack', async ({ page }) => {
+    await page.setContent(gridPage(true));
+
+    // The columns arrive late, as they do on a live grid — rental-calendar.js
+    // replacing #rental-calendar-fragment's innerHTML, calendar-chief.js
+    // rebuilding a month. Long enough that a check which does not wait
+    // cannot miss the stacked state, short enough to stay well inside the
+    // poll's budget.
+    await page.evaluate(() => {
+        setTimeout(() => document.body.classList.remove('not-laid-out-yet'), 1_000);
+    });
+
+    // The assertion IS that this resolves. Against the condition this
+    // replaced — a poll satisfied as soon as both rectangles were readable
+    // — it measures the stack, and `two days of one week must sit side by
+    // side` fails on x = 0 against x = 0.
+    await expectRendersAsACalendar(page.locator('.daygrid'));
+});
+
+test('and still refuses a grid that never receives its columns', async ({ page }) => {
+    // The other direction, which is what makes the wait above safe to add:
+    // a page that genuinely forgets its columns — the unstyled stack this
+    // whole helper exists to catch — must still fail. Waiting for a state
+    // that never comes is a timeout, not a pass.
+    await page.setContent(gridPage(true));
+
+    await expect(expectRendersAsACalendar(page.locator('.daygrid'))).rejects.toThrow(
+        /laid out side by side/,
+    );
+});

--- a/tests/e2e/support/calendar.js
+++ b/tests/e2e/support/calendar.js
@@ -42,50 +42,41 @@ async function expectWeekIsAGridRow(week) {
 }
 
 /**
- * @param {import('@playwright/test').Locator} grid A `.daygrid` element.
+ * The first two day cells of a week, measured together and waited for
+ * rather than sampled once.
+ *
+ * Two hazards, and the second is the one that kept coming back.
+ *
+ * A cell measured a millisecond ago can be DETACHED by the time the next
+ * line asks for its neighbour: these grids are live —
+ * public/assets/js/rental-calendar.js replaces #rental-calendar-fragment's
+ * innerHTML, calendar-chief.js rebuilds the month on a page. evaluateAll()
+ * runs once inside the page, so both rectangles come out of the same
+ * layout pass and a re-render cannot slip between them.
+ *
+ * But a single layout pass is not the same as a FINISHED one. Waiting only
+ * for the two rectangles to be readable returns as soon as the cells
+ * exist, which is before the grid has been laid out — both cells still at
+ * x = 0, stacked at the left edge. The caller's assertion then read that
+ * transient as a broken calendar: `two days of one week must sit side by
+ * side / Expected: > 0 / Received: 0`, intermittently and only under
+ * scripts/dast.sh, where every request crosses ZAP and a TLS terminator so
+ * every window is widest. The browser suite passed the same spec in the
+ * same run, which is what says it was never the calendar (#171).
+ *
+ * So the poll waits for what its message claims: the cells laid out side
+ * by side. This is exactly what expectWeekIsAGridRow() above does for
+ * `display`, and it weakens nothing for the same reason — a page that
+ * genuinely stacks its days never reaches that state, the poll times out,
+ * and the failure still names the symptom.
+ *
+ * @param {import('@playwright/test').Locator} days the week's day cells
+ * @returns {Promise<{first: {x: number, y: number, height: number}, second: {x: number, y: number}}>}
  */
-export async function expectRendersAsACalendar(grid) {
-    await expect(grid).toBeVisible();
+async function measureFirstTwoDays(days) {
+    /** @type {{first: {x: number, y: number, height: number}, second: {x: number, y: number}}|null} */
+    let box = null;
 
-    const week = grid.locator('.daygrid-week').first();
-
-    await expectWeekIsAGridRow(week);
-
-    // The observable consequence of that grid, stated in geometry: two
-    // days of the same week sit side by side. A future CSS change that
-    // keeps `display: grid` but loses the seven columns still fails here.
-    //
-    // A week is seven days — partials/month_day_grid.html.twig emits
-    // exactly that, padding included — so this is an invariant of the
-    // markup and not of any one month.
-    const days = week.locator('.daygrid-day');
-    await expect(days).toHaveCount(7);
-
-    // Both boxes measured in ONE page evaluation, and retried until the
-    // cells are there to measure.
-    //
-    // On the rental pages this grid is LIVE:
-    // public/assets/js/rental-calendar.js replaces
-    // #rental-calendar-fragment's innerHTML when a month is paged or an
-    // estimate recomputed. Two separate boundingBox() calls are two
-    // separate round trips to the browser, so the cell measured a
-    // millisecond ago can be detached — answering null — by the time the
-    // next line asks for its neighbour.
-    //
-    // Polling the pair until both answer fixes the null half and NOT the
-    // other half, which is the one that actually cost time: two non-null
-    // rectangles can still come from two DIFFERENT renders, and then the
-    // comparison below is between cells that never coexisted. That is how
-    // this read « two days of one week must share a row » as 8 px apart,
-    // intermittently, and only under scripts/dast.sh — where every request
-    // crosses ZAP and a TLS terminator, so the window between the two
-    // round trips is widest. The browser suite passed the same spec in the
-    // same run, which is what says it was never the calendar.
-    //
-    // evaluateAll() runs once inside the page: both rectangles come out of
-    // the same layout pass, and a re-render cannot slip between them.
-    /** @type {{first: {x: number, y: number, height: number}, second: {x: number}}} */
-    let box;
     await expect
         .poll(async () => {
             // ONE evaluation in the page, so both rectangles come from
@@ -107,9 +98,41 @@ export async function expectRendersAsACalendar(grid) {
             }
             box = pair;
 
-            return true;
-        }, { message: "the week's first two day cells must both be laid out at the same moment" })
+            // Not merely readable: actually laid out as a row.
+            return pair.second.x > pair.first.x;
+        }, { message: "the week's first two day cells must be laid out side by side" })
         .toBe(true);
+
+    if (box === null) {
+        throw new Error('unreachable: the poll only succeeds once both cells were measured');
+    }
+
+    return box;
+}
+
+/**
+ * @param {import('@playwright/test').Locator} grid A `.daygrid` element.
+ */
+export async function expectRendersAsACalendar(grid) {
+    await expect(grid).toBeVisible();
+
+    const week = grid.locator('.daygrid-week').first();
+
+    await expectWeekIsAGridRow(week);
+
+    // The observable consequence of that grid, stated in geometry: two
+    // days of the same week sit side by side. A future CSS change that
+    // keeps `display: grid` but loses the seven columns still fails here.
+    //
+    // A week is seven days — partials/month_day_grid.html.twig emits
+    // exactly that, padding included — so this is an invariant of the
+    // markup and not of any one month.
+    const days = week.locator('.daygrid-day');
+    await expect(days).toHaveCount(7);
+
+    // Measured together, and waited for until the row is actually laid
+    // out — see measureFirstTwoDays() for the two hazards that shape it.
+    const box = await measureFirstTwoDays(days);
 
     expect(box.second.x, 'two days of one week must sit side by side').toBeGreaterThan(box.first.x);
     expect(Math.abs(box.second.y - box.first.y), 'and share a row').toBeLessThan(2);
@@ -139,36 +162,10 @@ export async function expectRendersAsAnEventCalendar(container) {
     const days = week.locator('.calendar-day-cell');
     await expect(days).toHaveCount(7);
 
-    // The same paired poll as the day grid above, for the same reason:
+    // The same measurement as the day grid above, for the same reasons:
     // this month is live too — public/assets/js/calendar-chief.js rebuilds
-    // it on a month change — so measuring the two cells separately can
-    // measure one that no longer exists.
-    /** @type {{first: {x: number, y: number}, second: {x: number, y: number}}} */
-    let box;
-    await expect
-        .poll(async () => {
-            // ONE evaluation in the page, so both rectangles come from
-            // the same layout pass.
-            const pair = await days.evaluateAll((nodes) => {
-                if (nodes.length < 2) {
-                    return null;
-                }
-                const a = nodes[0].getBoundingClientRect();
-                const b = nodes[1].getBoundingClientRect();
-
-                return {
-                    first: { x: a.x, y: a.y, height: a.height },
-                    second: { x: b.x, y: b.y },
-                };
-            });
-            if (pair === null) {
-                return false;
-            }
-            box = pair;
-
-            return true;
-        }, { message: "the week's first two day cells must both be laid out at the same moment" })
-        .toBe(true);
+    // it on a month change.
+    const box = await measureFirstTwoDays(days);
 
     expect(box.second.x, 'two days of one week must sit side by side').toBeGreaterThan(box.first.x);
     expect(Math.abs(box.second.y - box.first.y), 'and share a row').toBeLessThan(2);


### PR DESCRIPTION
## Description

Corrige **#171**.

`Dynamic scan (passive)` est devenu rouge sur `c818e3c` avec `two days of one week must sit side by side / Expected: > 0 / Received: 0`, puis **vert sur une relance du même commit**, sans rien changer entre les deux. `End-to-end (browser)` avait passé le même spec dans le même run. Les deux cellules rapportaient `x = 0` : la grille était dans le DOM et pas encore disposée.

### Le mécanisme

Le `poll` autour de la mesure attendait que les deux rectangles soient **lisibles** — `pair !== null` — et non ce que son propre message annonçait (« must both be laid out »). Il rendait donc la main sur cet état transitoire, et l'assertion du caller transformait un état qui méritait d'être attendu en échec.

`c7ffc22c` (#145) avait fermé la fenêtre voisine — les deux rectangles issus de deux rendus différents. Celle-ci est la moitié qu'il avait laissée ouverte.

### Le correctif

Le `poll` attend maintenant `second.x > first.x`. C'est exactement ce que `expectWeekIsAGridRow()`, quelques lignes plus haut dans le même fichier, fait déjà pour `display` — et l'argument qui y est écrit s'applique sans retouche :

> It does NOT weaken what is being asserted. A page that genuinely forgets to link components.css never reaches `grid`, the poll times out, and the failure reads exactly as before.

Le coût est qu'une vraie régression — les 42 carrés empilés que ce helper existe pour attraper — est signalée après le budget `expect` de 10 s au lieu d'immédiatement. C'est le même coût que ce contrôle voisin paie déjà.

### Les deux helpers, une seule mesure

`expectRendersAsACalendar()` et `expectRendersAsAnEventCalendar()` portaient le `poll` **à l'identique**, donc la même course. La mesure est désormais une fonction qu'ils partagent : corriger deux fois à la main est précisément la façon dont l'une des deux dérive — et `expectRendersAsAnEventCalendar()` était déjà la copie dont le docblock avait dérivé.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French — aucun texte visible modifié
- [x] Automated tests are written/updated for this change — le changement *est* dans le harnais de test
- [x] Tests pass locally (`vendor/bin/phpunit`) — aucun code PHP touché
- [x] PHPStan passes — aucun code PHP touché
- [x] If this PR changes `public/assets/js/` behavior — non : `tests/e2e/support/` uniquement. `npm run typecheck` : 0 nouveau finding ; `calendar-events`, `rental-management` et `rental-request` passent via `scripts/e2e.sh`

## Ce qu'un run vert ne prouve pas

Le défaut était intermittent et le run était vert la plupart du temps de toute façon. Les trois specs qui passent établissent que rien n'est cassé, rien de plus. **Le correctif se juge en lisant la condition du `poll` contre son message** — c'est leur divergence qui a créé le défaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbQrctJzTazTgkpT3cppTG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbQrctJzTazTgkpT3cppTG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved calendar layout checks to measure the first two days together.
  * Prevented transient, incorrectly positioned calendar cells from passing end-to-end tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->