### PR TITLE
Name the issue-reading tools the server actually exposes

### DIFF
--- a/.github/workflows/issue-backlog-scan.yml
+++ b/.github/workflows/issue-backlog-scan.yml
@@ -298,13 +298,16 @@ jobs:
 
       # Both attempts are given the identical arguments — see
       # issue-triage.yml's TRIAGE_ARGS for why each half of this list is
-      # what it is. The two differences are deliberate: this job's
-      # --max-turns is 300 rather than 60, because a scan handles up to
-      # five issues in one turn budget rather than one, and the read-only
-      # tool list is the same list, because it is the same work.
+      # what it is, including why the issue-reading tools are named under
+      # two spellings. The one difference is deliberate: this job's
+      # --max-turns is 300 rather than 100, because a scan handles up to
+      # five issues in one turn budget rather than one. The read-only tool
+      # list is the same list, because it is the same work — and it has to
+      # stay the same list, since a name missing here fails exactly as it
+      # did in triage, on five reporters at once instead of one.
       SCAN_ARGS: >-
         --disallowedTools "Agent,Task,ScheduleWakeup,Bash,Read,Glob,Grep,Write,Edit,NotebookEdit"
-        --allowedTools "mcp__github__issue_read,mcp__github__get_file_contents,mcp__github__search_issues,mcp__github__list_issues,mcp__github__search_code,mcp__github__get_commit,mcp__github__list_commits"
+        --allowedTools "mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__issue_read,mcp__github__get_file_contents,mcp__github__search_issues,mcp__github__list_issues,mcp__github__search_code,mcp__github__get_commit,mcp__github__list_commits"
         --max-turns 300
 
     steps:

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -55,7 +55,10 @@
 #     it is now the price of the guarantee. A rename fails CLOSED — the
 #     run goes red and the issue keeps `triage:pending` — whereas naming
 #     the server fails OPEN the day the server gains a write tool nobody
-#     here has heard of. Whoever bumps the pinned action SHA below should
+#     here has heard of. That price was paid the first time this ran: the
+#     list named `issue_read` and the server offers `get_issue`, so the
+#     agent triaged #181 without ever reading it. Both spellings are in
+#     the list now, and whoever bumps the pinned action SHA below should
 #     re-check these tool names in the same change.
 #
 # WHY THE AGENT RUNS TWICE AND THE JOB CHECKS ITS OWN WORK. Because a run
@@ -437,15 +440,43 @@ jobs:
       # nothing already unpublished, and a reporter who links to a page is
       # a case the skill file expects.
       #
+      # THE SERVER SPELLS THE ISSUE-READING TOOLS `get_issue` AND
+      # `get_issue_comments`, and it took the first real run to find out.
+      # On 2026-09-06 the triage of #181 asked for those two names 48
+      # times and was denied 48 times, because this list named only
+      # `issue_read` — the spelling this repository's own session tools
+      # use. The agent therefore never read the issue it was triaging: it
+      # read files and searched code around a report it could not see,
+      # spent 66 turns retrying the same two denied calls, overran the
+      # turn ceiling, and the action failed the step without returning a
+      # verdict. That is the rename-fails-CLOSED cost named in the header,
+      # arriving on the first issue rather than on some future SHA bump.
+      #
+      # Both spellings are listed. `issue_read` is what a newer image
+      # would expose, `get_issue` and `get_issue_comments` are what the
+      # pinned one does, and naming a tool the server does not have costs
+      # nothing — the permission never comes up. What costs everything is
+      # naming none of the ones it does.
+      #
+      # If a triage is ever red with no verdict again, this is the first
+      # thing to check, and the transcript says it in one line:
+      # `Claude requested permissions to use mcp__github__<name>, but you
+      # haven't granted it yet`. The name in that message goes in this
+      # list.
+      #
       # --max-turns bounds the work the way timeout-minutes bounds the
-      # clock. 60, not the 30 this started with: a real triage of #173
-      # spent 26 turns and still wrote nothing, close enough to a 30-turn
-      # ceiling that the ceiling stopped being a safety net and became a
-      # plausible cause.
+      # clock. 100, not the 30 this started with and not the 60 that
+      # replaced it: a real triage of #173 spent 26 turns and still wrote
+      # nothing, and #181 was cut off at 66. The ceiling is not only a
+      # budget — the action treats a run that OVERRUNS it as a failure
+      # even when the agent finished successfully, so a ceiling close to
+      # the real cost of the work turns good triages red. A thread with
+      # several comments, read alongside the code it accuses, is that
+      # work.
       TRIAGE_ARGS: >-
         --disallowedTools "Agent,Task,ScheduleWakeup,Bash,Read,Glob,Grep,Write,Edit,NotebookEdit"
