### PR TITLE
Dire à une issue que son correctif est là avant de la fermer, pas après

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -131,12 +131,22 @@ that `ci.yml` calls — which is why a pull request shows them as
 | `Checks / SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
 
-The issue workflows — `issue-triage.yml` and `issue-backlog-scan.yml` — are
-deliberately absent from that table, and adding a row for either would make
-it wrong. They never run on a pull request: one fires on `issues:`, the
-other on a cron, and neither can turn a check red or block a merge. There
-is nothing to reproduce when one misbehaves, and nothing to reproduce it
-with. `docs/quality-pipeline.md` covers them instead.
+The issue workflows — `issue-triage.yml`, `issue-backlog-scan.yml` and
+`issue-fixed-comment.yml` — are deliberately absent from that table, and
+adding a row for any of them would make it wrong. None can turn a pull
+request check red or block a merge: the first fires on `issues:`, the
+second on a cron, and the third on `pull_request: [closed]` filtered to a
+merge, so it starts only once the merge it reacts to has happened. There is
+nothing to reproduce when one misbehaves, and nothing to reproduce it with.
+`docs/quality-pipeline.md` covers them instead.
+
+`issue-fixed-comment.yml` is still worth watching after you merge: it says
+on each issue the body named that the fix landed, then closes it, and it
+exits non-zero when it could not say so — a comment the API refused, a
+state it could not read back. That red run is on the merge commit rather
+than on the pull request, and it means an issue is fixed and does not say
+so. Finish that one by hand: comment, then close as `completed`, per
+AGENTS.md § Fix the backlog, step 6.
 
 The flags are not decoration — each is a failure the shorter command
 cannot show you:

--- a/.github/workflows/issue-fixed-comment.yml
+++ b/.github/workflows/issue-fixed-comment.yml
@@ -132,7 +132,16 @@ jobs:
             # Read back rather than assumed: an issue somebody had already
             # closed by hand, or one an old-style keyword closed at merge,
             # is left exactly as it is. `completed`, because it was.
-            state="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" --jq '.state' || echo 'unknown')"
+            #
+            # A read that FAILED is not a state, and treating it as one
+            # (`unknown`, then no closing) would be the whole point of
+            # this file lost to a rate limit: the comment posted, the
+            # issue still open, the run green, and nobody told.
+            if ! state="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" --jq '.state')"; then
+              echo "::error title=Could not read state::Could not tell whether #${issue} is still open."
+              unsaid=1
+              continue
+            fi
 
             if [ "${state}" = 'open' ]; then
               if gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \

--- a/.github/workflows/issue-fixed-comment.yml
+++ b/.github/workflows/issue-fixed-comment.yml
@@ -1,28 +1,37 @@
-# Says on an issue that its fix has landed, instead of letting it go
-# silent.
+# Says on an issue that its fix has landed, and only then closes it.
 #
-# A pull request body carrying `Closes #158` (AGENTS.md § Fix the backlog,
-# step 5) makes GitHub close that issue the moment the pull request merges.
-# What GitHub writes on the issue is a timeline reference and nothing else:
-# the reporter gets a notification saying their report was closed, with no
-# sentence telling them it was FIXED, in what, or where to look. Somebody
-# who wrote a careful report and waited three weeks deserves better than a
-# strikethrough.
+# GitHub closes an issue named by one of its own keywords (`Closes #158`)
+# the moment the pull request merges, and what it writes on the issue is a
+# timeline reference and nothing else: the reporter gets a notification
+# saying their report was closed, with no sentence telling them it was
+# FIXED, in what, or where to look. Somebody who wrote a careful report and
+# waited three weeks deserves better than a strikethrough.
 #
-# So on every merge this posts one comment per closed issue — the pull
-# request, the commit, and the plain statement that the fix is on `main` —
-# and then makes sure the issue really is closed as `completed`. The
-# comment is the point; the closing is the belt to GitHub's braces, for the
-# case where the keyword was missing or the auto-close silently failed.
+# So on every merge this posts one comment per issue the pull request names
+# — the pull request, the commit, the plain statement that the fix is on
+# `main` — and closes the issue afterwards, as `completed`.
 #
