### PR TITLE
A verdict replaces the previous one, it does not join it

### DIFF
--- a/.github/workflows/issue-backlog-scan.yml
+++ b/.github/workflows/issue-backlog-scan.yml
@@ -614,6 +614,20 @@ jobs:
             gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}/labels" \
               -X POST -f 'labels[]=triage:done' --silent
 
+            # A verdict REPLACES the previous one — see the same loop
+            # in issue-triage.yml for the issue that arrived carrying
+            # two contradictory `bug:*` labels at once. This job picks
+            # up issues the per-issue run failed on, so a stale verdict
+            # label from that run is exactly what it meets.
+            for stale in 'bug:confirmed' 'bug:not-a-bug' 'bug:needs-info'; do
+              if [ "${stale}" != "${bug_label}" ]; then
+                gh api \
+                  "repos/${GITHUB_REPOSITORY}/issues/${issue}/labels/${stale//:/%3A}" \
+                  -X DELETE --silent \
+                  || echo "Removing ${stale} from #${issue} did not succeed; counted below."
+              fi
+            done
+
             if [ -n "${bug_label}" ]; then
               gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}/labels" \
                 -X POST -f "labels[]=${bug_label}" --silent

--- a/.github/workflows/issue-backlog-scan.yml
+++ b/.github/workflows/issue-backlog-scan.yml
@@ -559,9 +559,10 @@ jobs:
 
           applied=0
           refused=0
+          unlanded=0
 
           # Through a file rather than a pipe: `… | while read` runs the
-          # loop in a subshell, and the two counters this step exits on
+          # loop in a subshell, and the counters this step exits on
           # would be lost when it ended.
           entries="$(mktemp)"
           # `unique_by` because the selection bounds WHICH issues this
@@ -644,18 +645,51 @@ jobs:
                 -X PATCH -f state=closed -f state_reason=not_planned --silent
             fi
 
+            # READ BACK BEFORE COUNTING IT APPLIED. The label removals
+            # above tolerate a failure, because the usual reason one
+            # fails is that the label was not there — so what makes
+            # that safe is reading the result. An issue left carrying
+            # two contradictory `bug:*` labels reads as triaged to the
+            # backlog count below while saying nothing to a human, and
+            # would be counted here as one more verdict delivered.
+            labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}/labels" \
+              --jq '[.[].name]')"
+
+            # `triage:done` and the verdict labels, deliberately NOT
+            # the absence of `triage:pending`: that half is the
+            # candidate predicate, it lives in ${CANDIDATE_FILTER}
+            # alone, and a leftover `triage:pending` is already what
+            # the backlog count at the end of this job measures. Two
+            # copies of the selection rule is the failure that check
+            # exists to refuse.
+            state="$(printf '%s' "${labels}" | jq -r --arg expected "${bug_label}" '
+              (index("triage:done") != null)
+              and ((map(select(startswith("bug:"))) | sort)
+                    == (if $expected == "" then [] else [$expected] end))')"
+
+            if [ "${state}" != 'true' ]; then
+              echo "::error title=Verdict did not land::Issue #${issue} should carry triage:done \
+              and exactly ${bug_label:-no bug:* label} after this run, and does not. Its labels \
+              are ${labels}."
+              unlanded=$(( unlanded + 1 ))
+              continue
+            fi
+
             echo "Applied ${verdict} to issue #${issue}."
             applied=$(( applied + 1 ))
           done < "${entries}"
 
           rm -f "${entries}"
 
-          echo "Applied ${applied} verdict(s); refused ${refused}."
+          echo "Applied ${applied} verdict(s); refused ${refused}; ${unlanded} did not land."
 
           # A refused entry is not a detail to log and move past: it is
           # either a model that ignored its selection or an issue body
           # that talked it into doing so, and both are worth a red run.
-          if [ "${refused}" -gt 0 ]; then
+          # An entry that did not land is a different failure with the
+          # same remedy — the issue is in a state no human asked for —
+          # and it is counted apart so the log says which happened.
+          if [ "${refused}" -gt 0 ] || [ "${unlanded}" -gt 0 ]; then
             exit 1
           fi
 

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -844,6 +844,10 @@ jobs:
               -X PATCH -f state=closed -f state_reason=not_planned --silent
           fi
 
+          # Published for the read-back below, which is what makes the
+          # tolerated 404s above safe to tolerate.
+          echo "bug_label=${bug_label}" >> "${GITHUB_OUTPUT}"
+
           echo "Applied ${verdict} to issue #${ISSUE_NUMBER}."
 
       # The point of the whole exercise: an issue nobody triaged must not
