### PR TITLE
Un correctif annoncé pour rien reste un ticket fermé en silence

### DIFF
--- a/.github/workflows/issue-fixed-comment.yml
+++ b/.github/workflows/issue-fixed-comment.yml
@@ -30,6 +30,50 @@
 # fixed text plus the pull request number and the merge SHA. A body is
 # untrusted input here for the same reason an issue body is in
 # issue-triage.yml.
+#
+# **WHAT A GREEN RUN MEANS HERE, and it did not mean this at first.** Every
+# call in the step below used to end `|| echo "::warning …"`, so a run in
+# which nobody was told anything and nothing was closed finished GREEN,
+# with two annotations nobody reads on a merge everybody had moved on
+# from. That is the failure shape docs/quality-pipeline.md § "something
+# green that proved nothing" collects, and it is the one this whole family
+# of workflows was rewritten around — issue-triage.yml exists in its
+# current form because a triage that wrote nothing used to report success.
+#
+# So there is now exactly ONE tolerated failure, and it is the one the
+# original comment was actually describing: a **404**, meaning the number
+# in the body is not an issue of this repository — deleted since, or a
+# typo, or a reference to somewhere else. That is a warning and the issue
+# is skipped. Everything else — a 403, a rate limit, a network error, a
+# token that turned out to be read-only — sets the job's exit code, and
+# the merge that failed to tell somebody is visible in the Actions tab
+# instead of being one green tick among the others. The 404 is told apart
+# from the rest by reading `gh`'s own message, the way
+# scripts/sync-issue-labels.sh already does it.
+#
+# The FORK case is the concrete one behind "a token that turned out to be
+# read-only". `pull_request` (not `pull_request_target`, which
+# tests/Security/IssueTriageWorkflowPermissionsTest.php forbids here, and
+# rightly) hands a READ-ONLY `GITHUB_TOKEN` to a run raised by a pull
+# request from a fork, whatever this job's `permissions:` block says. So a
+# merged contribution from outside — the one case where nobody in this
+# repository is watching the thread — cannot be commented on at all. It
+# cannot be fixed from inside this file without giving the trigger a
+# writable token on a payload a fork controls, which is a worse trade, so
+# it is made LOUD instead: the run goes red and the error names the
+# reason, rather than leaving a reporter in silence behind a green tick.
+#
+# **IT SAYS IT ONCE.** The comment carries an invisible marker naming this
+# pull request, and an issue already carrying it is skipped whole — both
+# the comment and the closing. Re-running a workflow is an ordinary thing
+# to do (a transient API failure, now that those are red), and it must not
+# post a second identical notice on somebody's report, nor re-close an
+# issue a human has deliberately reopened since.
+#
+# **AND THE CLOSING WAITS FOR THE TELLING.** If the comment could not be
+# posted, the issue is left exactly as it is. Closing it anyway would
+# produce, from the workflow whose entire purpose is to stop that, the
+# thing it exists to stop: an issue closed with nothing said on it.
 
 name: Issue fixed
 
@@ -84,6 +128,41 @@ jobs:
             exit 0
           fi
 
+          # THE THREE OUTCOMES OF AN API CALL, told apart instead of
+          # collapsed into "did not succeed". `gh` says which happened in
+          # its own message on stderr, and reading that message is how
+          # scripts/sync-issue-labels.sh already tells "this label does
+          # not exist yet" from "this token no longer works".
+          #
+          #   0 — it worked.
+          #   1 — HTTP 404: the number in the body is not an issue of this
+          #       repository. Deleted since, mistyped, or pointing
+          #       somewhere else. Not this workflow's to fail on.
+          #   2 — anything else. A reporter was not told something, and
+          #       the run must say so in the only place anybody will look
+          #       at afterwards, which is the Actions tab.
+          errors="$(mktemp)"
+          trap 'rm -f "${errors}"' EXIT
+
+          attempt() {
+            if "$@" 2>"${errors}"; then
+              return 0
+            fi
+
+            if grep -q 'HTTP 404' "${errors}"; then
+              return 1
+            fi
+
+            cat "${errors}" >&2
+
+            return 2
+          }
+
+          # A reporter this run failed to tell. Collected rather than
+          # thrown immediately: one issue the API refused must not stop
+          # the others in the same merge from being answered.
+          failed=0
+
           for issue in ${issues}; do
             # Belt and braces on a value that goes into an API path. The
             # regex above cannot produce anything else; this is what
