### PR TITLE
fix(release): le job du brouillon ne sait pas à quel dépôt il parle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,6 +397,15 @@ jobs:
         if: ${{ github.ref_type == 'tag' }}
         env:
           GH_TOKEN: ${{ github.token }}
+          # This job never checks the repository out — it only downloads
+          # artifacts — so `gh` has no git remote to infer the repository
+          # from and dies with « failed to run git: fatal: not a git
+          # repository » before either command below runs. It cost v1.0.42
+          # a full run: every gate green, the pack built, signed and
+          # uploaded, and no draft Release at the end of it. GH_REPO is
+          # what `gh` reads when there is no checkout, and it is cheaper
+          # than checking out a repository this job has no other use for.
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ github.ref_name }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Premier passage réel de la chaîne ajoutée par #187, et elle s'arrête à la dernière marche.

## Ce qui s'est passé

`v1.0.42` a été taguée. Les cinq gates de `scripts/release.sh` sont passées, `release.yml` a rejoué chaque verrou de `checks.yml` sur le runner — **tous verts** —, assemblé le paquet de preuves, l'a signé via Sigstore et téléversé. Puis :

```
Evidence pack and draft Release / Create the draft Release
failed to run git: fatal: not a git repository (or any of the parent directories): .git
##[error]Process completed with exit code 1
```

Aucun brouillon de Release créé, donc `scripts/release.sh` a refusé de publier — ce qui est exactement son travail.

## La cause

Le job `Evidence pack and draft Release` ne fait aucun `actions/checkout` : il ne télécharge que des artefacts. `gh release view` et `gh release create` cherchent alors le dépôt dans le remote git du répertoire courant, n'en trouvent pas, et échouent avant d'émettre la moindre requête.

Les deux autres appels `gh` du workflow (`gh api`, lignes 134 et 153) passent un chemin d'API complet et ne dépendent donc pas du contexte git — eux fonctionnent.

## Le correctif

`GH_REPO: ${{ github.repository }}` sur l'étape. C'est ce que `gh` lit en l'absence de checkout, et c'est moins cher que de cloner un dépôt dont ce job n'a aucun autre usage.

## Comment ça a échappé aux tests

`release.yml` accepte `workflow_dispatch` précisément pour répéter la chaîne sans couper de version — mais l'étape est gardée par `if: github.ref_type == 'tag'`, donc une répétition par dispatch ne l'exécute jamais. Le bug ne pouvait se voir qu'en taguant. Ce n'est pas corrigé ici : rendre cette étape atteignable en répétition demande un vrai choix de conception (créer une Release jetable ? sur quel tag ?), et le paquet de preuves, lui, est bien produit et vérifié par une répétition.

## Suite

Une fois fusionné : supprimer le tag `v1.0.42` et relancer `scripts/release.sh`, comme le prescrit l'en-tête du script pour un verrou rouge côté runner après le tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPoRM6VriKx7uN2QfeFMVn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release automation so draft releases can be created more reliably.
  - Release jobs now work correctly even when the repository has not been checked out first.
  - No changes were made to the product’s user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->