-        --allowedTools "mcp__github__issue_read,mcp__github__get_file_contents,mcp__github__search_issues,mcp__github__list_issues,mcp__github__search_code,mcp__github__get_commit,mcp__github__list_commits"
-        --max-turns 60
+        --allowedTools "mcp__github__get_issue,mcp__github__get_issue_comments,mcp__github__issue_read,mcp__github__get_file_contents,mcp__github__search_issues,mcp__github__list_issues,mcp__github__search_code,mcp__github__get_commit,mcp__github__list_commits"
+        --max-turns 100
 
     steps:
       # SEND THE ISSUE BACK TO TRIAGE BEFORE TRIAGING IT, and the order

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -187,6 +187,19 @@ if the action's pinned image renames one, which is the price of the
 guarantee and the reason to re-check those names whenever the action SHA
 is bumped.
 
+That price was paid on the first live run. The list named
+`mcp__github__issue_read`; the pinned image spells those tools
+`get_issue` and `get_issue_comments`, so the triage of #181 was denied 48
+times, triaged a report it had never read, exhausted its turn budget
+retrying and went red with no verdict — while every audit in
+`tests/Security/IssueTriageWorkflowPermissionsTest.php` passed, because
+they all asked whether the list was *safe* and none asked whether it was
+*sufficient*. Both spellings are listed now, two tests cover the open half
+of the trade (the agent can read an issue and its comments; both workflows
+read with the same list), and the symptom to recognise is in the
+transcript verbatim: `Claude requested permissions to use
+mcp__github__<name>, but you haven't granted it yet`.
+
 Both issue workflows also **deny the tools that assume a "later"** —
 `Agent`, `Task`, `ScheduleWakeup` — because an agent that hands an issue to
 a subagent and ends its turn waiting for the answer has, in a one-shot run,
@@ -271,8 +284,10 @@ gate, the single shared prompt and the single shared argument list, the
 comment trigger with each clause of its guard, the label reset that must
 precede the agent — and the write boundary above: that no allowed tool is
 the bare server or carries a writing verb in its name, that a schema comes
-back with the verdict as an enum, and that the shell is what maps a
-verdict to a label.
+back with the verdict as an enum, that the shell is what maps a verdict to
+a label — and, since #181, that the list is also *sufficient*: the tools
+that read an issue and its comments are there, under every spelling, in
+both workflows.
 
 `.github/workflows/issue-backlog-scan.yml` is the same triage, applied to
 the issues that workflow never saw: everything filed before it reached