@@ -95,35 +174,121 @@ jobs:
                 ;;
             esac
 
+            # SAID ONCE, and the marker is what makes that true across
+            # re-runs. It is an HTML comment, so it is invisible in the
+            # rendered thread, and it names THIS pull request: a second
+            # fix for the same issue, months later, is a different notice
+            # and says so.
+            marker="<!-- issue-fixed-comment: pull request #${PR_NUMBER} -->"
+
+            # Read the thread first, and match afterwards, rather than
+            # piping one into the other: `grep -q` stops at the first
+            # match, the write end of the pipe then dies of SIGPIPE, and
+            # under `set -o pipefail` that is a FAILING pipeline — so the
+            # shape that reads naturally would silently mean the opposite
+            # on the only run where it matters, and post the duplicate it
+            # was written to prevent.
+            outcome=0
+            said="$(attempt gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/issues/${issue}/comments" --jq '.[].body')" || outcome=$?
+
+            if [ "${outcome}" -eq 1 ]; then
+              echo "::warning title=No such issue here::#${issue} is not an issue of \
+              ${GITHUB_REPOSITORY} — deleted, mistyped, or somewhere else. Nothing was written."
+              continue
+            fi
+
+            if [ "${outcome}" -ne 0 ]; then
+              echo "::error title=Could not read the issue::Reading the comments of #${issue} \
+              failed, so this run cannot tell whether its reporter has already been told. Nothing \
+              was written to it."
+              failed=1
+              continue
+            fi
+
+            if grep -qF "${marker}" <<< "${said}"; then
+              echo "#${issue} has already been told about #${PR_NUMBER}; it is left exactly as it is."
+              continue
+            fi
+
             # Fixed text, plus three values GitHub produced. Written in
             # French, like every other thing a reporter reads.
-            body="$(printf '%s\n\n%s\n\n%s\n\n---\n%s\n' \
+            body="$(printf '%s\n%s\n\n%s\n\n%s\n\n---\n%s\n' \
+              "${marker}" \
               "**C'est corrigé.** Le correctif est fusionné sur \`${BASE_REF}\` et partira dans la prochaine version." \
               "Il est arrivé par la pull request #${PR_NUMBER}, dans le commit \`${MERGE_SHA}\`." \
               "Si ce que vous aviez signalé se reproduit, répondez ici plutôt que d'ouvrir un nouveau ticket : le fil garde le contexte." \
               "_Generated by [Claude Code](https://claude.ai/code)_")"
 
-            if gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}/comments" \
-              -X POST -f "body=${body}" --silent; then
-              echo "Told #${issue} that its fix landed."
-            else
-              # A 404 is an issue in another repository, or one deleted
-              # since the body was written; neither is this workflow's to
-              # fail on. The state read back below is what decides.
-              echo "::warning title=Could not comment::Commenting on #${issue} did not succeed."
+            outcome=0
+            attempt gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}/comments" \
+              -X POST -f "body=${body}" --silent || outcome=$?
+
+            if [ "${outcome}" -eq 1 ]; then
+              echo "::warning title=No such issue here::#${issue} is not an issue of \
+              ${GITHUB_REPOSITORY}. Nothing was written."
+              continue
             fi