@@ -854,6 +858,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+          # The `bug:*` label the verdict called for, empty for a
+          # feature request. What the issue must carry, and the only
+          # one of the three it may.
+          BUG_LABEL: ${{ steps.apply.outputs.bug_label }}
         run: |
           set -euo pipefail
 
@@ -861,17 +869,37 @@ jobs:
           # so a label read that fails must fail the job rather than be
           # reported as an issue nobody triaged — or, worse, as one
           # somebody did.
-          landed="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/labels" \
-            --jq 'map(.name)
-                  | if (index("triage:done") != null) and (index("triage:pending") == null)
-                    then "true" else "false" end')"
+          labels="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/labels" \
+            --jq '[.[].name]')"
 
-          if [ "${landed}" = "true" ]; then
-            echo "Issue #${ISSUE_NUMBER} carries a triage verdict."
-            exit 0
+          landed="$(printf '%s' "${labels}" \
+            | jq -r '(index("triage:done") != null) and (index("triage:pending") == null)')"
+
+          if [ "${landed}" != 'true' ]; then
+            echo "::error title=Issue triage did not land::Issue #${ISSUE_NUMBER} does not carry \
+            triage:done, or still carries triage:pending, after the verdict was applied. The \
+            nightly backlog scan will retry it."
+            exit 1
           fi
 
-          echo "::error title=Issue triage did not land::Issue #${ISSUE_NUMBER} does not carry \
-          triage:done, or still carries triage:pending, after the verdict was applied. The \
-          nightly backlog scan will retry it."
-          exit 1
+          # AND IT CARRIES ONE VERDICT, not two. Removing the stale
+          # `bug:*` labels tolerates a failed DELETE, because the usual
+          # reason one fails is that the label was not there — so what
+          # makes that safe is reading the result rather than trusting
+          # the calls. An issue left carrying `bug:confirmed` AND
+          # `bug:not-a-bug` reads as triaged to every other part of this
+          # pipeline while saying nothing to a human, which is the
+          # failure this whole step exists to refuse.
+          verdict_state="$(printf '%s' "${labels}" | jq -r --arg expected "${BUG_LABEL}" '
+            (map(select(startswith("bug:"))) | sort)
+              == (if $expected == "" then [] else [$expected] end)')"
+
+          if [ "${verdict_state}" != 'true' ]; then
+            echo "::error title=Contradictory verdict labels::Issue #${ISSUE_NUMBER} should carry \
+            exactly ${BUG_LABEL:-no bug:* label} after this run, and does not. Its labels are \
+            ${labels}. A stale verdict from an earlier pass was not removed; fix the labels by \
+            hand, because the nightly scan skips triage:done."
+            exit 1
+          fi
+
+          echo "Issue #${ISSUE_NUMBER} carries a triage verdict, and only one."

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -800,6 +800,30 @@ jobs:
           gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/labels" \
             -X POST -f 'labels[]=triage:done' --silent
 
+          # A VERDICT REPLACES THE PREVIOUS ONE; it does not join it.
+          # The reset step strips the old `bug:*` labels when a comment
+          # brings an issue back, but that step is skipped on the
+          # `issues:` path — and an issue can be re-triaged from there
+          # too, by being reopened. #181 came out of that path carrying
+          # `bug:confirmed` AND `bug:not-a-bug`, which says nothing at
+          # all to a maintainer reading the list and is worse than
+          # either label alone. So the labels the verdict is NOT are
+          # removed here, next to the one it is, on every path.
+          for stale in 'bug:confirmed' 'bug:not-a-bug' 'bug:needs-info'; do
+            # An `if`, not `[ … ] && continue`: under `set -e` a test
+            # that ends a line is a status the shell may act on, and
+            # this loop must not be the reason a verdict is half
+            # applied.
+            if [ "${stale}" != "${bug_label}" ]; then
+              # Absent is a 404 and the normal case; the state read
+              # back in the next step settles anything else.
+              gh api \
+                "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/labels/${stale//:/%3A}" \
+                -X DELETE --silent \
+                || echo "Removing ${stale} did not succeed; the state is checked below."
+            fi
+          done
+
           if [ -n "${bug_label}" ]; then
             gh api "repos/${GITHUB_REPOSITORY}/issues/${ISSUE_NUMBER}/labels" \
               -X POST -f "labels[]=${bug_label}" --silent

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -295,7 +295,11 @@ skipped on the `issues:` path — and a reopened issue is re-triaged from
 there. #181 came out of it carrying `bug:confirmed` *and* `bug:not-a-bug`:
 one was the answer, the other was the answer before the reporter corrected
 it, and the pair told a maintainer nothing. The removal now sits beside the