-# **On ordering.** GitHub's own close fires server-side at merge, and this
-# runs a few seconds later, so the comment lands beside the close rather
-# than strictly before it. What matters is that the issue never ends up
-# closed with nothing said on it, and that is what this guarantees. The
-# alternative — dropping the closing keyword so this workflow could comment
-# and then close — would cost the *Development* link that puts the pull
-# request on the issue, which is the thing that makes an issue say what is
-# fixing it.
+# **On ordering, which is the whole point of the shape below.** An earlier
+# version of this file ran beside GitHub's own close rather than before it:
+# the keyword closed the issue server-side at merge and this posted its
+# comment a few seconds later, so a reporter's first notification was still
+# a bare closure. The fix is to take the closing away from GitHub: a pull
+# request body names its issues with `Corrige #158` (AGENTS.md § Fix the
+# backlog, step 5), which is NOT one of GitHub's nine closing keywords, so
+# nothing closes the issue but this job — after it has spoken. A comment
+# that could not be posted skips the closing entirely: an issue left open
+# is something the maintainer can finish by hand, an issue closed in
+# silence is the thing this file exists to prevent.
+#
+# **What that costs, and what stands in its place.** Only a closing keyword
+# puts a pull request in an issue's *Development* section, so that sidebar
+# link is gone. `Corrige #158` still cross-references the pull request on
+# the issue's timeline where the link would have pointed, and the comment
+# below names the pull request and the merge commit outright — which is
+# more than the sidebar ever said. English keywords are still read here, so
+# a body written the old way (or by somebody who does not know this
+# convention) is still commented on; GitHub will have closed that one
+# first, and the `state` read below simply finds it already closed.
 #
 # **Nothing a contributor wrote reaches a shell.** The pull request body is
 # read for issue NUMBERS only, each one checked against `^[0-9]+$` before
@@ -54,7 +63,7 @@ jobs:
       # numbers below are validated rather than trusted.
       issues: write
     steps:
-      - name: Say on each issue that its fix is on main
+      - name: Say on each issue that its fix is on main, then close it
         env:
           GH_TOKEN: ${{ github.token }}
           # Read through the environment, never interpolated into the
@@ -69,20 +78,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          # GitHub's own list of closing keywords, matched the way GitHub
-          # matches them: case-insensitive, one issue per keyword. A
-          # number mentioned in prose closes nothing and is not read here
-          # either — this comments on exactly the issues GitHub closed.
+          # `corrige` is this repository's marker and the one that leaves
+          # the closing to the job below; GitHub's own keywords are read
+          # too, so a body written the old way still gets its sentence.
+          # Case-insensitive, one issue per marker. A number mentioned in
+          # prose closes nothing and is not read here either.
           issues="$(printf '%s' "${PR_BODY}" \
-            | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oiE '\b(corrige(nt)?|close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
             | grep -oE '[0-9]+$' \
             | sort -un \
             || true)"
 
           if [ -z "${issues}" ]; then
-            echo "This pull request names no issue with a closing keyword; nothing to say."
+            echo "This pull request names no issue; nothing to say."
             exit 0
           fi
+
+          unsaid=0
 
           for issue in ${issues}; do
             # Belt and braces on a value that goes into an API path. The
@@ -103,27 +115,37 @@ jobs:
               "Si ce que vous aviez signalé se reproduit, répondez ici plutôt que d'ouvrir un nouveau ticket : le fil garde le contexte." \
               "_Generated by [Claude Code](https://claude.ai/code)_")"
 
-            if gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}/comments" \
+            if ! gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}/comments" \
               -X POST -f "body=${body}" --silent; then
-              echo "Told #${issue} that its fix landed."
-            else
               # A 404 is an issue in another repository, or one deleted
-              # since the body was written; neither is this workflow's to
-              # fail on. The state read back below is what decides.
-              echo "::warning title=Could not comment::Commenting on #${issue} did not succeed."
+              # since the body was written; a 5xx is GitHub having a bad
+              # minute. Either way nothing has been said on this issue,
+              # so nothing closes it — the run goes red instead and the
+              # maintainer finishes it by hand.
+              echo "::error title=Could not comment::Commenting on #${issue} did not succeed; leaving it open."
+              unsaid=1
+              continue
             fi
 