+
+            # AND THE CLOSING WAITS FOR THE TELLING. Closing an issue the
+            # comment did not reach would produce exactly the silent
+            # closure this workflow exists to prevent, from the workflow
+            # that exists to prevent it. A merged pull request from a
+            # FORK is the known cause: `pull_request` hands such a run a
+            # read-only token whatever the permissions above say.
+            if [ "${outcome}" -ne 0 ]; then
+              echo "::error title=Nobody was told::Commenting on #${issue} failed, so it was \
+              deliberately left as it is rather than closed in silence. If this pull request came \
+              from a fork, the token was read-only and no permission here can change that: say it \
+              on the issue by hand."
+              failed=1
+              continue
+            fi
+
+            echo "Told #${issue} that its fix landed."
 
             # GitHub has almost certainly closed it already; this settles
             # the cases where it did not — a keyword on a pull request
             # from a fork, a base branch that is not the default one, an
             # auto-close that silently failed. `completed`, because it
             # was.
-            state="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" --jq '.state' || echo 'unknown')"
+            #
+            # The REASON is read too, not just the state, and that is not
+            # pedantry: GitHub's keyword does not reopen a closed issue,
+            # so a report closed as `not planned` before its fix landed
+            # stays filed under "dropped" for ever — on a thread that now
+            # says it is corrected. Setting the reason is what the
+            # release notes read.
+            outcome=0
+            state="$(attempt gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \
+              --jq '.state + " " + (.state_reason // "")')" || outcome=$?
 
-            if [ "${state}" = 'open' ]; then
-              gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \
-                -X PATCH -f state=closed -f state_reason=completed --silent \
-                || echo "::warning title=Could not close::Closing #${issue} did not succeed."
-              echo "Closed #${issue} as completed; the keyword had not."
+            if [ "${outcome}" -ne 0 ]; then
+              echo "::error title=Could not read the issue::#${issue} was told its fix landed, and \
+              reading its state back failed. Check by hand that it is closed as completed."
+              failed=1
+              continue
             fi
+
+            if [ "${state}" = 'closed completed' ]; then
+              continue
+            fi
+
+            outcome=0
+            attempt gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \
+              -X PATCH -f state=closed -f state_reason=completed --silent || outcome=$?
+
+            if [ "${outcome}" -ne 0 ]; then
+              echo "::error title=Could not close::#${issue} was told its fix landed and reads \
+              '${state}'. Closing it as completed failed; close it by hand."
+              failed=1
+              continue
+            fi
+
+            echo "Closed #${issue} as completed; it read '${state}' before."
           done
+
+          # One exit code for the whole merge. A reporter nobody could
+          # answer is a red run, which is the only thing anybody sees
+          # afterwards.
+          exit "${failed}"

--- a/.github/workflows/issue-fixed-comment.yml
+++ b/.github/workflows/issue-fixed-comment.yml
@@ -51,6 +51,18 @@
 # from the rest by reading `gh`'s own message, the way
 # scripts/sync-issue-labels.sh already does it.
 #
+# AT EVERY CALL, not at the first two. Each of the four calls below —
+# read the thread, post the comment, read the state, close — gets the
+# same two branches in the same order: 404 warns and skips, anything else
+# is the job's failure. Writing it at some of them and not the others is
+# a rule that says one thing and does another, and it is what the first
+# version of this change did: an issue deleted in the seconds after its
+# comment was posted turned the merge red, on the one failure this file
+# says out loud it tolerates. CodeRabbit caught it on the pull request.
+# `tests/Security/IssueTriageWorkflowPermissionsTest.php` now counts the
+# two branches against each other, so the next call added here cannot
+# quietly have only one of them.
+#
 # The FORK case is the concrete one behind "a token that turned out to be
 # read-only". `pull_request` (not `pull_request_target`, which
 # tests/Security/IssueTriageWorkflowPermissionsTest.php forbids here, and
@@ -263,6 +275,12 @@ jobs:
             state="$(attempt gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \
               --jq '.state + " " + (.state_reason // "")')" || outcome=$?
 
+            if [ "${outcome}" -eq 1 ]; then
+              echo "::warning title=No such issue here::#${issue} was told its fix landed and has \
+              disappeared since — deleted, or transferred elsewhere. There is nothing left to close."
+              continue
+            fi
+
             if [ "${outcome}" -ne 0 ]; then
               echo "::error title=Could not read the issue::#${issue} was told its fix landed, and \
               reading its state back failed. Check by hand that it is closed as completed."