--- a/tests/Security/IssueTriageWorkflowPermissionsTest.php
+++ b/tests/Security/IssueTriageWorkflowPermissionsTest.php
@@ -1221,6 +1221,106 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
     }
 
     /**
+     * THE OTHER HALF OF THE SAME TRADE, and the half nothing checked
+     * until it failed on a live issue: the agent must be able to READ
+     * the issue it is triaging.
+     *
+     * Naming read tools one by one fails closed, which is the point —
+     * but "closed" includes the case where the list is a perfectly
+     * safe list of names the server does not answer to. On 2026-09-06
+     * the triage of #181 asked for `mcp__github__get_issue` and
+     * `mcp__github__get_issue_comments` 48 times and was denied 48
+     * times, because the allowlist named only `mcp__github__issue_read`
+     * — the spelling this repository's own tooling uses, not the one
+     * the pinned action's server exposes. The agent triaged a report
+     * it had never read, spent its whole turn budget retrying the two
+     * denied calls, overran the ceiling, and the run went red with no
+     * verdict. Every test in this file passed on that commit.
+     *
+     * So the rule is the union, not the alternative: every spelling a
+     * GitHub MCP image is known to use for reading an issue and its
+     * comments is listed. Naming a tool the server does not have costs
+     * nothing — the permission simply never comes up — while naming
+     * none of the ones it does costs the reporter their answer.
+     *
+     * If a future image renames these again, this test does not know
+     * it; nothing static can. What it does is make the list a decision
+     * somebody has to change on purpose, with the incident above one
+     * scroll away, rather than a name that quietly stopped meaning
+     * anything.
+     */
+    #[DataProvider('issueWorkflows')]
+    public function testTheAgentCanActuallyReadAnIssueAndItsComments(string $workflow): void
+    {
+        $arguments = $this->agentArguments($workflow);
+
+        self::assertSame(
+            1,
+            preg_match('/--allowedTools\s+"([^"]*)"/', $arguments, $allowed),
+            $workflow . ' passes no `--allowedTools`, so there is no list to read an issue with.',
+        );
+
+        $tools = array_values(array_filter(array_map('trim', explode(',', $allowed[1]))));
+
+        $spellings = [
+            'mcp__github__get_issue' => 'the issue body, as the pinned image spells it',
+            'mcp__github__get_issue_comments' => 'the comment thread, as the pinned image spells it',
+            'mcp__github__issue_read' => 'both, as a newer image spells it',
+        ];
+
+        foreach ($spellings as $tool => $what) {
+            self::assertContains(
+                $tool,
+                $tools,
+                $workflow . ' does not allow `' . $tool . '` — ' . $what . '. A triage agent that '
+                . 'cannot read the report answers a report it never saw, and the symptom is a red '
+                . 'run with no verdict rather than anything that names the missing tool. Every '
+                . 'known spelling is listed on purpose: an unused name costs nothing, a missing '
+                . 'one costs the reporter their answer.',
+            );
+        }
+    }
+
+    /**
+     * And both workflows read with the same list.
+     *
+     * They do the same work on the same kind of input — one issue now,
+     * five overnight — so a name that has to be added to one has to be
+     * added to the other. The failure mode this refuses is the tidy one:
+     * a live triage goes red, somebody fixes the list in the file that
+     * went red, and the nightly scan keeps the broken list for as long
+     * as nobody watches a scan run. That scan is the safety net for the
+     * per-issue workflow; a safety net repaired second is not one.
+     */
+    public function testBothIssueWorkflowsReadWithTheSameToolList(): void
+    {
+        $lists = [];
+
+        foreach ([self::TRIAGE, self::BACKLOG_SCAN] as $workflow) {
+            self::assertSame(
+                1,
+                preg_match('/--allowedTools\s+"([^"]*)"/', $this->agentArguments($workflow), $allowed),
+                $workflow . ' passes no `--allowedTools`.',
+            );
+
+            $tools = array_values(array_filter(array_map('trim', explode(',', $allowed[1]))));
+            sort($tools);
+            $lists[$workflow] = $tools;
+        }
+
+        $lists = array_values($lists);
+
+        self::assertSame(
+            $lists[0],
+            $lists[1],
+            'The two issue workflows allow different tools. They triage the same reports against '
+            . 'the same code, so a read tool one of them needs is one the other needs too — and '
+            . 'the backlog scan is what catches the issues the per-issue run failed on. Fix both '
+            . 'lists in the same change.',
+        );
+    }
+
+    /**
      * And the other half of that split: the verdict comes back as DATA,
      * against a schema, and the workflow applies it.
      *


### PR DESCRIPTION
## Description

The first live triage under #182's read-only tool list, **#181**, was denied 48 times and answered nobody.

### What happened

`--allowedTools` named `mcp__github__issue_read`. The pinned action's GitHub MCP server spells those two tools `get_issue` and `get_issue_comments`, so every attempt to read the issue and its thread came back:

```
Claude requested permissions to use mcp__github__get_issue, but you haven't granted it yet
```

The agent went on triaging anyway: it read files and searched code around a report **it could not see**, retried the two denied calls until it had spent 66 turns of a 60-turn budget, and the action failed the step for overrunning the ceiling. `FIRST_VERDICT` and `SECOND_VERDICT` both empty, red run, reporter left with nothing — [run 34020744330](https://github.com/xdubois-57/scoutmagic/actions/runs/34020744330), `permission_denials_count: 17` on the first attempt, 48 denied calls across the two.

That is precisely the **fail-CLOSED** cost #182's header names as the price of not granting the whole `mcp__github` server. It is still the right trade — failing *open* the day the server gains a write tool is the failure nobody would notice — but it arrived on the first issue rather than on some future SHA bump.

### What changed

- **Both spellings are listed**, in both workflows: `get_issue`, `get_issue_comments` (what the pinned image exposes) alongside `issue_read` (what a newer one would). Naming a tool the server does not have costs nothing — the permission never comes up. Naming none of the ones it does costs the reporter their answer.
- **`--max-turns` 60 → 100** for the per-issue job. The action treats a run that *overruns* the ceiling as a failure even when the agent finished successfully, so a ceiling near the real cost of the work turns good triages red; reading a thread of several comments alongside the code it accuses is that work. The scan keeps 300.
- The header, the argument block and `docs/quality-pipeline.md` record the incident and the one log line that identifies it, so the next occurrence is a lookup rather than an investigation.

### Why no test caught it

Every test in `tests/Security/IssueTriageWorkflowPermissionsTest.php` passed on the commit that shipped this. They all asked whether the tool list was **safe**; none asked whether it was **sufficient**. Two tests now cover the open half of the trade:

- `testTheAgentCanActuallyReadAnIssueAndItsComments` — every known spelling for reading an issue and its comments is present, in both workflows.
- `testBothIssueWorkflowsReadWithTheSameToolList` — the nightly scan cannot keep a broken list after the per-issue job is repaired. A safety net repaired second is not one.

Both were mutation-checked by reverting the list to the shipped one: both go red, with the message naming the missing tool.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist — the write boundary is untouched; this widens the **read** list only, and `testTheAgentHoldsNoToolThatWrites` still refuses the bare server and any writing verb
- [x] All code and comments are in English
- [x] All UI-facing text is in French (no UI text in this change)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 15492 tests, green)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — no errors)
- [x] If this PR changes `public/assets/js/` behavior: it does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VvPZZKNvAFjxmNj6ZW3Gw

---
_Generated by [Claude Code](https://claude.ai/code/session_016VvPZZKNvAFjxmNj6ZW3Gw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue backlog scanning and triage reliability by ensuring issue details and comments can be read consistently.
  * Reduced failures caused by mismatched tool names and insufficient processing limits during issue triage.

* **Documentation**
  * Documented the issue-triage tool configuration and known workflow failure conditions.

* **Tests**
  * Added coverage to verify issue and comment readability and consistency across issue workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->