-            # GitHub has almost certainly closed it already; this settles
-            # the cases where it did not — a keyword on a pull request
-            # from a fork, a base branch that is not the default one, an
-            # auto-close that silently failed. `completed`, because it
-            # was.
+            echo "Told #${issue} that its fix landed."
+
+            # Read back rather than assumed: an issue somebody had already
+            # closed by hand, or one an old-style keyword closed at merge,
+            # is left exactly as it is. `completed`, because it was.
             state="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" --jq '.state' || echo 'unknown')"
 
             if [ "${state}" = 'open' ]; then
-              gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \
-                -X PATCH -f state=closed -f state_reason=completed --silent \
-                || echo "::warning title=Could not close::Closing #${issue} did not succeed."
-              echo "Closed #${issue} as completed; the keyword had not."
+              if gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \
+                -X PATCH -f state=closed -f state_reason=completed --silent; then
+                echo "Closed #${issue} as completed."
+              else
+                echo "::error title=Could not close::Closing #${issue} did not succeed."
+                unsaid=1
+              fi
             fi
           done
+
+          # A red run here means an issue is fixed and does not say so, or
+          # says so and is still open. Both are somebody's five minutes;
+          # neither is worth hiding behind a green tick.
+          exit "${unsaid}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -417,20 +417,28 @@ backlog » — and it is a standing instruction, not a one-off. It means:
    arming auto-merge still holds without exception: every check green on
    the current head, every review thread answered, the template's checklist
    honestly filled.
-5. **Attach the pull request to the issue.** The body names each issue with
-   a closing keyword — `Closes #158`, one per issue — which is what puts
-   the pull request in that issue's *Development* section and makes the
-   issue say what is fixing it. A PR number mentioned in prose links
-   nothing. Do this when the PR is opened, not afterwards.
-6. **Close the issue once the fix is on `main`.** The closing keyword does
-   it on merge, and `issue-fixed-comment.yml` posts the sentence that says
-   so — which pull request, which commit, that the fix is on `main` — so a
-   reporter never finds their report closed in silence. Your job is to
-   *verify* both happened, on each issue, and to close by hand any that
-   stayed open (`state_reason: completed` — the fix shipped), saying on it
-   what landed. An accepted issue whose fix is merged and which is still
-   open is the backlog lying about itself; one closed with nothing written
-   on it is the backlog being rude.
+5. **Name each issue in the pull request body with `Corrige #158`** — that
+   word, one line per issue, when the PR is opened rather than afterwards.
+   `Corrige` is deliberately **not** one of GitHub's closing keywords
+   (`Closes`, `Fixes`, `Resolves` and their inflections): a keyword makes
+   GitHub close the issue itself, server-side, at the instant of the merge,
+   which is seconds *before* `issue-fixed-comment.yml` can say anything —
+   so the reporter's first notification is a bare closure. Leaving the
+   closing to that workflow is what buys the sentence-then-closure order.
+   The cost is the issue's *Development* sidebar link, which only a closing
+   keyword creates; `Corrige #158` still cross-references the pull request
+   on the issue's timeline, and the workflow's comment names the pull
+   request and the merge commit outright. **Do not "fix" a body by putting
+   a closing keyword back** — that is the bug, not the convention.
+6. **Close the issue once the fix is on `main`.** `issue-fixed-comment.yml`
+   does it on merge: one comment per issue naming the pull request, the
+   commit and the branch, and *then* the closure as `completed`. An issue
+   it could not comment on is left open on purpose and the run goes red.
+   Your job is to *verify* both happened, on each issue, and to finish by
+   hand any it left open (comment first, then `state_reason: completed` —
+   the fix shipped). An accepted issue whose fix is merged and which is
+   still open is the backlog lying about itself; one closed with nothing
+   written on it is the backlog being rude.
 
 **Do not wait for the maintainer at any point of this.** Not to start, not
 to merge, not to close. The instruction covers the whole sequence — fix,

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -871,14 +871,30 @@ verdict becomes `bug:confirmed` about the interface instead. What changed
 is the cost of being wrong, not the standard for being right.
 
 **The one thing that does close an issue automatically is a merged fix**,