@@ -277,6 +295,12 @@ jobs:
             outcome=0
             attempt gh api "repos/${GITHUB_REPOSITORY}/issues/${issue}" \
               -X PATCH -f state=closed -f state_reason=completed --silent || outcome=$?
+
+            if [ "${outcome}" -eq 1 ]; then
+              echo "::warning title=No such issue here::#${issue} disappeared between reading its \
+              state and closing it. Nothing left to close."
+              continue
+            fi
 
             if [ "${outcome}" -ne 0 ]; then
               echo "::error title=Could not close::#${issue} was told its fix landed and reads \

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -880,6 +880,31 @@ base branch that is not the default one). GitHub's own close lands a few
 seconds before that comment; what the workflow guarantees is that nobody
 finds their report closed with nothing said on it.
 
+That guarantee is only as good as the run's exit code, and at first it was
+not: every call in that job ended `|| echo "::warning …"`, so a run in
+which nobody was told anything finished **green**, with two annotations on
+a merge everybody had moved on from — the shape this document's last
+section is entirely about. Now exactly one failure is tolerated, and it is
+the one the code was describing: a **404**, meaning the number is not an
+issue of this repository (deleted, mistyped, pointing elsewhere), which
+warns and skips. Everything else fails the run, told apart by reading
+`gh`'s own message the way `scripts/sync-issue-labels.sh` does. Two
+consequences worth knowing: **the closing waits for the telling** — an
+issue whose comment could not be posted is left exactly as it is, since
+closing it anyway is the silent closure this job exists to prevent — and a
+merged pull request **from a fork** now goes red instead of quiet, because
+`pull_request` hands such a run a read-only token whatever the job's
+permissions say, and no permission here can change that (the alternative,
+`pull_request_target`, is forbidden for this file and asserted to be).
+
+It also says it **once**: the comment carries an invisible marker naming
+the pull request, and an issue already carrying it is skipped whole — no
+second notice on a re-run, and no re-closing of an issue a human has since
+reopened. And it reads the closing **reason**, not just the state, so a
+report closed as `not planned` before its fix landed (GitHub's keyword
+does not reopen a closed issue) stops being filed under "dropped" on a
+thread that now says it is corrected.
+
 One gap, recorded rather than papered over: **a feature request has no
 verdict.** `feature.yml` opens issues with `triage:pending` like `bug.yml`,
 but the three verdicts are all about defects, and `bug:not-a-bug` means

--- a/tests/Security/IssueTriageWorkflowPermissionsTest.php
+++ b/tests/Security/IssueTriageWorkflowPermissionsTest.php
@@ -229,12 +229,28 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
             . 'request closed unmerged it would announce a fix that does not exist.',
         );
 
