### PR TITLE
Enregistrer que `All checks` est requis, et ce que cela n'achète pas

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -295,15 +295,16 @@ the checklist honestly filled, nothing of your own left unfiled. Then GitHub
 lands it the moment the ruleset is satisfied, whether or not you are still
 here. If everything is already green the same command merges immediately.
 
-The CI confirmation is not a formality the ruleset would catch for you. Only
-`Claude review` is a required context, and the `code_scanning` rule waits on
-CodeQL and SonarCloud alone — so a red `database-mariadb`, `Authorization
-matrix` or `Dynamic scan (passive)` blocks nothing. Arm on one of those and
-GitHub merges it. `All checks` is the one context built to be required
-instead — it needs every `Checks / …` job and goes red when any of them is
-— and until the maintainer adds it to the ruleset (`docs/quality-pipeline.md`
-§ Branch ruleset on `main` says whether that has happened), read it as the
-quickest way to confirm the whole set, never as something that stops a merge.
+The CI confirmation is not a formality, though since 2026-09-06 the ruleset
+catches most of it: `Claude review` and `All checks` are both required
+contexts (`docs/quality-pipeline.md` § Branch ruleset on `main`), and `All
+checks` needs every `Checks / …` job and goes red when any of them is — so a
+red `database-mariadb`, `Authorization matrix` or `Dynamic scan (passive)`
+does block the merge now, where before it blocked nothing and arming on one
+merged it (issue #170). Read `All checks` as the quickest way to confirm the
+whole set. What it cannot tell you is that the pipeline has *finished*: it
+reports only once every job it needs has, so arming before that is arming on
+a verdict nobody has reached.
 
 Do not poll the PR instead. That is what cost #152 four CI cycles and three
 interruptions on 2026-09-05, and it is why auto-merge is enabled at all

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -298,10 +298,10 @@ here. If everything is already green the same command merges immediately.
 The CI confirmation is not a formality, though since 2026-09-06 the ruleset
 catches most of it: `Claude review` and `All checks` are both required
 contexts (`docs/quality-pipeline.md` § Branch ruleset on `main`), and `All
-checks` needs every `Checks / …` job and goes red when any of them is — so a
-red `database-mariadb`, `Authorization matrix` or `Dynamic scan (passive)`
-does block the merge now, where before it blocked nothing and arming on one
-merged it (issue #170). Read `All checks` as the quickest way to confirm the
+checks` needs every `Checks / …` job and goes red when any of them fails or
+is cancelled. So a red `database-mariadb`, `Authorization matrix` or
+`Dynamic scan (passive)` does block the merge now, where before it blocked
+nothing and arming on one merged it (issue #170). Read `All checks` as the quickest way to confirm the
 whole set. What it cannot tell you is that the pipeline has *finished*: it
 reports only once every job it needs has, so arming before that is arming on
 a verdict nobody has reached.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,12 @@
 # job, runs whatever they concluded (`if: always()`), and goes red unless
 # each of them succeeded. Its name never changes when a gate is added,
 # renamed or split; the list of what it waits for is in this file, reviewed
-# like any other change. Adding it to the ruleset — Settings → Rules →
-# Rulesets → Main → Require status checks to pass — is the one manual step,
-# and it can only be done after this job has run once (a check only appears
-# in GitHub's picker after its first run). docs/quality-pipeline.md § Branch
-# ruleset on `main` carries the current state of that setting.
+# like any other change. It has been a required context on `main` since
+# 2026-09-06 — Settings → Rules → Rulesets → Main → Require status checks
+# to pass, alongside `Claude review` — which is what closed #170. That is a
+# repository setting no diff here can show, so renaming this job silently
+# stops gating anything: docs/quality-pipeline.md § Branch ruleset on `main`
+# is where its current state is recorded.
 
 name: CI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,16 +481,16 @@ Arming it is *merging*, so everything that must be true before a merge must
 be true before you arm it:
 
 - **Every check green on the current head.** Not "the required one" —
-  every one. The ruleset requires `Claude review` and `All checks` — the
-  `ci.yml` job that needs every `Checks / …` job and is red when any of
-  them is — so since 2026-09-06 GitHub no longer lands a pull request
-  whose `database-mariadb`, `Authorization matrix` or `Dynamic scan
-  (passive)` is red. That hole was issue #170; `docs/quality-pipeline.md`
-  § Branch ruleset on `main` records the required list. Reading `All
-  checks` is therefore the fastest way to confirm the whole set — but not
-  a substitute for confirming it, because it reports only once every job
-  it needs has finished. A pipeline still running has reached no verdict,
-  and arming on one is arming on nothing.
+  every one. The ruleset requires `Claude review` and `All checks`, the
+  `ci.yml` job that needs every `Checks / …` job and goes red when any of
+  them fails or is cancelled. So since 2026-09-06 GitHub no longer lands a
+  pull request whose `database-mariadb`, `Authorization matrix` or
+  `Dynamic scan (passive)` is red — that hole was issue #170, and
+  `docs/quality-pipeline.md` § Branch ruleset on `main` records the
+  required list. Reading `All checks` is therefore the fastest way to
+  confirm the whole set, but not a substitute for confirming it: it
+  reports only once every job it needs has finished, and a pipeline still
+  running has reached no verdict. Arming on one is arming on nothing.
 - **Every review thread replied to and resolved on purpose**, rather than
   resolved to clear the way.
 - **The PR template's checklist honestly filled**, and no finding of your

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,16 +481,16 @@ Arming it is *merging*, so everything that must be true before a merge must
 be true before you arm it:
 
 - **Every check green on the current head.** Not "the required one" —
-  every one. The ruleset requires a single context, `Claude review`, so
-  GitHub will happily land a pull request whose `database-mariadb`,
-  `Authorization matrix` or `Dynamic scan (passive)` is red: none of the
-  three is required, and none feeds the `code_scanning` rule that waits on
-  CodeQL and SonarCloud. The gate that stops that is you, before you arm.
-  `All checks` — the `ci.yml` job that needs every `Checks / …` job and is
-  red when any of them is — is the fastest way to read the whole set, and
-  the context built to be required in their place; whether the maintainer
-  has added it to the ruleset is recorded in `docs/quality-pipeline.md`
-  § Branch ruleset on `main`, and until that line says so it stops nothing.
+  every one. The ruleset requires `Claude review` and `All checks` — the
+  `ci.yml` job that needs every `Checks / …` job and is red when any of
+  them is — so since 2026-09-06 GitHub no longer lands a pull request
+  whose `database-mariadb`, `Authorization matrix` or `Dynamic scan
+  (passive)` is red. That hole was issue #170; `docs/quality-pipeline.md`
+  § Branch ruleset on `main` records the required list. Reading `All
+  checks` is therefore the fastest way to confirm the whole set — but not
+  a substitute for confirming it, because it reports only once every job
+  it needs has finished. A pipeline still running has reached no verdict,
+  and arming on one is arming on nothing.
 - **Every review thread replied to and resolved on purpose**, rather than
   resolved to clear the way.
 - **The PR template's checklist honestly filled**, and no finding of your

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -170,8 +170,9 @@ the ruleset keeps waiting for a check that will never report again. So
 `ci.yml` carries one job whose name never changes and whose `needs:` is
 reviewed like any other line; it runs with `if: always()` so an upstream
 failure leaves it red rather than *skipped* (a skipped required check
-reads as "expected" — the misreading #152 lost an hour to). Whether it is
-actually required is a ruleset setting: § Branch ruleset on `main` below.
+reads as "expected" — the misreading #152 lost an hour to). It is a
+required context on `main` **since 2026-09-06**, which is what closed
+#170: § Branch ruleset on `main` below.
 
 `checks.yml` takes one input, `evidence`. Off, it is what the table shows.
 On — only `release.yml` sets it — each job also keeps what its tool emits
@@ -655,18 +656,17 @@ an error.
   itself a merge.
 - **Require status checks to pass.** A check only appears in GitHub's list
   after it has run at least once, so add each one after its first run, not
-  before. `Claude review` is the one required context **as of 2026-09-06**.
-  `All checks` (§ Continuous integration) was built to be the second: one
-  name standing for every `Checks / …` job, stable across renames, red
-  whenever any gate is red or was cancelled. Adding it closes issue #170
-  at the source — a red `database-mariadb`, `Authorization matrix` or
-  `Dynamic scan (passive)`, or one still running, then blocks the merge
-  and holds an armed auto-merge — and it is the one manual step this
-  repository cannot make for itself: add it after its first run on
-  `main`, then confirm with `GET /repos/xdubois-57/scoutmagic/rules/branches/main`
-  that `required_status_checks` lists both contexts, and update this
-  line. Do not add the individual `Checks / …` names as well: that is
-  the fragile form, and `All checks` already waits for all of them.
+  before. Two contexts are required **as of 2026-09-06**, confirmed
+  against `GET /repos/xdubois-57/scoutmagic/rules/branches/main`:
+  `Claude review`, and `All checks` (§ Continuous integration) — one name
+  standing for every `Checks / …` job, stable across renames, red whenever
+  any gate is red or was cancelled. The second is what closed issue #170
+  at the source: a red `database-mariadb`, `Authorization matrix` or
+  `Dynamic scan (passive)` now blocks the merge and holds an armed
+  auto-merge, where until that day the three gated nothing at all. Do not
+  add the individual `Checks / …` names as well: that is the fragile form
+  — each name is a merge that stalls forever the day that job is renamed
+  — and `All checks` already waits for all of them.
 - **Require branches to be up to date before merging** — *deliberately off.*
   It is the sub-option of the rule above, and turning it on again brings back
   the failure it was turned off for: with it on, a pull request must be even
@@ -720,15 +720,21 @@ a change of base branch, disarms auto-merge silently.** Nothing announces
 it. A pull request that was going to land and then simply did not is the
 first thing to check.
 
-And note what it does *not* wait for. The required-check list is one
-context, `Claude review`, and the `code_scanning` rule above waits on CodeQL
-and SonarCloud — so `database-mariadb`, `Authorization matrix` and
-`Dynamic scan (passive)` gate nothing at all. An armed pull request whose
-`database-mariadb` is red still merges. Requiring `All checks` fixes that
-at the source (§ Branch ruleset on `main` above says whether it has been
-done); until then the gate is the person or agent arming it, which is why
-AGENTS.md § Merging a pull request puts "every check green on the current
-head" first among the things to confirm.
+And note what it now waits for, and what it still does not. The
+required-check list is two contexts, `Claude review` and `All checks`, and
+the `code_scanning` rule above waits on CodeQL and SonarCloud — so an armed
+pull request whose `database-mariadb`, `Authorization matrix` or `Dynamic
+scan (passive)` is red no longer merges: `All checks` is red with it. Until
+2026-09-06 those three gated nothing at all and an armed pull request
+merged over them, which is what issue #170 was about.
+
+What no ruleset can tell you is that a pipeline has *finished*. `All checks`
+reports only once every job it needs has, so arming before that is arming
+on a verdict nobody has reached yet — and a required check that has not
+reported looks, in GitHub's own display, like one that is merely waiting.
+That is why AGENTS.md § Merging a pull request still puts "every check green
+on the current head" first among the things to confirm, and why arming and
+walking away from an unfinished pull request is the one thing it forbids.
 
 ### Private vulnerability reporting
 

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -172,7 +172,7 @@ reviewed like any other line; it runs with `if: always()` so an upstream
 failure leaves it red rather than *skipped* (a skipped required check
 reads as "expected" — the misreading #152 lost an hour to). It is a
 required context on `main` **since 2026-09-06**, which is what closed
-#170: § Branch ruleset on `main` below.
+issue #170 — see § Branch ruleset on `main` below.
 
 `checks.yml` takes one input, `evidence`. Off, it is what the table shows.
 On — only `release.yml` sets it — each job also keeps what its tool emits

--- a/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
+++ b/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
@@ -135,13 +135,15 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
     /**
      * The step that stops auto-merge from landing a red pull request.
      *
-     * Only `Claude review` is a required context, and the `code_scanning`
-     * rule waits on CodeQL and SonarCloud — so `database-mariadb`,
-     * `Authorization matrix` and `Dynamic scan (passive)` gate nothing.
-     * A first draft of this rule listed the thread and checklist items and
-     * left CI out, which would have let an agent arm a pull request whose
-     * database job was red and walk away. The ruleset will not catch that;
-     * only the instruction will.
+     * `All checks` became a required context on 2026-09-06, so the ruleset
+     * does now refuse a pull request whose `database-mariadb`,
+     * `Authorization matrix` or `Dynamic scan (passive)` is red — that was
+     * issue #170. It still does not refuse one whose pipeline has not
+     * finished: a required check that has not reported is displayed like
+     * one that is merely waiting. A first draft of this rule listed the
+     * thread and checklist items and left CI out, which would have let an
+     * agent arm on a half-run pipeline and walk away, and that is the part
+     * only the instruction catches.
      */
     public function testTheRuleRequiresGreenChecksBeforeArming(): void
     {
@@ -158,7 +160,7 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
             $this->assertStringContainsString(
                 'database-mariadb',
                 $contents,
-                $file . ' no longer names a check the ruleset does not require'
+                $file . ' no longer names the checks this step exists to have read'
             );
         }
     }


### PR DESCRIPTION
## Description

Le mainteneur a ajouté `All checks` au ruleset de `main` le 2026-09-06. Vérifié contre `GET /repos/xdubois-57/scoutmagic/rules/branches/main`, qui répond maintenant :

```json
"required_status_checks": [
  { "context": "Claude review", "integration_id": 15368 },
  { "context": "All checks",    "integration_id": 15368 }
],
"strict_required_status_checks_policy": false
```

C'est le geste que #187 ne pouvait pas faire lui-même — un check n'apparaît dans le sélecteur de GitHub qu'après sa première exécution — et c'est lui qui ferme **#170** à la source : un `database-mariadb`, un `Authorization matrix` ou un `Dynamic scan (passive)` rouge bloque désormais la fusion et retient un auto-merge armé, là où les trois ne gardaient rien du tout.

Ce réglage vit dans les paramètres du dépôt, où aucun diff ne le montre. Six passages décrivaient l'ancien état et se lisaient comme le présent :

- `docs/quality-pipeline.md` § *Continuous integration* — « whether it is actually required is a ruleset setting » ;
- `docs/quality-pipeline.md` § *Branch ruleset on `main`* — « `Claude review` is the one required context », suivi du mode d'emploi du geste manuel ;
- `docs/quality-pipeline.md` § *Auto-merge* — « an armed pull request whose `database-mariadb` is red still merges » ;
- `AGENTS.md` § *Merging a pull request* — « the ruleset requires a single context » ;
- `.claude/skills/steward/SKILL.md` — le même point dans la section d'armement ;
- l'en-tête de `.github/workflows/ci.yml`, qui appelait l'ajout « the one manual step ».

### La consigne reste, sa raison change

« Every check green on the current head » avant d'armer n'est pas supprimée. Ce qu'elle attrape n'est simplement plus le même : non plus un check rouge que le ruleset ignore, mais **un pipeline qui n'a pas fini**. `All checks` ne rapporte qu'une fois que chacun des jobs dont il dépend a conclu, et GitHub affiche un check requis qui n'a pas rapporté exactement comme un check en attente. Armer là, c'est armer sur un verdict que personne n'a rendu — et c'est aussi pourquoi renommer ce job cesserait silencieusement de garder quoi que ce soit.

Le docblock de `AutoMergeRuleIsWrittenDownTest::testTheRuleRequiresGreenChecksBeforeArming()` portait la même justification périmée ; il dit maintenant ce que le ruleset refuse et ce qu'il ne refuse toujours pas. Les deux assertions ne changent pas de cible : les deux fichiers doivent toujours nommer la consigne et les checks qu'elle fait lire.

Closes #170

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English — les fichiers touchés sont de la documentation d'agent et de mainteneur, en anglais comme le reste ; seule cette description de PR est en français
- [x] All UI-facing text is in French — sans objet, aucun texte d'interface n'est touché
- [x] Automated tests are written/updated for this change — `AutoMergeRuleIsWrittenDownTest` couvrait déjà ces passages et les vérifie toujours ; son docblock est remis à jour avec eux
- [x] Tests pass locally (`vendor/bin/phpunit`) — suite `Architecture` : 177 tests, 1 852 assertions, verte ; les quatre classes qui lisent la documentation (`AutoMergeRuleIsWrittenDown`, `ReleasePipelineIsWired`, `ReleaseGates`, `IssueTriageWorkflowPermissions`) : 75 tests, 623 assertions
- [x] PHPStan passes (`vendor/bin/phpstan analyse`) — 1 435 fichiers, aucune erreur
- [x] If this PR changes `public/assets/js/` behavior — sans objet, aucun JavaScript touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TRZYemi5CqAw4zrMLxNnEy

---
_Generated by [Claude Code](https://claude.ai/code/session_01TRZYemi5CqAw4zrMLxNnEy)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that successful merges require both `Claude review` and `All checks`.
  * Documented that `All checks` covers database, authorization, and passive security scan jobs.
  * Failed or cancelled checks block merging; incomplete checks still require verification before auto-merge.

* **Tests**
  * Updated validation coverage to reflect the current required-check and auto-merge rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->