-through the `Closes #158` keyword GitHub reads on a pull request body —
-and `issue-fixed-comment.yml` makes sure it never happens in silence. On
-every merge it posts one comment per issue the pull request names, saying
-the fix is on `main` and in which pull request and commit, then closes as
-`completed` any that the keyword failed to close (a fork's pull request, a
-base branch that is not the default one). GitHub's own close lands a few
-seconds before that comment; what the workflow guarantees is that nobody
-finds their report closed with nothing said on it.
+and `issue-fixed-comment.yml` is what does it — not GitHub. On every merge
+it reads the pull request body for the issues it names, posts one comment
+per issue saying the fix is on `main` and in which pull request and commit,
+and closes each as `completed` afterwards. An issue it could not comment on
+is deliberately left open and the run goes red: an open issue is five
+minutes of somebody's time, a silent closure is the thing the file exists
+to prevent.
+
+That order is the reason a pull request body here says `Corrige #158`
+rather than `Closes #158`. GitHub's own closing keywords close the issue
+server-side at the instant of the merge, seconds before any workflow can
+run, so the earlier version of this file commented *beside* a closure that
+had already happened — the reporter's first notification was still a
+strikethrough. `Corrige` is not a keyword GitHub acts on, so nothing closes
+the issue but the workflow, after it has spoken. What that costs is the
+issue's *Development* sidebar link, which only a closing keyword creates;
+what stands in its place is the timeline cross-reference `Corrige #158`
+still produces and a comment that names the pull request and the commit
+outright. English keywords are still read, so a body written the old way
+gets its comment too — GitHub will have closed that one first, and the
+workflow finds it already closed. The convention is asserted in
+`tests/Security/IssueTriageWorkflowPermissionsTest.php`, because AGENTS.md
+drifting back to `Closes` would be a green pull request that silently
+restores the old ordering.
 
 One gap, recorded rather than papered over: **a feature request has no
 verdict.** `feature.yml` opens issues with `triage:pending` like `bug.yml`,

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -871,13 +871,17 @@ verdict becomes `bug:confirmed` about the interface instead. What changed
 is the cost of being wrong, not the standard for being right.
 
 **The one thing that does close an issue automatically is a merged fix**,
-and `issue-fixed-comment.yml` is what does it — not GitHub. On every merge
-it reads the pull request body for the issues it names, posts one comment
-per issue saying the fix is on `main` and in which pull request and commit,
-and closes each as `completed` afterwards. An issue it could not comment on
-is deliberately left open and the run goes red: an open issue is five
-minutes of somebody's time, a silent closure is the thing the file exists
-to prevent.
+and on a body written to the convention below — `Corrige #158` — it is
+`issue-fixed-comment.yml` that closes it, not GitHub. On every merge the
+workflow reads the pull request body for the issues it names, posts one
+comment per issue saying the fix is on `main` and in which pull request and
+commit, and closes each as `completed` afterwards. An issue it could not
+comment on, or whose state it could not read back, is deliberately left
+open and the run goes red: an open issue is five minutes of somebody's
+time, a silent closure is the thing the file exists to prevent. A body that
+uses one of GitHub's own closing keywords instead is the exception, and it
+is the old behaviour: GitHub closes that issue at the merge and the
+workflow's comment lands beside the closure rather than before it.
 
 That order is the reason a pull request body here says `Corrige #158`
 rather than `Closes #158`. GitHub's own closing keywords close the issue

--- a/tests/Security/IssueTriageWorkflowPermissionsTest.php
+++ b/tests/Security/IssueTriageWorkflowPermissionsTest.php
@@ -358,9 +358,11 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
 
         self::assertMatchesRegularExpression(
             '/grep -oiE .*corrige/',
-            $workflow,
+            $this->shellOf($workflow),
             self::FIXED_COMMENT . ' no longer reads `Corrige #158`, which is the marker AGENTS.md '
-            . 'tells a pull request body to carry.',
+            . 'tells a pull request body to carry. Asserted against the script with its comments '
+            . 'stripped: the header explains the marker at length, and a test satisfied by prose '
+            . 'would pass while the extraction no longer looked for it.',
         );
 
         self::assertStringContainsString(
@@ -2600,5 +2602,42 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
         self::assertIsString($contents, 'Could not read ' . $workflow . '.');
 
         return $contents;
+    }
+
+    /**
+     * What a workflow's `run:` blocks actually EXECUTE — every `#` line
+     * dropped.
+     *
+     * These files carry more prose than script, and an assertion made
+     * against the whole text is satisfied by a comment saying the right
+     * thing. That is not a hypothetical: the paragraph explaining a
+     * marker and the command reading it are twenty lines apart, and only
+     * one of them runs.
+     */
+    private function shellOf(string $contents): string
+    {
+        $script = '';
+        $inRun = false;
+
+        foreach (explode("\n", $contents) as $line) {
+            if (preg_match('/^\s*run: \|/', $line) === 1) {
+                $inRun = true;
+                continue;
+            }
+
+            // A line back at column 0 that is not blank has left the
+            // block scalar; anything indented, or empty, is still in it.
+            if ($inRun && trim($line) !== '' && $line[0] !== ' ') {
+                $inRun = false;
+            }
+
+            if ($inRun && !str_starts_with(ltrim($line), '#')) {
+                $script .= $line . "\n";
+            }
+        }
+
+        self::assertNotSame('', trim($script), 'Found no `run:` script to read.');
+
+        return $script;
     }
 }