-        self::assertStringNotContainsString(
-            'pull_request_target',
-            $file,
-            self::FIXED_COMMENT . ' now triggers on `pull_request_target`, which runs with the base '
-            . "repository's secrets against a head somebody else controls.",
+        // The DECLARATIONS, not the prose — the same treatment
+        // testTheFixedCommentWorkflowHoldsOnlyWhatItNeeds gives the
+        // permission block, and for the same reason. The file explains at
+        // some length why it is not on that trigger, and an audit that
+        // reads a paragraph is an audit that fails when somebody rewrites
+        // the paragraph. What must not happen is the trigger appearing in
+        // the `on:` block; a comment saying the word is the file doing its
+        // job.
+        $declarations = array_filter(
+            $this->lines(self::FIXED_COMMENT),
+            static fn (string $line): bool => trim($line) !== '' && !str_starts_with(trim($line), '#'),
         );
+
+        foreach ($declarations as $number => $line) {
+            self::assertStringNotContainsString(
+                'pull_request_target',
+                $line,
+                self::FIXED_COMMENT . ' now triggers on `pull_request_target` at line '
+                . ($number + 1) . ', which runs with the base repository\'s secrets against a head '
+                . 'somebody else controls.',
+            );
+        }
     }
 
     /**
@@ -307,6 +323,156 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
             $file,
             self::FIXED_COMMENT . ' closes an issue as `not planned`. A merged fix completed it, '
             . 'and `not planned` is a lie the release notes would pick up.',
+        );
+    }
+
+    /**
+     * A RUN IN WHICH NOBODY WAS TOLD MUST BE RED.
+     *
+     * Every call in that job used to end `|| echo "::warning …"`, so a
+     * merge whose comments all failed finished green with two annotations
+     * nobody reads. That is the failure shape the whole of this file is
+     * about — issue-triage.yml is written the way it is because a triage
+     * that wrote nothing used to report success — and it had reappeared
+     * in the one workflow whose entire purpose is to stop a report going
+     * silent.
+     *
+     * Exactly one failure may be tolerated, and it is the one the
+     * original comment was describing: a 404, meaning the number is not
+     * an issue of this repository. It is told apart by reading `gh`'s own
+     * message, the way scripts/sync-issue-labels.sh tells "this label
+     * does not exist yet" from "this token no longer works".
+     */
+    public function testAMergeThatToldNobodyIsARedRun(): void
+    {
+        $file = $this->contents(self::FIXED_COMMENT);
+
+        self::assertStringContainsString(
+            "grep -q 'HTTP 404'",
+            $file,
+            self::FIXED_COMMENT . ' no longer tells a 404 from any other failure. Either it fails '
+            . 'on an issue number that was deleted since the body was written, or — far worse — it '
+            . 'passes over a 403, a rate limit and a read-only token in the same breath.',
+        );
+
+        self::assertStringContainsString(
+            'exit "${failed}"',
+            $file,
+            self::FIXED_COMMENT . ' cannot end red. A merge where every comment failed then reports '
+            . 'success, and the reporters it could not answer are invisible: nobody reads a '
+            . 'warning annotation on a green run of a workflow they have never heard of.',
+        );
+
+        self::assertSame(
+            0,
+            preg_match('/\|\|\s*echo "::warning title=Could not/', $file),
+            self::FIXED_COMMENT . ' swallows a failed write into a warning again. A warning is what '
+            . 'this workflow used to do instead of failing, and it is why a run that achieved '
+            . 'nothing looked exactly like one that worked.',
+        );
+    }
+
+    /**
+     * AND AN ISSUE NOBODY COULD BE TOLD ABOUT IS NOT CLOSED.
+     *
+     * The ordering test above says the comment comes first in the file.
+     * This one says the closing DEPENDS on it: an issue whose comment
+     * failed must be left exactly as it is, because closing it anyway
+     * produces — from the workflow whose whole purpose is to prevent it —
+     * an issue closed with nothing said on it.
+     *
+     * The likeliest cause is a merged pull request from a FORK:
+     * `pull_request` hands that run a read-only `GITHUB_TOKEN` whatever
+     * the job's `permissions:` block says, and the alternative trigger is
+     * forbidden here (see above). It cannot be fixed from inside the
+     * file, so it is made loud instead.
+     */
+    public function testAnIssueThatCouldNotBeToldIsNotClosed(): void
+    {
+        $file = $this->contents(self::FIXED_COMMENT);
+
+        self::assertStringContainsString(
+            'title=Nobody was told',
+            $file,
+            self::FIXED_COMMENT . ' no longer says, in the run\'s own log, that a reporter went '
+            . 'unanswered. That sentence is the only trace anybody gets of it.',
+        );
+
+        $told = strpos($file, 'title=Nobody was told');
+        $close = strpos($file, '-X PATCH -f state=closed');
+
+        self::assertIsInt($told);
+        self::assertIsInt($close, self::FIXED_COMMENT . ' no longer closes anything.');
+
+        self::assertLessThan(
+            $close,
+            $told,
+            self::FIXED_COMMENT . ' closes an issue on a path that has not established the comment '
+            . 'landed. A silent closure is what this workflow exists to prevent, and performing it '
+            . 'itself is the one way it can be worse than not existing.',
+        );
+    }
+
+    /**
+     * It says it ONCE, across re-runs.
+     *
+     * Re-running a workflow is an ordinary thing to do — more so now that
+     * a transient API failure turns the run red — and it must not post a
+     * second identical notice on somebody's report, nor re-close an issue
+     * a human has deliberately reopened since. So the comment carries an
+     * invisible marker naming the pull request, and an issue already
+     * carrying it is skipped whole.
+     */
+    public function testTheFixedNoticeIsSaidOnlyOnce(): void
+    {
+        $file = $this->contents(self::FIXED_COMMENT);
+
+        self::assertStringContainsString(
+            'issue-fixed-comment: pull request #${PR_NUMBER}',
+            $file,
+            self::FIXED_COMMENT . ' posts a notice carrying no marker, so a re-run comments a '
+            . 'second time on every issue the merge named, and re-closes any that somebody has '
+            . 'reopened in between.',
+        );
+
+        self::assertStringContainsString(
+            'grep -qF "${marker}" <<< "${said}"',
+            $file,
+            self::FIXED_COMMENT . ' no longer matches the marker against comments it has already '
+            . 'read. Piping `gh api` into `grep -q` is the shape to avoid: grep stops at the first '
+            . 'match, the write end dies of SIGPIPE, and under `pipefail` the pipeline FAILS — so '
+            . 'the check silently means the opposite on the only run where it matters.',
+        );
+    }
+
+    /**
+     * `completed` is set even on an issue that is already closed for
+     * another reason.
+     *
+     * GitHub's closing keyword does not reopen a closed issue, so a
+     * report closed as `not planned` before its fix landed keeps that
+     * reason for ever — filed under "dropped", on a thread that now says
+     * it is corrected, and read that way by the release notes. Comparing
+     * the state alone cannot see it.
+     */
+    public function testAFixedIssueEndsClosedAsCompletedWhateverItWasBefore(): void
+    {
+        $file = $this->contents(self::FIXED_COMMENT);
+
+        self::assertStringContainsString(
+            "'.state + \" \" + (.state_reason // \"\")'",
+            $file,
+            self::FIXED_COMMENT . ' reads an issue\'s state without its reason, so an issue closed '
+            . 'as `not planned` before the fix landed is left that way — the reason a merged fix '
+            . 'was supposed to correct.',
+        );
+
+        self::assertStringContainsString(
+            "\"\${state}\" = 'closed completed'",
+            $file,
+            self::FIXED_COMMENT . ' no longer compares against `closed completed`, so it either '
+            . 'skips an issue that is closed for the wrong reason or re-closes one that is already '
+            . 'right.',
         );
     }
 