-write, in both workflows, and is asserted there.
+write, in both workflows, and is asserted there — together with the read-back
+that makes it safe: each deletion is allowed to fail, because the ordinary
+reason one fails is that the label was not there, so what the job trusts is
+the label set it reads afterwards. Exactly one `bug:*` label, or none for a
+feature request, or the run goes red naming what it found.
 
 `.github/workflows/issue-backlog-scan.yml` is the same triage, applied to
 the issues that workflow never saw: everything filed before it reached

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -289,6 +289,14 @@ a label — and, since #181, that the list is also *sufficient*: the tools
 that read an issue and its comments are there, under every spelling, in
 both workflows.
 
+**A verdict replaces the one before it.** The label reset strips the old
+`bug:*` labels when a *comment* brings an issue back, but that step is
+skipped on the `issues:` path — and a reopened issue is re-triaged from
+there. #181 came out of it carrying `bug:confirmed` *and* `bug:not-a-bug`:
+one was the answer, the other was the answer before the reporter corrected
+it, and the pair told a maintainer nothing. The removal now sits beside the
+write, in both workflows, and is asserted there.
+
 `.github/workflows/issue-backlog-scan.yml` is the same triage, applied to
 the issues that workflow never saw: everything filed before it reached
 `main`, and everything whose run was lost to a cancelled job or a failed

--- a/tests/Security/IssueTriageWorkflowPermissionsTest.php
+++ b/tests/Security/IssueTriageWorkflowPermissionsTest.php
@@ -1330,6 +1330,31 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
             $applied,
             $workflow . ' builds the stale-label path without deleting anything with it.',
         );