--- a/tests/Security/IssueTriageWorkflowPermissionsTest.php
+++ b/tests/Security/IssueTriageWorkflowPermissionsTest.php
@@ -277,12 +277,13 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
      * The point of the workflow, asserted so it cannot quietly become a
      * closer that says nothing.
      *
-     * GitHub closes an issue named by a closing keyword and writes a
-     * timeline reference: the reporter is notified their report was
-     * closed, with no sentence saying it was FIXED. This exists to put
-     * that sentence there.
+     * The comment is posted first and the closure follows it, in that
+     * order, because the order is the whole reason this file stopped
+     * relying on GitHub's closing keywords: a keyword closes the issue
+     * server-side at the merge, seconds before any workflow runs, and the
+     * reporter's first notification is then a bare strikethrough.
      */
-    public function testAFixedIssueIsToldSoBeforeItIsLeftClosed(): void
+    public function testAFixedIssueIsToldSoBeforeItIsClosed(): void
     {
         $file = $this->contents(self::FIXED_COMMENT);
 
@@ -292,14 +293,14 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
         self::assertIsInt($comment, self::FIXED_COMMENT . ' no longer posts a comment at all.');
         self::assertIsInt(
             $close,
-            self::FIXED_COMMENT . ' no longer closes as `completed` the issues the keyword missed.',
+            self::FIXED_COMMENT . ' no longer closes as `completed` the issues its fix landed on.',
         );
 
         self::assertLessThan(
             $close,
             $comment,
-            self::FIXED_COMMENT . ' closes an issue before saying anything on it. The comment is '
-            . 'the point of this workflow; the closing is the belt to GitHub\'s braces.',
+            self::FIXED_COMMENT . ' closes an issue before saying anything on it. Nothing else '
+            . 'closes these issues any more, so this order is the only one there is.',
         );
 
         self::assertStringNotContainsString(
@@ -308,6 +309,77 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
             self::FIXED_COMMENT . ' closes an issue as `not planned`. A merged fix completed it, '
             . 'and `not planned` is a lie the release notes would pick up.',
         );
+    }
+
+    /**
+     * An issue this workflow could not speak on is left open.
+     *
+     * "Comment, then close" is not a guarantee if a failed comment falls
+     * through to the closing anyway — that is precisely the silent
+     * closure the file exists to prevent, reached by the other road. The
+     * failure branch must leave the loop before the `PATCH`.
+     */
+    public function testAnIssueThatCouldNotBeCommentedOnIsLeftOpen(): void
+    {
+        $file = $this->contents(self::FIXED_COMMENT);
+
+        $failure = strpos($file, 'Could not comment');
+        $close = strpos($file, '-f state=closed -f state_reason=completed');
+
+        self::assertIsInt($failure, self::FIXED_COMMENT . ' no longer handles a comment that fails.');
+        self::assertIsInt($close, self::FIXED_COMMENT . ' no longer closes anything.');
+        self::assertLessThan($close, $failure, self::FIXED_COMMENT . ' handles a failed comment '
+            . 'after it has already closed the issue.');
+
+        self::assertStringContainsString(
+            'continue',
+            substr($file, $failure, $close - $failure),
+            self::FIXED_COMMENT . ' closes an issue it failed to comment on. A comment that did '
+            . 'not land must skip the closing, not be followed by it.',
+        );
+    }
+
+    /**
+     * The doctrine and the workflow name the same marker, and it is one
+     * GitHub does not act on.
+     *
+     * This is the invariant the ordering rests on, and it lives in two
+     * files that nothing otherwise ties together: AGENTS.md tells whoever
+     * writes a pull request body what to put in it, and the workflow
+     * reads it back. A body that said `Closes #158` again would close the
+     * issue at the merge, seconds before this workflow could speak — a
+     * green pull request, a green CI run, and the old bad order silently
+     * restored.
+     */
+    public function testTheDoctrineNamesAMarkerGitHubWillNotActOn(): void
+    {
+        $workflow = $this->contents(self::FIXED_COMMENT);
+        $agents = $this->contents('AGENTS.md');
+
+        self::assertMatchesRegularExpression(
+            '/grep -oiE .*corrige/',
+            $workflow,
+            self::FIXED_COMMENT . ' no longer reads `Corrige #158`, which is the marker AGENTS.md '
+            . 'tells a pull request body to carry.',
+        );
+
+        self::assertStringContainsString(
+            '`Corrige #158`',
+            $agents,
+            'AGENTS.md no longer tells a pull request body to name its issues with `Corrige #158`, '
+            . 'which is the only marker ' . self::FIXED_COMMENT . ' can close in the right order.',
+        );
+
+        foreach (['Closes #', 'Fixes #', 'Resolves #'] as $keyword) {
+            self::assertStringNotContainsString(
+                $keyword,
+                $agents,
+                'AGENTS.md tells a pull request body to write `' . $keyword . '`, one of GitHub\'s '
+                . 'own closing keywords. GitHub then closes the issue at the merge, before '
+                . self::FIXED_COMMENT . ' can say the fix landed — which is the bug this '
+                . 'convention exists to avoid.',
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

`issue-fixed-comment.yml` commented *beside* the closure rather than before it. The `Closes #158` keyword makes GitHub close the issue server-side at the instant of the merge, seconds before any workflow can run, so a reporter's first notification was still a bare strikethrough with no sentence saying the report had been fixed.

**The closing is taken away from GitHub.** A pull request body now names its issues with `Corrige #158` — deliberately not one of GitHub's nine closing keywords — so nothing closes the issue but the workflow, after it has posted its comment. A comment that could not be posted skips the closing entirely and turns the run red: an issue left open is something the maintainer finishes by hand; an issue closed in silence is the thing this file exists to prevent.

**What it costs, and what stands in its place.** Only a closing keyword creates the issue's *Development* sidebar link, so that link is gone — the trade-off the maintainer asked for. `Corrige #158` still cross-references the pull request on the issue's timeline where the link would have pointed, and the comment names the pull request and the merge commit outright, which is more than the sidebar ever said. English keywords are still read, so a body written the old way still gets its comment; GitHub will have closed that one first, and the state read back finds it already closed.

The convention now lives in two files nothing otherwise ties together — `AGENTS.md` § Fix the backlog tells a body what to carry, the workflow reads it back — so it is asserted rather than left to review. Drift back to `Closes` would be a green pull request, a green CI run, and the old ordering silently restored.

**Changed**

- `.github/workflows/issue-fixed-comment.yml` — reads `Corrige #N` alongside the English keywords; comments, then closes; a failed comment leaves its issue open and the run red.
- `AGENTS.md` steps 5 and 6, `docs/quality-pipeline.md` — the convention and why it is shaped that way.
- `tests/Security/IssueTriageWorkflowPermissionsTest.php` — three assertions: the comment precedes the closure, a failed comment skips the closure, and AGENTS.md names the same marker and no GitHub closing keyword.

The step's shell was exercised against a stubbed `gh` for all three paths (every comment lands, one comment fails, no issue named) before it was committed.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 15817 tests, green)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — no errors)
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — n/a, no JS changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JbQrctJzTazTgkpT3cppTG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JbQrctJzTazTgkpT3cppTG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for using `Corrige `#N`` to reference issues without closing them automatically.
  * Fixed issues are now commented on with pull request, commit, and branch details before being closed.

* **Bug Fixes**
  * Issues remain open when commenting fails, and the workflow reports failure.
  * Closure failures are now reported as unsuccessful runs.

* **Documentation**
  * Updated contributor guidance and quality-pipeline documentation to describe the revised issue-closing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->