--- a/tests/Security/IssueTriageWorkflowPermissionsTest.php
+++ b/tests/Security/IssueTriageWorkflowPermissionsTest.php
@@ -370,6 +370,24 @@ class IssueTriageWorkflowPermissionsTest extends TestCase
             . 'this workflow used to do instead of failing, and it is why a run that achieved '
             . 'nothing looked exactly like one that worked.',
         );
+
+        // AND THE TOLERANCE IS THE SAME AT EVERY CALL. Each of the four
+        // — read the thread, post the comment, read the state, close —
+        // needs both branches, in the same order: 404 warns and skips,
+        // anything else fails the job. The first version of this change
+        // had them at two calls out of four, so an issue deleted in the
+        // seconds after its comment was posted turned the merge red on
+        // the one failure the file says out loud that it tolerates.
+        // CodeRabbit caught it on the pull request; counting them is what
+        // stops the next call added here from carrying only one.
+        self::assertSame(
+            preg_match_all('/"\$\{outcome\}" -ne 0/', $file),
+            preg_match_all('/"\$\{outcome\}" -eq 1/', $file),
+            self::FIXED_COMMENT . ' has an API call whose failure branch has no 404 branch in front '
+            . 'of it, or the reverse. A 404 means the number is not an issue of this repository, '
+            . 'which this workflow tolerates by design — tolerating it at some calls and not at '
+            . 'others is a rule that says one thing and does another.',
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

`issue-fixed-comment.yml` (#202) faisait la bonne chose et ne pouvait pas dire qu'elle avait échoué : chaque appel finissait par `|| echo "::warning …"`, donc **une fusion où personne n'a été prévenu et rien n'a été fermé se terminait en vert**, avec deux annotations que personne ne lit sur une pull request dont tout le monde était passé à autre chose. C'est la forme d'échec que la dernière section de `docs/quality-pipeline.md` collectionne, et celle pour laquelle `issue-triage.yml` a été réécrit — réapparue dans le seul workflow dont le but entier est qu'un signalement ne se referme pas en silence.

**Un seul échec reste toléré**, celui que le commentaire décrivait vraiment : un **404**, c'est-à-dire un numéro qui n'est pas une issue de ce dépôt (supprimée, mal tapée, ailleurs) — un warning, et on passe. Tout le reste — 403, limite de débit, réseau, jeton en lecture seule — fait rougir le run. Le 404 est distingué en lisant le message de `gh`, comme le fait déjà `scripts/sync-issue-labels.sh`.

Deux conséquences :

- **La fermeture attend l'annonce.** Une issue dont le commentaire n'est pas passé est laissée telle quelle : la fermer quand même produirait, depuis le workflow qui existe pour l'empêcher, l'issue fermée sans rien de dit.
- **Une pull request venue d'un fork devient rouge au lieu d'être muette.** `pull_request` donne à ce run un jeton en lecture seule quoi que dise son bloc `permissions:`, et aucune permission ici n'y changera rien. `pull_request_target` reste interdit pour ce fichier — le test qui l'interdit vise désormais les *déclarations* et non la prose (le même traitement que `testTheFixedCommentWorkflowHoldsOnlyWhatItNeeds` applique au bloc de permissions), pour que l'en-tête puisse expliquer pourquoi il ne l'utilise pas.

Deux autres manques, tant que le fichier est ouvert :

- **Il le dit une seule fois.** Le commentaire porte un marqueur invisible nommant la pull request, et une issue qui le porte déjà est sautée entièrement — pas de second avis sur une relance (plus fréquentes maintenant qu'un échec transitoire rougit), pas de refermeture d'une issue que quelqu'un a rouverte depuis.
- **Il lit la raison de fermeture, pas seulement l'état.** Le mot-clé de GitHub ne rouvre pas une issue fermée : un signalement fermé en `not planned` avant l'arrivée de son correctif restait classé « abandonné » sur un fil qui dit maintenant qu'il est corrigé.

Chacune des quatre propriétés est tenue par un test qui échoue quand on la retire — vérifié en la retirant, une par une. La logique du script a par ailleurs été rejouée hors CI contre un `gh` simulé : cas nominal, issue absente (404), jeton en lecture seule (403 au POST), échec de lecture du fil, relance avec marqueur, aucun mot-clé.

Aucun changement de comportement pour un merge qui se passe bien : les mêmes commentaires, au même endroit, dans le même ordre.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [ ] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — *sans objet, aucun fichier JavaScript touché*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVhVkzQynX44Bm1ok2JCAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01HVhVkzQynX44Bm1ok2JCAk)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved issue triage handling for API successes, missing issues, and other failures.
  * Prevented duplicate fixed notifications.
  * Issues are closed only after a successful notification and must end in the completed state.
  * Processing continues across issues while reporting failures at the end.
  * Fork-originated pull requests now fail when required write permissions are unavailable.

* **Documentation**
  * Updated quality pipeline documentation to reflect notification, closure, and permission-handling behavior.

* **Tests**
  * Added coverage for notification failures, duplicate prevention, issue closure, and workflow permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->