+
+        // AND THE RESULT IS READ BACK. Each of those deletions is
+        // allowed to fail, because the ordinary reason one fails is
+        // that the label was not there — which is only safe while
+        // something afterwards looks at what the issue actually
+        // carries. Without this, a DELETE that fails for a real reason
+        // leaves the two contradictory labels in place and the run
+        // still ends green.
+        $verified = $this->firstRunScriptContaining($workflow, 'startswith("bug:")');
+
+        self::assertStringContainsString(
+            '/labels',
+            $verified,
+            $workflow . ' names the `bug:*` labels in a check that never asks GitHub what the '
+            . 'issue carries. The removals above tolerate a failure; reading the result is what '
+            . 'makes that tolerable.',
+        );
+
+        self::assertStringContainsString(
+            '$expected',
+            $verified,
+            $workflow . ' reads the `bug:*` labels back but compares them against nothing. The '
+            . 'predicate has to be the exact set the verdict called for — one label, or none for '
+            . 'a feature request — or a leftover verdict passes as a triaged issue.',
+        );
     }
 
     /**

--- a/tests/Security/IssueTriageWorkflowPermissionsTest.php
+++ b/tests/Security/IssueTriageWorkflowPermissionsTest.php
@@ -1282,6 +1282,57 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
     }
 
     /**
+     * A VERDICT REPLACES THE PREVIOUS ONE, and both workflows must say
+     * so in the step that writes.
+     *
+     * The reset step strips the old `bug:*` labels when a comment
+     * brings an issue back to triage, which covered the case anybody
+     * was thinking about. It is skipped on the `issues:` path — and an
+     * issue is re-triaged from there too, by being reopened. #181 came
+     * out of that path carrying `bug:confirmed` AND `bug:not-a-bug`:
+     * one of them was the answer, the other was the answer before the
+     * reporter corrected it, and a maintainer reading the label list
+     * learns nothing from the pair. The nightly scan meets the same
+     * state from the other direction, since the issues it picks up are
+     * the ones a per-issue run left labelled and unfinished.
+     *
+     * So the removal belongs beside the write, not beside the reset,
+     * and this asserts it there: the apply step names all three `bug:*`
+     * labels and deletes the ones the verdict is not.
+     */
+    #[DataProvider('issueWorkflows')]
+    public function testAVerdictReplacesTheLabelsOfTheOneBeforeIt(string $workflow): void
+    {
+        $applied = $this->firstRunScriptContaining($workflow, 'labels[]=triage:done');
+
+        foreach (['bug:confirmed', 'bug:not-a-bug', 'bug:needs-info'] as $label) {
+            self::assertStringContainsString(
+                "'" . $label . "'",
+                $applied,
+                $workflow . ' applies a verdict without naming `' . $label . '` among the labels '
+                . 'a new verdict removes. An issue re-triaged after a first pass then carries two '
+                . 'contradictory `bug:*` labels — which is what happened to #181 — and the label '
+                . 'list stops being an answer to anything.',
+            );
+        }
+
+        self::assertStringContainsString(
+            'labels/${stale//:/%3A}',
+            $applied,
+            $workflow . ' names the stale labels but never builds the path that removes one. The '
+            . 'colon has to be percent-encoded — GitHub reads an unencoded `bug:confirmed` as two '
+            . 'path segments — and the removal has to happen in the step that writes the verdict, '
+            . 'because the reset step that also strips them is skipped on the `issues:` path.',
+        );
+
+        self::assertStringContainsString(
+            '-X DELETE',
+            $applied,
+            $workflow . ' builds the stale-label path without deleting anything with it.',
+        );
+    }
+
+    /**
      * And both workflows read with the same list.
      *
      * They do the same work on the same kind of input — one issue now,
@@ -1943,6 +1994,35 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
         }
 
         return $scripts;
+    }
+
+    /**
+     * The one `run:` script in a workflow that contains a marker, as a
+     * string — asserting that exactly one does.
+     *
+     * Both files have several shell steps and the assertions about the
+     * step that WRITES must not accidentally be satisfied by another
+     * one, nor pass silently when the step is restructured out of
+     * existence. A marker matched twice is as much a failure here as a
+     * marker matched never: it means the caller is no longer reading
+     * the step it thinks it is.
+     */
+    private function firstRunScriptContaining(string $workflow, string $marker): string
+    {
+        $matching = array_values(array_filter(
+            $this->runScripts($workflow),
+            static fn (string $script): bool => str_contains($script, $marker),
+        ));
+
+        self::assertCount(
+            1,
+            $matching,
+            $workflow . ' has ' . count($matching) . ' `run:` script(s) containing `' . $marker
+            . '`; exactly one is expected. Either the step this asserts against is gone, or a '
+            . 'second step now does the same writing and the two can disagree.',
+        );
+
+        return $matching[0];
     }
 
     /**


### PR DESCRIPTION
## Description

**#181** came back from its re-triage carrying `bug:confirmed` **and** `bug:not-a-bug`. One of them was the answer; the other was the answer before the reporter corrected himself. A maintainer reading that pair learns nothing from either, and the nightly scan's "has it been triaged" question gets two contradictory answers.

### Why the existing removal missed it

The old `bug:*` labels are stripped in **`Send the issue back to triage`** — which covers the path anybody was thinking about, a comment on an answered issue. That step is gated on `github.event_name == 'issue_comment'` and is skipped on the **`issues:`** path, where a *reopened* issue is re-triaged just the same. `issue-backlog-scan.yml` meets the same state from the other side: the issues it picks up are precisely the ones a per-issue run left labelled and unfinished.

### What changed

The removal moves next to the **write**, where every path reaches it. Both apply steps now delete the two `bug:*` labels the verdict is *not*, beside the one it is; `feature-request` removes all three, which is what "carries no `bug:*` label at all" has always meant.

An `if` rather than `[ … ] && continue` — a bare test ending a line under `set -eo pipefail` is a status the shell may act on, and this loop must not be the reason a verdict is half applied.

### Verification

Both apply steps extracted and run offline against a stubbed `gh`, across all four verdicts:

- `bug:confirmed` — removes `bug:not-a-bug` and `bug:needs-info`, adds `bug:confirmed`, drops `triage:pending`;
- `feature-request` — removes all three `bug:*`, adds none;
- `bug:not-a-bug` — removes the other two, then closes as `not_planned`;
- a 404 on an absent label prints its note and the run continues, rather than dying under `set -e`;
- a comment containing `$(whoami)`, backticks and quotes still reaches the API through `jq` and never the shell.

`testAVerdictReplacesTheLabelsOfTheOneBeforeIt` asserts it for **both** workflows and fails on both with the loop reverted. It reads the apply step through a new `firstRunScriptContaining()` helper that also fails when a marker matches twice — a second step doing the same writing is a defect of its own.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist — the write boundary is unchanged; the loop iterates a literal list of three labels, not anything the model returns
- [x] All code and comments are in English
- [x] All UI-facing text is in French (no UI text in this change)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 15494 tests, green)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — no errors)
- [x] If this PR changes `public/assets/js/` behavior: it does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016VvPZZKNvAFjxmNj6ZW3Gw

---
_Generated by [Claude Code](https://claude.ai/code/session_016VvPZZKNvAFjxmNj6ZW3Gw)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Issue triage now keeps only the current bug verdict label, removing conflicting or outdated verdict labels.
  * Label-removal failures are logged without interrupting further processing.

* **Documentation**
  * Updated quality pipeline guidance to reflect verdict label replacement behavior.

* **Tests**
  * Added coverage to verify stale verdict labels are removed across triage workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->