### PR TITLE
style(sonar): 36 lignes trop longues, et un chaînage optionnel

### DIFF
--- a/public/scheduler-bootstrap.php
+++ b/public/scheduler-bootstrap.php
@@ -527,7 +527,8 @@ function scoutmagic_bootstrap_scheduler(
                         // throwable's message is not bounded. An id and a
                         // mime type, never the filename — personal data
                         // (§7.9).
-                        static function (\Throwable $e, string $mimeType, int $attachmentId) use ($journalService): void {
+                        static function (\Throwable $e, string $mimeType, int $attachmentId)
+                        use ($journalService): void {
                             $journalService->log(
                                 'finance',
                                 'inbound_receipt_not_filed',

--- a/public/sw.js
+++ b/public/sw.js
@@ -332,7 +332,7 @@ function appShellResponse(request, url) {
 
     return fetch(request).then(
         function (response) {
-            if (response && response.ok) {
+            if (response?.ok) {
                 return response;
             }
 

--- a/scripts/dependency-inventory.php
+++ b/scripts/dependency-inventory.php
@@ -119,15 +119,23 @@ const INVENTORY_LICENCE_COMPATIBILITY = [
     'ISC' => 'Licence permissive : compatible.',
     'BSD-2-Clause' => 'Licence permissive : compatible.',
     'BSD-3-Clause' => 'Licence permissive : compatible.',
-    'Apache-2.0' => 'Compatible dans un seul sens : du code Apache-2.0 peut entrer dans une œuvre AGPL-3.0 (la FSF la déclare compatible avec la GPLv3, et l\'AGPLv3 §13 étend cette compatibilité), pas l\'inverse.',
-    'LGPL-2.1' => 'LGPL v2.1 : la bibliothèque reste sous ses propres termes ; sa section 3 permet en outre de la placer sous la GPL (v2 ou ultérieure), d\'où l\'AGPLv3 via la GPLv3 §13.',
-    'LGPL-2.1-only' => 'LGPL v2.1 : la bibliothèque reste sous ses propres termes ; sa section 3 permet en outre de la placer sous la GPL (v2 ou ultérieure), d\'où l\'AGPLv3 via la GPLv3 §13.',
-    'LGPL-2.1-or-later' => 'LGPL v2.1 ou ultérieure : la bibliothèque reste sous ses propres termes ; la LGPLv3 est la GPLv3 assortie d\'exceptions, elle-même combinable avec l\'AGPLv3 (§13).',
+    'Apache-2.0' => 'Compatible dans un seul sens : du code Apache-2.0 peut entrer dans une œuvre AGPL-3.0 '
+        . '(la FSF la déclare compatible avec la GPLv3, et l\'AGPLv3 §13 étend cette compatibilité), pas l\'inverse.',
+    'LGPL-2.1' => 'LGPL v2.1 : la bibliothèque reste sous ses propres termes ; sa section 3 permet en outre '
+        . 'de la placer sous la GPL (v2 ou ultérieure), d\'où l\'AGPLv3 via la GPLv3 §13.',
+    'LGPL-2.1-only' => 'LGPL v2.1 : la bibliothèque reste sous ses propres termes ; sa section 3 permet en outre '
+        . 'de la placer sous la GPL (v2 ou ultérieure), d\'où l\'AGPLv3 via la GPLv3 §13.',
+    'LGPL-2.1-or-later' => 'LGPL v2.1 ou ultérieure : la bibliothèque reste sous ses propres termes ; la LGPLv3 '
+        . 'est la GPLv3 assortie d\'exceptions, elle-même combinable avec l\'AGPLv3 (§13).',
     'LGPL-3.0' => 'LGPL v3 : la GPLv3 assortie d\'exceptions supplémentaires, combinable avec l\'AGPLv3 (GPLv3 §13).',
-    'LGPL-3.0-only' => 'LGPL v3 : la GPLv3 assortie d\'exceptions supplémentaires, combinable avec l\'AGPLv3 (GPLv3 §13).',
-    'LGPL-3.0-or-later' => 'LGPL v3 ou ultérieure : la GPLv3 assortie d\'exceptions supplémentaires, combinable avec l\'AGPLv3 (GPLv3 §13).',
-    'GPL-3.0-or-later' => 'GPL v3 ou ultérieure : la GPLv3 §13 autorise explicitement la combinaison avec une œuvre AGPLv3 ; la partie GPL reste sous GPL, la partie AGPL sous AGPL.',
-    'GPL-3.0-only' => 'GPL v3 : la GPLv3 §13 autorise explicitement la combinaison avec une œuvre AGPLv3 ; la partie GPL reste sous GPL, la partie AGPL sous AGPL.',
+    'LGPL-3.0-only' => 'LGPL v3 : la GPLv3 assortie d\'exceptions supplémentaires, combinable avec l\'AGPLv3 '
+        . '(GPLv3 §13).',
+    'LGPL-3.0-or-later' => 'LGPL v3 ou ultérieure : la GPLv3 assortie d\'exceptions supplémentaires, combinable '
+        . 'avec l\'AGPLv3 (GPLv3 §13).',
+    'GPL-3.0-or-later' => 'GPL v3 ou ultérieure : la GPLv3 §13 autorise explicitement la combinaison avec une '
+        . 'œuvre AGPLv3 ; la partie GPL reste sous GPL, la partie AGPL sous AGPL.',
+    'GPL-3.0-only' => 'GPL v3 : la GPLv3 §13 autorise explicitement la combinaison avec une œuvre AGPLv3 ; '
+        . 'la partie GPL reste sous GPL, la partie AGPL sous AGPL.',
     'AGPL-3.0-or-later' => 'La licence du projet lui-même.',
     'AGPL-3.0-only' => 'La licence du projet lui-même.',
     'MIT-0' => 'Licence permissive : compatible.',
@@ -137,7 +145,8 @@ const INVENTORY_LICENCE_COMPATIBILITY = [
 ];
 
 /** What the compatibility table says about a licence this file has never seen. */
-const INVENTORY_LICENCE_UNKNOWN = '**À examiner** — licence absente de la table de compatibilité de `scripts/dependency-inventory.php`.';
+const INVENTORY_LICENCE_UNKNOWN = '**À examiner** — licence absente de la table de compatibilité de '
+    . '`scripts/dependency-inventory.php`.';
 
 // Guarded the same way scripts/authz-support.php is: the test suite defines
 // DEPENDENCY_INVENTORY_TEST and includes this file for its functions, and
@@ -190,8 +199,11 @@ function inventory_render(string $root): string
     $nodeRequirement = (string) ($packageJson['engines']['node'] ?? 'voir package.json');
 
     $out = "## Dépendances livrées\n\n";
-    $out .= "Versions lues dans les fichiers de verrouillage (`composer.lock`, `package-lock.json`) et dans les bannières des bibliothèques vendorisées — ce qui a été livré, pas ce qu'une contrainte autorisait. Généré par `scripts/dependency-inventory.php`.\n\n";
-    $out .= '**PHP requis :** `' . $phpRequirement . '` — **Node requis (développement seulement) :** `' . $nodeRequirement . "`\n\n";
+    $out .= "Versions lues dans les fichiers de verrouillage (`composer.lock`, `package-lock.json`) et dans les "
+        . "bannières des bibliothèques vendorisées — ce qui a été livré, pas ce qu'une contrainte autorisait. "
+        . "Généré par `scripts/dependency-inventory.php`.\n\n";
+    $out .= '**PHP requis :** `' . $phpRequirement . '` — **Node requis (développement seulement) :** `'
+        . $nodeRequirement . "`\n\n";
 
     $out .= '### PHP — production (' . count($php) . ")\n\n";
     $out .= "Présentes dans `vendor/` de l'archive installable : c'est ce qui tourne sur l'hébergement.\n\n";
@@ -202,15 +214,22 @@ function inventory_render(string $root): string
     $out .= inventory_table($phpDev, '_Aucune._');
 
     $out .= "\n### JavaScript — développement (" . count($node) . ")\n\n";
-    $out .= "Outillage de test et d'analyse uniquement. Le JavaScript de production est du code navigateur simple, sans bundler ni Node : rien d'ici n'atteint un visiteur.\n\n";
+    $out .= "Outillage de test et d'analyse uniquement. Le JavaScript de production est du code navigateur "
+        . "simple, sans bundler ni Node : rien d'ici n'atteint un visiteur.\n\n";
     $out .= inventory_table($node, '_Aucune._');
 
     $out .= "\n### Bibliothèques front-end vendorisées (" . count($vendored) . ")\n\n";
-    $out .= "Dans aucun fichier de verrouillage : des fichiers minifiés commités sous `public/assets/vendor/`, version lue dans leur bannière. Ce sont les seules dépendances tierces que le navigateur d'un visiteur exécute réellement.\n\n";
-    $out .= inventory_table($vendored, '_Aucune trouvée — vérifier le balayage dans `scripts/dependency-inventory.php`._');
+    $out .= "Dans aucun fichier de verrouillage : des fichiers minifiés commités sous `public/assets/vendor/`, "
+        . "version lue dans leur bannière. Ce sont les seules dépendances tierces que le navigateur d'un "
+        . "visiteur exécute réellement.\n\n";
+    $out .= inventory_table(
+        $vendored,
+        '_Aucune trouvée — vérifier le balayage dans `scripts/dependency-inventory.php`._',
+    );
 
     $out .= "\n### Compatibilité avec la licence du projet\n\n";
-    $out .= "ScoutMagic est publié sous **AGPL-3.0-or-later**. Pour chaque licence rencontrée ci-dessus, pourquoi elle peut être combinée avec celle-ci :\n\n";
+    $out .= "ScoutMagic est publié sous **AGPL-3.0-or-later**. Pour chaque licence rencontrée ci-dessus, "
+        . "pourquoi elle peut être combinée avec celle-ci :\n\n";
     $out .= inventory_compatibility_table(array_merge($php, $phpDev, $node, $vendored));
 
     return $out;

--- a/scripts/sonar-evidence.php
+++ b/scripts/sonar-evidence.php
@@ -94,7 +94,8 @@ const SONAR_EVIDENCE_METRICS = [
 ];
 
 /** The per-file subset: enough to place debt and coverage, not the whole list. */
-const SONAR_EVIDENCE_FILE_METRICS = 'ncloc,coverage,bugs,vulnerabilities,security_hotspots,code_smells,duplicated_lines_density,cognitive_complexity';
+const SONAR_EVIDENCE_FILE_METRICS = 'ncloc,coverage,bugs,vulnerabilities,security_hotspots,code_smells,'
+    . 'duplicated_lines_density,cognitive_complexity';
 
 /** SonarCloud's page ceiling per request, and a hard cap on pages so a loop cannot run away. */
 const SONAR_EVIDENCE_PAGE_SIZE = 500;
@@ -147,7 +148,10 @@ function sonar_evidence_main(array $argv): void
 
     if ($token === '') {
         if ($expected !== null) {
-            fwrite(STDERR, "sonar-evidence: SONAR_TOKEN is not set and an analysis of {$expected} is required — refusing.\n");
+            fwrite(
+                STDERR,
+                "sonar-evidence: SONAR_TOKEN is not set and an analysis of {$expected} is required — refusing.\n",
+            );
             exit(1);
         }
         sonar_evidence_write_unavailable($outDir, 'Aucun SONAR_TOKEN n\'était disponible pour cette exécution.');
@@ -261,12 +265,14 @@ function sonar_evidence_resolve_token(string $fromEnvironment, string $tokenFile
 /**
  * The one line this script prints on a run that worked.
  *
- * @param array{revision: string, analysis_date: string, quality_gate: string, issues: int, blocking: int, hotspots: int, hotspots_to_review: int} $summary
+ * @param array{revision: string, analysis_date: string, quality_gate: string, issues: int, blocking: int,
+ *     hotspots: int, hotspots_to_review: int} $summary
  */
 function sonar_evidence_summary_line(array $summary, string $outDir): string
 {
     return sprintf(
-        "sonar-evidence: analysis %s of %s — quality gate %s, %d issue(s) (%d blocking), %d hotspot(s) (%d to review), written to %s\n",
+        "sonar-evidence: analysis %s of %s — quality gate %s, %d issue(s) (%d blocking), "
+        . "%d hotspot(s) (%d to review), written to %s\n",
         $summary['analysis_date'],
         substr($summary['revision'], 0, 7),
         $summary['quality_gate'],
@@ -309,7 +315,8 @@ function sonar_evidence_refusal_message(array $refusals): string
  * not "nothing blocks". Reading the first as the second is how a release
  * ships over a finding nobody was ever shown.
  *
- * @param array{quality_gate: string, blocking: int, hotspots_to_review: int, revision: string, truncated?: bool} $summary
+ * @param array{quality_gate: string, blocking: int, hotspots_to_review: int, revision: string,
+ *     truncated?: bool} $summary
  * @return list<string>
  */
 function sonar_evidence_release_refusals(array $summary): array
@@ -320,13 +327,15 @@ function sonar_evidence_release_refusals(array $summary): array
         $refusals[] = 'le Quality Gate est ' . $summary['quality_gate'] . ' (il doit être OK).';
     }
     if ($summary['blocking'] > 0) {
-        $refusals[] = $summary['blocking'] . ' signalement(s) non résolu(s) bloquant(s) — les nits de convention exemptés ne comptent pas.';
+        $refusals[] = $summary['blocking'] . ' signalement(s) non résolu(s) bloquant(s) — les nits de convention '
+            . 'exemptés ne comptent pas.';
     }
     if ($summary['hotspots_to_review'] > 0) {
         $refusals[] = $summary['hotspots_to_review'] . ' Security Hotspot(s) encore à trier (TO_REVIEW).';
     }
     if ($summary['truncated'] ?? false) {
-        $refusals[] = 'la liste des signalements a été tronquée au plafond de pagination : les comptes ci-dessus sont des minorants, pas un état complet.';
+        $refusals[] = 'la liste des signalements a été tronquée au plafond de pagination : les comptes ci-dessus '
+            . 'sont des minorants, pas un état complet.';
     }
 
     return $refusals;
@@ -397,7 +406,8 @@ function sonar_evidence_decode(string|bool $body, int $status, string $error, st
  *
  * @param callable(string): array<string, mixed> $api
  * @param callable(int): void $sleep
- * @return array{revision: string, analysis_date: string, quality_gate: string, issues: int, blocking: int, hotspots: int, hotspots_to_review: int, truncated: bool}
+ * @return array{revision: string, analysis_date: string, quality_gate: string, issues: int, blocking: int,
+ *     hotspots: int, hotspots_to_review: int, truncated: bool}
  * @throws RuntimeException
  */
 function sonar_evidence_collect(
@@ -447,16 +457,21 @@ function sonar_evidence_collect(
     sonar_evidence_write_json($outDir . '/sonarcloud-quality-gate.json', $gate);
 
     $measures = $api(
-        "measures/component?component={$project}&branch={$branchQuery}&metricKeys=" . implode(',', SONAR_EVIDENCE_METRICS)
+        "measures/component?component={$project}&branch={$branchQuery}&metricKeys="
+        . implode(',', SONAR_EVIDENCE_METRICS)
     );
     sonar_evidence_write_json($outDir . '/sonarcloud-measures.json', $measures);
 
     $byFile = sonar_evidence_fetch_all_pages(
         $api,
-        "measures/component_tree?component={$project}&branch={$branchQuery}&qualifiers=FIL&metricKeys=" . SONAR_EVIDENCE_FILE_METRICS,
+        "measures/component_tree?component={$project}&branch={$branchQuery}&qualifiers=FIL&metricKeys="
+        . SONAR_EVIDENCE_FILE_METRICS,
         'components'
     );
-    sonar_evidence_write_json($outDir . '/sonarcloud-measures-by-file.json', ['total' => count($byFile), 'components' => $byFile]);
+    sonar_evidence_write_json(
+        $outDir . '/sonarcloud-measures-by-file.json',
+        ['total' => count($byFile), 'components' => $byFile],
+    );
 
     // $truncated matters more than it looks. Every count below is derived
     // from these lists, so one the page cap cut short yields counts that
@@ -477,7 +492,8 @@ function sonar_evidence_collect(
         'blocking' => count($blocking),
         'exempt' => count($issues) - count($blocking),
         'truncated' => $issuesTruncated,
-        'rule' => 'AGENTS.md § SonarQube Cloud release gate: every unresolved issue blocks a release except one that is, all at once, MAINTAINABILITY, LOW and tagged convention.',
+        'rule' => 'AGENTS.md § SonarQube Cloud release gate: every unresolved issue blocks a release except one '
+            . 'that is, all at once, MAINTAINABILITY, LOW and tagged convention.',
         'issues' => $issues,
     ]);
 
@@ -562,7 +578,8 @@ function sonar_evidence_wait_for_analysis(
     }
 
     throw new RuntimeException(sprintf(
-        'SonarCloud has not analysed %s (latest analysis: %s) after %d attempt(s) — a pass read off an older analysis is not a pass',
+        'SonarCloud has not analysed %s (latest analysis: %s) after %d attempt(s) — a pass read off an older '
+        . 'analysis is not a pass',
         $expectedRevision,
         (string) ($latest['revision'] ?? 'none'),
         $attempts
@@ -671,7 +688,8 @@ function sonar_evidence_write_unavailable(string $outDir, string $reason): void
  */
 function sonar_evidence_write_json(string $path, array $data): void
 {
-    file_put_contents($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n");
+    $flags = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+    file_put_contents($path, json_encode($data, $flags) . "\n");
 }
 
 /** SonarCloud returns ratings as 1..5; nobody reads "3.0". */
@@ -722,7 +740,8 @@ function sonar_evidence_report(
             ? 'C\'est bien le commit livré par cette release.'
             : '**Attention : ce n\'est pas le commit livré (`' . $expectedRevision . '`).**';
     } else {
-        $lines[] = 'Aucun commit particulier n\'était attendu (exécution de répétition) : ceci est la dernière analyse de la branche.';
+        $lines[] = 'Aucun commit particulier n\'était attendu (exécution de répétition) : ceci est la dernière '
+            . 'analyse de la branche.';
     }
     $lines[] = '';
     $lines[] = 'Quality Gate : **' . (string) ($gate['projectStatus']['status'] ?? 'INCONNU') . '**';
@@ -746,13 +765,16 @@ function sonar_evidence_report(
 
     $rows = [
         'Fiabilité' => sonar_evidence_rating($m('reliability_rating')) . ' — ' . $m('bugs') . ' bug(s)',
-        'Sécurité' => sonar_evidence_rating($m('security_rating')) . ' — ' . $m('vulnerabilities') . ' vulnérabilité(s)',
+        'Sécurité' => sonar_evidence_rating($m('security_rating')) . ' — ' . $m('vulnerabilities')
+            . ' vulnérabilité(s)',
         'Revue de sécurité' => sonar_evidence_rating($m('security_review_rating')) . ' — ' . $m('security_hotspots')
             . ' hotspot(s), ' . $m('security_hotspots_reviewed') . ' % revus',
         'Maintenabilité' => sonar_evidence_rating($m('sqale_rating')) . ' — ' . $m('code_smells') . ' code smell(s), '
             . $m('sqale_index') . ' min de dette',
-        'Couverture' => $m('coverage') . ' % (' . $m('uncovered_lines') . ' lignes non couvertes sur ' . $m('lines_to_cover') . ')',
-        'Tests rapportés' => $m('tests') . ' (échecs : ' . $m('test_failures') . ', erreurs : ' . $m('test_errors') . ', ignorés : ' . $m('skipped_tests') . ')',
+        'Couverture' => $m('coverage') . ' % (' . $m('uncovered_lines') . ' lignes non couvertes sur '
+            . $m('lines_to_cover') . ')',
+        'Tests rapportés' => $m('tests') . ' (échecs : ' . $m('test_failures') . ', erreurs : ' . $m('test_errors')
+            . ', ignorés : ' . $m('skipped_tests') . ')',
         'Duplication' => $m('duplicated_lines_density') . ' % sur ' . $m('duplicated_blocks') . ' bloc(s)',
         'Taille' => $m('ncloc') . ' lignes de code, ' . $m('files') . ' fichier(s)',
         'Complexité' => $m('cognitive_complexity') . ' cognitive, ' . $m('complexity') . ' cyclomatique',
@@ -768,7 +790,8 @@ function sonar_evidence_report(
     $lines[] = '### Signalements ouverts (' . count($issues) . ')';
     $lines[] = '';
     $lines[] = count($blocking) . ' bloquant(s) pour une release, ' . (count($issues) - count($blocking))
-        . ' exempté(s) — la règle est celle d\'`AGENTS.md` § SonarQube Cloud release gate : tout signalement non résolu bloque, sauf s\'il est à la fois `MAINTAINABILITY`, `LOW` et étiqueté `convention`.';
+        . ' exempté(s) — la règle est celle d\'`AGENTS.md` § SonarQube Cloud release gate : tout signalement non '
+        . 'résolu bloque, sauf s\'il est à la fois `MAINTAINABILITY`, `LOW` et étiqueté `convention`.';
     $lines[] = '';
 
     if ($issues === []) {
@@ -811,7 +834,8 @@ function sonar_evidence_report(
     } else {
         $byStatus = [];
         foreach ($hotspots as $hotspot) {
-            $status = (string) ($hotspot['vulnerabilityProbability'] ?? '?') . ' / ' . (string) ($hotspot['status'] ?? '?');
+            $status = (string) ($hotspot['vulnerabilityProbability'] ?? '?') . ' / '
+                . (string) ($hotspot['status'] ?? '?');
             $byStatus[$status] = ($byStatus[$status] ?? 0) + 1;
         }
         ksort($byStatus);


### PR DESCRIPTION
Les 36 découvertes SonarCloud qui bloquent actuellement toute release sur `main`. Toutes mécaniques, aucune ne change un comportement.

## Ce qui bloquait

**35 × `php:S103`** — plus de 120 caractères. Elles sont bien étiquetées `convention`, mais en severity **MEDIUM**, et la règle d'`AGENTS.md` § SonarQube Cloud release gate demande les trois conditions à la fois : `MAINTAINABILITY`, `LOW` **et** `convention`. Une `convention` en MEDIUM bloque. 34 d'entre elles sont dans les deux scripts que #187 vient d'ajouter (`scripts/sonar-evidence.php`, `scripts/dependency-inventory.php`).

**1 × `javascript:S6582`** dans `public/sw.js` : `response && response.ok` devient `response?.ok`. Le fichier utilise déjà le chaînage optionnel sept fois et `tsconfig.json` cible ES2020.

## Un choix qui mérite d'être dit

Dans `public/scheduler-bootstrap.php`, la ligne est coupée **avant le `use`**, pas au milieu des paramètres :

```php
static function (\Throwable $e, string $mimeType, int $attachmentId)
use ($journalService): void {
```

parce que `InboundReceiptIsNotSilentTest` lit cette signature par expression régulière pour prouver que la racine de composition installe bien le rapporteur que `FinanceMessageConsumer` appelle (#175). Couper les paramètres cassait ce test ; assouplir sa regex aurait affaibli ce qu'il protège. La coupure avant `use` laisse la signature intacte et le test inchangé.

## Vérifications

| | |
|---|---|
| `vendor/bin/phpstan analyse` | OK, 0 erreur |
| `vendor/bin/phpunit` | 15596 tests, seuls les 2 échecs `E2eSchedulerCoverageTest` préexistants — identiques sur l'arbre propre avant ces modifications |
| `npm run typecheck` | OK, 0 nouveau signalement |
| `npm run test:coverage` | 1979/1979 |
| `php scripts/dependency-inventory.php` | tourne, sortie inchangée |

Après ce merge, le gate SonarCloud doit repasser au vert et la release peut être coupée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPoRM6VriKx7uN2QfeFMVn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded licence compatibility explanations in generated inventory output, including “only” and “or later” variants.

- **Refactor**
  - Improved code formatting and readability across internal scripts and service-worker logic without changing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->