### PR TITLE
Le relecteur se voyait refuser l'outil sur lequel toute sa procédure repose

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -171,10 +171,11 @@ saying whether a review happened and going **red** when it cannot show that
 one did. Read that comment; it is the answer the check alone cannot give.
 
 **And a green `Claude review` did not always mean a review happened even
-when Claude ran.** For its first 105 runs the reviewer was refused the
-`Task` tool its whole procedure is built on, so on every run anybody has
-looked at it launched no review agent, posted nothing, and reported
-success (2026-09-07, fixed
+when Claude ran.** For its first 105 runs the reviewer was refused one tool
+call per run — which one is still not known, the summary counts them
+without naming them — and on every run anybody has looked at, it launched
+no review agent, posted nothing, and reported success (2026-09-07, the
+tools its procedure needs now granted
 in `claude_args`; the story is in that file's header and in
 docs/quality-pipeline.md § Code review). Which is why the comment's verdict
 now rests on two rows — **`Review agents launched`** and **`Tool calls

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -126,7 +126,7 @@ that `ci.yml` calls — which is why a pull request shows them as
 | `Checks / Dynamic scan (passive)` | `./scripts/dast.sh --profile=passive` |
 | `Checks / security` | `composer audit` |
 | `All checks` | nothing of its own — it reads the reusable workflow's roll-up, so it is red exactly when a `Checks / …` job failed or was cancelled, and green when every one either passed or was deliberately skipped (`Checks / SonarQube Cloud` on a fork). Start from the red job, never from here |
-| `Claude review` | no local equivalent — read the findings on the PR; see below |
+| `Claude review` | no local equivalent — read the findings on the PR; see below. Two steps: the action, which reviews and keeps its whole transcript in the run log (`show_full_output`), then `Read what the run actually did`, which reads that transcript back into the counts the status job judges on. That second step never fails the job — a transcript it cannot parse is published as `evidence=missing`, because this is the one required check on `main` |
 | `Claude review status` | no local equivalent — it posts the comment that says what the green above means, deciding from the review job's `result`, its `conclusion` output, and the transcript the run left behind; it is the one check here that can be red on its own |
 | `Checks / SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |

--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -127,7 +127,7 @@ that `ci.yml` calls — which is why a pull request shows them as
 | `Checks / security` | `composer audit` |
 | `All checks` | nothing of its own — it reads the reusable workflow's roll-up, so it is red exactly when a `Checks / …` job failed or was cancelled, and green when every one either passed or was deliberately skipped (`Checks / SonarQube Cloud` on a fork). Start from the red job, never from here |
 | `Claude review` | no local equivalent — read the findings on the PR; see below |
-| `Claude review status` | no local equivalent — it posts the comment that says what the green above means, deciding from the review job's `result` and the `conclusion` output it exports |
+| `Claude review status` | no local equivalent — it posts the comment that says what the green above means, deciding from the review job's `result`, its `conclusion` output, and the transcript the run left behind; it is the one check here that can be red on its own |
 | `Checks / SonarQube Cloud` | no local equivalent — read the bot's PR comment |
 | `Analyze (…)` (CodeQL) | no local equivalent — see `AGENTS.md` § CodeQL |
 
@@ -167,10 +167,21 @@ seconds having reviewed nothing.
 
 You no longer have to open the run to find that out: the `Claude review
 status` job posts one comment on the pull request, rewritten on every run,
-saying which of the three happened — reviewed, skipped without reviewing,
-or did not complete. It reads the action's own `conclusion` output, which
-is empty exactly when the action returned before running Claude. Read that
-comment; it is the answer the check alone cannot give.
+saying whether a review happened and going **red** when it cannot show that
+one did. Read that comment; it is the answer the check alone cannot give.
+
+**And a green `Claude review` did not always mean a review happened even
+when Claude ran.** For its first 105 runs the reviewer was refused the
+`Task` tool its whole procedure is built on, so on every run anybody has
+looked at it launched no review agent, posted nothing, and reported
+success (2026-09-07, fixed
+in `claude_args`; the story is in that file's header and in
+docs/quality-pipeline.md § Code review). Which is why the comment's verdict
+now rests on two rows — **`Review agents launched`** and **`Tool calls
+refused`** — read from the run's own transcript. Agents launched at zero,
+or any tool refused, and no review happened, whatever the check says.
+A refusal names the tool: grant it in `claude_args`, or write down in that
+file why it must stay denied.
 
 **Its `Took` row is information, not evidence.** That comment used to
 decide on duration — under a minute meant a skip — and it was wrong

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -62,9 +62,12 @@ jobs:
     # takes a few minutes; this is a ceiling, not a target.
     timeout-minutes: 20
 
-    # THE ONE FACT THE STATUS JOB BELOW NEEDS, and it comes from the action
-    # rather than from a guess. In anthropics/claude-code-action's
-    # src/entrypoints/run.ts, the workflow-validation refusal does
+    # WHAT THE STATUS JOB BELOW READS, and every value here comes from the
+    # run itself rather than from a guess about it.
+    #
+    # `conclusion` answers ONE question: did the action start Claude at all?
+    # In anthropics/claude-code-action's src/entrypoints/run.ts, the
+    # workflow-validation refusal does
     #
     #     core.setOutput("skipped_due_to_workflow_validation_mismatch", "true");
     #     return;                                    // line 182
@@ -76,9 +79,41 @@ jobs:
     # itself is internal to the action — action.yml does not re-export it —
     # which is why this reads the presence of `conclusion` instead.)
     #
-    # Empty therefore means "nothing was reviewed", with no clock involved.
+    # THAT QUESTION IS NOT THE ONE ANYBODY IS ASKING, and reading it as if
+    # it were was the third instance of this repository's own recurring
+    # failure — see the status job for the first two. `conclusion` is
+    # `success` for an agent that started, was refused a tool it needed,
+    # wrote nothing and ended its turn normally. That is what this workflow
+    # was doing on 2026-09-07, on every one of the four runs sampled out of
+    # the 105 it had made by then: five turns and one permission denial on
+    # a one-line pull request (#193) AND on a twenty-five-file one (#200),
+    # no buffered inline comment on any of them, no Opus model in any
+    # `modelUsage` — while CodeRabbit was finding real defects in the same
+    # diffs. Effort that does not move with the size of the diff is not
+    # review effort, and the command's two bug-hunting agents are Opus by
+    # definition, so they had not run.
+    #
+    # So the rest of these outputs come from the action's `execution_file`,
+    # the transcript the SDK writes: how many turns were spent, how many
+    # tool calls were REFUSED and which ones, and how many review agents
+    # were actually launched. The command this job runs
+    # (plugins/code-review in anthropics/claude-code) is built entirely on
+    # subagents — "Launch a haiku agent", "Launch 4 agents in parallel" —
+    # so zero agent calls means the procedure never started, whatever the
+    # exit status says. That signal needs no threshold, which is the point:
+    # the previous two readers were both a number standing in for a fact.
     outputs:
       conclusion: ${{ steps.claude.outputs.conclusion }}
+      evidence: ${{ steps.evidence.outputs.evidence }}
+      subtype: ${{ steps.evidence.outputs.subtype }}
+      is_error: ${{ steps.evidence.outputs.is_error }}
+      turns: ${{ steps.evidence.outputs.turns }}
+      denials: ${{ steps.evidence.outputs.denials }}
+      denied_tools: ${{ steps.evidence.outputs.denied_tools }}
+      agent_calls: ${{ steps.evidence.outputs.agent_calls }}
+      tools_used: ${{ steps.evidence.outputs.tools_used }}
+      models: ${{ steps.evidence.outputs.models }}
+      cost: ${{ steps.evidence.outputs.cost }}
 
     permissions:
       contents: read
@@ -136,9 +171,13 @@ jobs:
       # gets write access — that is when a code owner distinct from the
       # author exists, and when the gap acquires someone who could use it.
       # Until then the tell is the `Claude review status` comment below,
-      # which reads the action's own `conclusion` output and says outright
-      # whether Claude ran. It used to read the clock, and got it wrong
-      # often enough to warrant issue #159 — see that job for why.
+      # which says outright whether a review happened and goes red when it
+      # cannot show that one did. It reads the action's own `conclusion`
+      # output for this particular skip, and the run's transcript for
+      # everything else. It has already been wrong twice — first on the
+      # clock (issue #159), then on `conclusion` alone, which is `success`
+      # for an agent that started and reviewed nothing — so see that job
+      # for what it reads now and why.
       - uses: anthropics/claude-code-action@d9a44dc489924665d246f0fd0508d102211be397 # v1
         # The id is load-bearing: it is what lets the job above export
         # this step's `conclusion` output to the status job.
@@ -163,12 +202,149 @@ jobs:
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
           prompt: "/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+          # WITHOUT THIS THE TRANSCRIPT IS DISCARDED, and a run that keeps
+          # no transcript cannot explain itself. That is not a general
+          # preference, it is this repository's own experience twice over:
+          # three rounds of fixes to the issue triage could not explain the
+          # failure because no run kept its transcript, and the first one
+          # that did explained it in a single line. The review had the same
+          # hole and paid the same price.
+          #
+          # The cost is that the whole conversation lands in a public run
+          # log. What it holds is the diff and the code around it, both
+          # already public on a public repository; the tokens in it are
+          # registered as secrets and come out `***`, and the action runs
+          # its own redaction over the output besides.
+          show_full_output: true
           # --comment is what puts the findings on the pull request; without
-          # it they are written to the run log and nobody reads them. The
-          # --allowedTools line is not redundant with the skill's own
-          # frontmatter: the action starts the inline-comment MCP server
-          # only when claude_args names that tool.
-          claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
+          # it they are written to the run log and nobody reads them.
+          #
+          # --allowedTools DOES TWO THINGS, and only one of them was being
+          # used. It is what makes the action start the inline-comment MCP
+          # server — it installs that server only when claude_args names one
+          # of its tools — and it is the permission allowlist the agent is
+          # judged against. Naming the comment tool ALONE bought the server
+          # and left everything the reviewing procedure needs to reach it
+          # ungranted, which is where the one permission denial in every
+          # single run came from.
+          #
+          # So the list now covers the work rather than only its last step.
+          # `Task`/`Agent` are first because the command is nothing without
+          # them: every one of its steps is "launch an agent". The gh
+          # commands are the ones the command's own frontmatter declares,
+          # plus the read-only git calls its linking rule needs — it
+          # requires a full commit sha in every inline comment. Naming a
+          # tool that does not exist costs nothing, as issue-triage.yml
+          # records at length; naming none of the ones that do costs the
+          # whole run.
+          #
+          # NO --max-turns, deliberately. The action treats a run that
+          # overruns a turn ceiling as a failure even when the agent
+          # finished its work, so a ceiling set anywhere near the real cost
+          # turns good reviews red — that is what happened to the triage of
+          # #181. A review that fans out to a dozen subagents has no
+          # turn count anybody here can predict, and `timeout-minutes`
+          # above already bounds what a runaway can spend.
+          #
+          # The --append-system-prompt sentence answers step 1 of the
+          # command, which stops the whole review when it believes Claude
+          # has already commented on the pull request. Two things on every
+          # pull request here look exactly like that: the status comment
+          # below, headed "Claude review" and posted by the workflow on
+          # every previous push, and the maintainer's own replies, which
+          # carry a Claude Code signature because that is how they are
+          # written. Neither is a review of the current diff. The rule the
+          # step is really there for — do not review the same commit twice
+          # — is already held by `concurrency` above.
+          claude_args: >-
+            --allowedTools "Task,Agent,Read,Glob,Grep,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
+            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one."
+
+      # WHAT THE RUN ACTUALLY DID, read off the transcript the SDK wrote.
+      #
+      # `if: always()` because a review that failed is exactly the one whose
+      # numbers matter, and because the status job below must never be left
+      # with empty strings it cannot tell apart from zeros. Every branch
+      # here writes every output.
+      #
+      # jq reads the last `result` message for the totals and sweeps the
+      # whole transcript for tool calls. `agent_calls` counts launches of
+      # `Task`/`Agent`: the reviewing command is built entirely on
+      # subagents, so that count is zero exactly when the procedure never
+      # started. `denied_tools` names what was refused, which is the one
+      # line that would have saved 105 runs of silence.
+      - name: Read what the run actually did
+        id: evidence
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          set -euo pipefail
+
+          unknown() {
+            {
+              echo "evidence=missing"
+              echo "subtype="
+              echo "is_error="
+              echo "turns=-1"
+              echo "denials=-1"
+              echo "denied_tools="
+              echo "agent_calls=-1"
+              echo "tools_used="
+              echo "models="
+              echo "cost="
+            } >> "${GITHUB_OUTPUT}"
+            echo "$1"
+          }
+
+          if [[ -z "${EXECUTION_FILE}" || ! -f "${EXECUTION_FILE}" ]]; then
+            unknown "The action published no execution file, so this run cannot say what it did."
+            exit 0
+          fi
+
+          if ! jq -e 'type == "array"' "${EXECUTION_FILE}" >/dev/null 2>&1; then
+            unknown "The execution file is not the array of messages this step knows how to read."
+            exit 0
+          fi
+
+          # No `result` message means the run never reached an end the SDK
+          # summarised, so every total below would be a default rather than
+          # a reading. Defaults that look like readings are the failure this
+          # whole step exists to stop.
+          if ! jq -e '[.[] | select(.type == "result")] | length > 0' "${EXECUTION_FILE}" >/dev/null 2>&1; then
+            unknown "The execution file carries no result message: the run did not reach an end this step can read."
+            exit 0
+          fi
+
+          # One line per output. `// -1` and `// ""` rather than a missing
+          # key: a value this step could not find must arrive as something
+          # the reader can recognise, never as an empty string that reads
+          # as a zero.
+          jq -r '
+            ([.[] | select(.type == "result")] | last) as $r
+            | [ .[]
+                | select(.type == "assistant")
+                | .message.content[]?
+                | select(.type == "tool_use")
+                | .name
+              ] as $calls
+            | ($calls | map(select(. == "Task" or . == "Agent")) | length) as $agents
+            | def flat: gsub("[\r\n]"; " ");
+              [
+                "evidence=present",
+                "subtype=" + (($r.subtype // "") | tostring | flat),
+                "is_error=" + (($r.is_error // false) | tostring),
+                "turns=" + (($r.num_turns // -1) | tostring),
+                "denials=" + (($r.permission_denials_count // -1) | tostring),
+                "denied_tools=" + ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed")] | unique | join(", ") | flat),
+                "agent_calls=" + ($agents | tostring),
+                "tools_used=" + ($calls | unique | join(", ") | flat),
+                "models=" + ((($r.modelUsage // {}) | keys | join(", ")) | flat),
+                "cost=" + (($r.total_cost_usd // 0) | tostring)
+              ] | .[]
+          ' "${EXECUTION_FILE}" | cut -c 1-400 >> "${GITHUB_OUTPUT}"
+
+          echo "Evidence read from ${EXECUTION_FILE}."
 
   # WHY THIS JOB EXISTS. The review above posts inline comments when it finds
   # something and stays silent when it does not — so a green `Claude review`
@@ -180,34 +356,59 @@ jobs:
   # The code-review skill would say so itself: given `--comment` and no
   # findings it posts "No issues found" through `gh pr comment`. That needs
   # `pull-requests: write`, and the review job deliberately does not have it.
-  # Granting it there would be worse than the silence: the same skill stops
-  # early when "Claude has already commented on this PR", so its own summary
-  # comment would suppress the review of every later push — undoing the
-  # per-push guarantee `synchronize` was added for. This job is therefore a
-  # separate one, so the write permission never reaches the step that runs
-  # Claude, and its comment is authored by the workflow rather than by
-  # Claude, so it cannot trip that rule.
+  # This job is therefore a separate one, so the write permission never
+  # reaches the step that runs Claude.
   #
-  # HOW IT TELLS THE TWO APART, and why it no longer reads the clock.
+  # THE SKILL ALSO STOPS EARLY when it believes "Claude has already
+  # commented on this PR", and this comment used to be excused from that on
+  # the grounds that the workflow, not Claude, authors it. That reasoning
+  # reads an author field the skill never looks at: its step 1 hands a
+  # haiku agent the output of `gh pr view --comments` and asks whether
+  # Claude has commented, and what that agent sees is a comment headed
+  # "Claude review" saying a review ran. The answer is in the prompt now —
+  # see `--append-system-prompt` on the review job — rather than in an
+  # assumption about how a model reads a page.
   #
-  # This job used to decide on the review job's duration: under 60 seconds
-  # meant a skip, over it meant a review. That was wrong often enough to be
-  # worse than useless, and issue #159 is the report. The premise — "a real
-  # review takes minutes" — only holds when the review has findings to
-  # write. A clean review posts nothing and finishes in about 20 seconds of
-  # model time; measured across twelve consecutive runs on this repository,
-  # those land between 55 and 70 seconds of job time, straddling the
-  # threshold. So the verdict on a review that found nothing was close to a
-  # coin flip, and it announced "green without a review" over a review that
-  # had genuinely run, cost real subscription usage, and read the whole diff.
+  # HOW IT TELLS THE TWO APART, and why neither the clock nor the exit
+  # status decides it any more. This reader has now been wrong twice, in
+  # the same shape both times: a proxy standing in for the fact.
   #
-  # The signal it uses now is the action's own `conclusion` output, which is
-  # empty exactly when the action returned before running Claude — see the
-  # review job's `outputs:` block for the two lines of run.ts that make that
-  # true. Deterministic, and it stays right whatever a review costs.
+  # FIRST it read the review job's DURATION: under 60 seconds meant a skip,
+  # over it meant a review (issue #159). The premise — "a real review takes
+  # minutes" — only holds when the review has findings to write. A clean
+  # review posts nothing and finishes in about 20 seconds of model time,
+  # which lands either side of the threshold, so the verdict on exactly the
+  # pull requests it was meant to reassure was close to a coin flip.
   #
-  # The duration is still reported. It is informative — a reader can see
-  # what the run spent — but it decides nothing.
+  # THEN it read the action's `conclusion` output, which is empty exactly
+  # when the action returned before running Claude. That is deterministic
+  # and it is still read first, but it answers "did the action start
+  # Claude", not "did anybody review the diff" — and on 2026-09-07 the
+  # difference turned out to be the whole question. Every run sampled that
+  # day had spent five turns and been refused one tool, on diffs of every
+  # size, and this comment had reported "Reviewed, nothing to report" over
+  # all 105 runs the workflow had made. `conclusion` was `success` for
+  # every one of them, because an agent that starts, is refused a tool and
+  # ends its turn normally is a successful agent.
+  #
+  # SO IT NOW READS THE RUN'S OWN RECORD: how many review agents were
+  # launched, and how many tool calls were refused. Both come from the
+  # transcript, both are facts about this run rather than estimates of it,
+  # and neither needs a threshold — the question "were any agents launched
+  # at all" has no borderline. A refusal is disqualifying on its own: the
+  # agent asked for a tool this workflow did not grant, so whatever it
+  # concluded, it concluded without something it judged it needed.
+  #
+  # AND IT GOES RED when it cannot say a review happened. A reader that can
+  # only ever report good news is the failure it was built to catch, one
+  # level up again. It is not on the ruleset's required list, so it warns
+  # rather than blocks — the required check is still `Claude review`, and
+  # promoting this one is a decision for the maintainer once these signals
+  # have a few weeks of runs behind them (docs/quality-pipeline.md
+  # § Branch ruleset on `main`).
+  #
+  # The duration and the cost are still reported. They are informative — a
+  # reader can see what the run spent — but they decide nothing.
   status:
     name: Claude review status
     needs: review
@@ -237,8 +438,21 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           REVIEW_RESULT: ${{ needs.review.result }}
           # Empty when the action declined to run at all; `success` or
-          # `failure` once Claude has run. This is the verdict's source.
+          # `failure` once Claude has run. First question, not the last one.
           REVIEW_CONCLUSION: ${{ needs.review.outputs.conclusion }}
+          # What the run itself recorded. `evidence` is `present` only when
+          # the transcript was found AND carried a result message, so a
+          # value below is a reading rather than a default.
+          EVIDENCE: ${{ needs.review.outputs.evidence }}
+          SUBTYPE: ${{ needs.review.outputs.subtype }}
+          IS_ERROR: ${{ needs.review.outputs.is_error }}
+          TURNS: ${{ needs.review.outputs.turns }}
+          DENIALS: ${{ needs.review.outputs.denials }}
+          DENIED_TOOLS: ${{ needs.review.outputs.denied_tools }}
+          AGENT_CALLS: ${{ needs.review.outputs.agent_calls }}
+          TOOLS_USED: ${{ needs.review.outputs.tools_used }}
+          MODELS: ${{ needs.review.outputs.models }}
+          COST: ${{ needs.review.outputs.cost }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           # The marker identifies this workflow's own comment so each run
           # rewrites it instead of adding another. It is invisible in the
@@ -263,25 +477,64 @@ jobs:
             elapsed="unknown"
           fi
 
-          # A skip and a clean review are both `success`, so the job result
-          # alone cannot separate them — but the action's `conclusion` can:
-          # it is set only after Claude has run. An empty value is read as
-          # "not reviewed", which is the safe direction: this comment must
-          # never claim a review that did not happen.
+          # THE ORDER IS THE ARGUMENT. Each test rules out one way this
+          # check can be green over nothing, cheapest first, and every one
+          # that fires is a reason to distrust the green — so each sets
+          # `unreviewed`, and this job ends red. Only the last branch is
+          # allowed to claim a review happened.
+          unreviewed=1
+
           if [[ "${REVIEW_RESULT}" != "success" ]]; then
             verdict="**The review did not complete** (\`${REVIEW_RESULT}\`). Nothing was reviewed — treat this pull request as unread by Claude."
           elif [[ -z "${REVIEW_CONCLUSION}" ]]; then
             verdict="**Green without a review.** The job succeeded without the action ever running Claude — it declines when this workflow file differs from the copy on \`main\`. Read the diff yourself, or merge the workflow change first and re-run."
+          elif [[ "${EVIDENCE}" != "present" ]]; then
+            verdict="**Unverified.** The action reported success but left no readable transcript, so nothing here can say whether the reviewer did any work. Read the run log."
+          elif [[ "${IS_ERROR}" == "true" || "${SUBTYPE}" != "success" ]]; then
+            verdict="**The reviewer stopped on an error** (\`${SUBTYPE:-unknown}\`). Whatever it had read when it stopped, it did not finish reading the diff."
+          elif [[ "${DENIALS}" != "0" ]]; then
+            verdict="**A tool was refused, so this is not a review.** The agent asked for \`${DENIED_TOOLS:-a tool this run did not name}\` and this workflow had not granted it, so it worked around the gap or gave up — either way it reached its conclusion without something it judged it needed. Grant the tool in \`claude_args\` or say in this file why it must stay denied."
+          elif [[ "${AGENT_CALLS}" == "0" ]]; then
+            verdict="**The review agents never ran.** Every step of the code-review command launches a subagent, and this run launched none, so nothing read the diff for bugs. The run log carries the full transcript; start at the first tool call."
           else
-            verdict="**Reviewed, nothing to report.** Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran."
+            verdict="**Reviewed, nothing to report.** ${AGENT_CALLS} review agents ran over ${TURNS} turns with no tool refused. Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran."
+            unreviewed=0
           fi
 
-          # `-` rather than an empty cell: a blank there reads as a
-          # rendering accident, and this row is the one the verdict rests on.
+          # `-` rather than an empty cell: a blank reads as a rendering
+          # accident, and these rows are what the verdict rests on. A `-1`
+          # means this run could not be read, never zero.
+          #
+          # Every one of these is written as an `if`, never as
+          # `[[ … ]] && x=y`: a false test there returns 1, and under
+          # `set -e` that ends the job silently — which would leave the
+          # comment unwritten in exactly the cases it matters most.
           conclusion_cell="${REVIEW_CONCLUSION:--}"
 
-          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Claude ran | `%s` |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. The verdict comes from the job'"'"'s result and the action'"'"'s own `conclusion` output, never from the duration. See `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
-            "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${conclusion_cell}" "${elapsed}" "${RUN_URL}")"
+          agents_cell="${AGENT_CALLS:--}"
+          if [[ "${agents_cell}" == "-1" ]]; then
+            agents_cell="unknown"
+          fi
+
+          turns_cell="${TURNS:--}"
+          if [[ "${turns_cell}" == "-1" ]]; then
+            turns_cell="unknown"
+          fi
+
+          denials_cell="${DENIALS:--}"
+          if [[ "${denials_cell}" == "-1" ]]; then
+            denials_cell="unknown"
+          fi
+          if [[ -n "${DENIED_TOOLS}" ]]; then
+            denials_cell="${denials_cell} (${DENIED_TOOLS})"
+          fi
+
+          cost_cell="${COST:--}"
+          models_cell="${MODELS:--}"
+          tools_cell="${TOOLS_USED:--}"
+
+          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Claude ran | `%s` |\n| Review agents launched | %s |\n| Tool calls refused | %s |\n| Turns | %s |\n| Tools used | %s |\n| Models | %s |\n| Cost | %s USD |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. The verdict comes from what the run recorded — agents launched, tools refused — never from its duration or its exit status, both of which have already been wrong here. See `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
+            "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${conclusion_cell}" "${agents_cell}" "${denials_cell}" "${turns_cell}" "${tools_cell}" "${models_cell}" "${cost_cell}" "${elapsed}" "${RUN_URL}")"
 
           jq -n --arg body "${body}" '{body: $body}' > payload.json
 
@@ -294,4 +547,13 @@ jobs:
           else
             gh api -X POST "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --input payload.json >/dev/null
             echo "Created the status comment."
+          fi
+
+          # THE COMMENT IS POSTED FIRST, then the job fails. A red job whose
+          # comment never got written says only that something went wrong
+          # here; the comment is the part that says WHAT, and it has to
+          # survive the failure it is reporting.
+          if [[ "${unreviewed}" -ne 0 ]]; then
+            echo "::error::No review can be shown to have happened on this commit — see the Claude review status comment on the pull request."
+            exit 1
           fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -225,8 +225,32 @@ jobs:
           # of its tools — and it is the permission allowlist the agent is
           # judged against. Naming the comment tool ALONE bought the server
           # and left everything the reviewing procedure needs to reach it
-          # ungranted, which is where the one permission denial in every
-          # single run came from.
+          # ungranted.
+          #
+          # WHETHER THAT IS WHAT THE ONE DENIAL WAS IS NOT PROVEN, and this
+          # file is not going to pretend otherwise on a change whose whole
+          # subject is claims nobody checked. What is established: one tool
+          # call was refused in every run sampled, no review agent was ever
+          # launched, and the console summary does not name the tool. What
+          # is NOT established is that the refused tool was `Task` —
+          # issue-triage.yml records the opposite-looking observation, an
+          # agent running `date` and `ls` with --allowedTools naming only
+          # the GitHub MCP server, so built-in tools may not be gated by
+          # this list at all. Granting them eliminates the hypothesis
+          # rather than confirming it; `show_full_output` and the
+          # `denied_tools` output below are what will name the tool on the
+          # next run that is not this pull request's own.
+          #
+          # `Bash(gh pr comment:*)` IS GRANTED THOUGH THE TOKEN CANNOT USE
+          # IT — this job is `pull-requests: read`, so the call returns 403
+          # rather than posting. Granted anyway, because the alternative is
+          # worse: the command's step 7 makes that call on every review that
+          # finds nothing, and a call that is not granted may be recorded as
+          # a denial, which would turn the new red signal below on for every
+          # clean review. A 403 costs the agent one turn and is invisible to
+          # that signal (CodeRabbit's finding on this pull request, and it
+          # is right about the invisibility); the summary comment it would
+          # have posted is the status job's job anyway.
           #
           # So the list now covers the work rather than only its last step.
           # `Task`/`Agent` are first because the command is nothing without
@@ -320,7 +344,30 @@ jobs:
           # key: a value this step could not find must arrive as something
           # the reader can recognise, never as an empty string that reads
           # as a zero.
-          jq -r '
+          #
+          # `permission_denials` IS AN ARRAY AND THERE IS NO COUNT FIELD.
+          # The `permission_denials_count` in the run log is the ACTION's
+          # own summary line — base-action/src/run-claude-sdk.ts computes
+          # `resultMsg.permission_denials?.length ?? 0` for the console —
+          # while `writeExecutionFile(messages)` a few lines later saves the
+          # RAW SDK messages, which carry the array and no count. Reading
+          # the console's field name out of the file yields null, `// -1`
+          # turns that into "unknown", and the status job would have called
+          # every clean review a refusal. CodeRabbit caught it on this very
+          # pull request; the reader built to stop unverified claims had
+          # shipped on one.
+          #
+          # The array is what the SDK documents, so its absence means the
+          # message is not the shape this step knows — `-1`, never `0`.
+          #
+          # WRITTEN ASIDE FIRST, appended only once jq has succeeded. This
+          # step runs under `set -euo pipefail`, so a jq that dies partway
+          # — a `modelUsage` that is not an object, any shape this filter
+          # does not expect — would fail the step, and a failed step fails
+          # the REVIEW job, which is the one required check on `main`. A
+          # reader that cannot read a transcript must say so, never take
+          # every merge down with it.
+          if ! jq -r '
             ([.[] | select(.type == "result")] | last) as $r
             | [ .[]
                 | select(.type == "assistant")
@@ -335,15 +382,19 @@ jobs:
                 "subtype=" + (($r.subtype // "") | tostring | flat),
                 "is_error=" + (($r.is_error // false) | tostring),
                 "turns=" + (($r.num_turns // -1) | tostring),
-                "denials=" + (($r.permission_denials_count // -1) | tostring),
+                "denials=" + ((if ($r | has("permission_denials")) then (($r.permission_denials // []) | length) else -1 end) | tostring),
                 "denied_tools=" + ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed")] | unique | join(", ") | flat),
                 "agent_calls=" + ($agents | tostring),
                 "tools_used=" + ($calls | unique | join(", ") | flat),
                 "models=" + ((($r.modelUsage // {}) | keys | join(", ")) | flat),
                 "cost=" + (($r.total_cost_usd // 0) | tostring)
               ] | .[]
-          ' "${EXECUTION_FILE}" | cut -c 1-400 >> "${GITHUB_OUTPUT}"
+          ' "${EXECUTION_FILE}" | cut -c 1-400 > evidence.env; then
+            unknown "The execution file did not read as this step expects."
+            exit 0
+          fi
 
+          cat evidence.env >> "${GITHUB_OUTPUT}"
           echo "Evidence read from ${EXECUTION_FILE}."
 
   # WHY THIS JOB EXISTS. The review above posts inline comments when it finds
@@ -492,6 +543,12 @@ jobs:
             verdict="**Unverified.** The action reported success but left no readable transcript, so nothing here can say whether the reviewer did any work. Read the run log."
           elif [[ "${IS_ERROR}" == "true" || "${SUBTYPE}" != "success" ]]; then
             verdict="**The reviewer stopped on an error** (\`${SUBTYPE:-unknown}\`). Whatever it had read when it stopped, it did not finish reading the diff."
+          elif [[ "${DENIALS}" == "-1" || "${AGENT_CALLS}" == "-1" ]]; then
+            # `-1` is the evidence step saying it could not find the field,
+            # never that it found a zero. Reading it as a count would call a
+            # transcript this reader does not understand a refusal, and name
+            # no tool while doing it.
+            verdict="**Unverified.** The transcript did not carry what this check reads — refused tool calls, agents launched — so it cannot say whether a review happened. That is a defect in the reader, not a verdict on the diff: the shape of the run's own record has changed under it."
           elif [[ "${DENIALS}" != "0" ]]; then
             verdict="**A tool was refused, so this is not a review.** The agent asked for \`${DENIED_TOOLS:-a tool this run did not name}\` and this workflow had not granted it, so it worked around the gap or gave up — either way it reached its conclusion without something it judged it needed. Grant the tool in \`claude_args\` or say in this file why it must stay denied."
           elif [[ "${AGENT_CALLS}" == "0" ]]; then

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -471,14 +471,25 @@ really ran; on every run sampled it never got past the first step of the
 command it was given. `claude_args` granted a single
 tool — the one that posts a finding — because that is what makes the action
 install the inline-comment MCP server. True, and incomplete: the same list
-is the permission allowlist, the code-review command is built entirely on
-subagents, and `Task` was not on it. The four runs sampled had each spent
-five turns, been refused exactly one tool, launched no review agent and
-posted nothing — on a one-line pull request (#193) and a twenty-five-file
-one (#200) alike, and with no Opus model in any of them, which the
-command's two bug-hunting agents are by definition. Meanwhile CodeRabbit
-was finding real defects in the same diffs. What the reader above said
-about all of it was "Reviewed, nothing to report".
+is the permission allowlist, and the code-review command is built entirely
+on subagents. The four runs sampled had each spent five turns, been refused
+exactly one tool, launched no review agent and posted nothing — on a
+one-line pull request (#193) and a twenty-five-file one (#200) alike, and
+with no Opus model in any of them, which the command's two bug-hunting
+agents are by definition. Meanwhile CodeRabbit was finding real defects in
+the same diffs. What the reader above said about all of it was "Reviewed,
+nothing to report".
+
+**Which tool was refused is still not known**, and that is worth stating
+plainly on a page about claims nobody checked. The action's console summary
+counts denials without naming them, and no run kept a transcript. `Task`
+was the leading candidate and is now granted, but this document is not
+going to record a hypothesis as the cause: `issue-triage.yml` records an
+agent running `date` and `ls` with `--allowedTools` naming only the GitHub
+MCP server, which suggests built-in tools may not be gated by that list at
+all. The grant eliminates the hypothesis; the `denied_tools` row of the
+status comment is what will settle it, on the first pull request that does
+not edit this workflow.
 
 Three things changed on 2026-09-07, and the third is the one that
 generalises:

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -465,6 +465,40 @@ ran, was skipped, or failed. Without it, a green check and no comment means
 either "read it, found nothing" or "declined to read it", and only the run
 log tells you which.
 
+**It made 105 runs before anybody could show that one of them had
+reviewed anything, and the check was green for all of them.** The reviewer
+really ran; on every run sampled it never got past the first step of the
+command it was given. `claude_args` granted a single
+tool — the one that posts a finding — because that is what makes the action
+install the inline-comment MCP server. True, and incomplete: the same list
+is the permission allowlist, the code-review command is built entirely on
+subagents, and `Task` was not on it. The four runs sampled had each spent
+five turns, been refused exactly one tool, launched no review agent and
+posted nothing — on a one-line pull request (#193) and a twenty-five-file
+one (#200) alike, and with no Opus model in any of them, which the
+command's two bug-hunting agents are by definition. Meanwhile CodeRabbit
+was finding real defects in the same diffs. What the reader above said
+about all of it was "Reviewed, nothing to report".
+
+Three things changed on 2026-09-07, and the third is the one that
+generalises:
+
+- The reviewer is granted the tools its procedure needs — `Task`/`Agent`
+  first — and told, through `--append-system-prompt`, that the status
+  comment below is written by the workflow rather than by Claude. Step 1 of
+  the command stops the whole review when it believes Claude has already
+  commented, and that comment is headed "Claude review".
+- `show_full_output: true`, so a run keeps its transcript. Three rounds of
+  fixes to the issue triage could not find its cause because no run kept
+  one; the first that did explained it in a line.
+- **The status job reads that transcript instead of the exit status**, and
+  **goes red when it cannot show a review happened**. Its two signals are
+  how many review agents were launched and how many tool calls were
+  refused: facts about the run, not estimates of it, and neither needs a
+  threshold. A refusal is disqualifying on its own — the agent asked for
+  something this workflow had not granted. `tests/Architecture/ClaudeReviewIsVerifiableTest`
+  pins each of these against the single edit that would undo it.
+
 **SonarQube Cloud** — posts a Quality Gate on each pull request. It is
 skipped entirely on pull requests from forks, because `SONAR_TOKEN` is not
 exposed to those runs. Absence of the comment there is not a failure.
@@ -734,6 +768,12 @@ an error.
   add the individual `Checks / …` names as well: that is the fragile form
   — each name is a merge that stalls forever the day that job is renamed
   — and `All checks` already waits for all of them.
+  **`Claude review status` is deliberately not on the list**, though since
+  2026-09-07 it can go red (§ Code review). It warns rather than blocks
+  while its two signals — review agents launched, tool calls refused —
+  build a run history: a check that has never been wrong on this repository
+  is not yet a check worth deadlocking every merge on. Promoting it is a
+  one-line change here and in the ruleset, and it is the maintainer's call.
 - **Require branches to be up to date before merging** — *deliberately off.*
   It is the sub-option of the rule above, and turning it on again brings back
   the failure it was turned off for: with it on, a pull request must be even
@@ -959,15 +999,31 @@ nothing**:
   workflow-file mismatch, so the check is green having reviewed nothing —
   and that happens precisely on a pull request editing the reviewer. This
   is the one on the list with a reader attached: the `Claude review status`
-  comment names which of the two a green check was, reading the action's
-  own `conclusion` output, which is set only once Claude has run.
-  **The reader itself was the next instance of this failure mode**: it
-  first judged on the run's duration, on the premise that a real review
-  takes minutes. A review that finds nothing takes about as long as a
-  refusal, so the verdict was near random on exactly the pull requests it
-  was meant to reassure — green checks reported as unread, and no way to
-  tell a true report from a false one (issue #159). A heuristic standing in
-  for a fact is the same defect one level up.
+  comment names which of the two a green check was.
+  **The reader itself has now been the next instance of this failure mode
+  twice.** It first judged on the run's duration, on the premise that a
+  real review takes minutes. A review that finds nothing takes about as
+  long as a refusal, so the verdict was near random on exactly the pull
+  requests it was meant to reassure — green checks reported as unread, and
+  no way to tell a true report from a false one (issue #159). It then
+  judged on the action's own `conclusion` output, which is deterministic
+  and answers a different question: *did the action start Claude*, not
+  *did anybody review the diff*. An agent that starts, is refused a tool
+  and ends its turn normally sets it, which is what every run sampled on
+  2026-09-07 was doing — see § Code review. A heuristic standing in for a fact,
+  then a fact standing in for a different fact: the same defect one level
+  up, twice. It now reads the run's own transcript — agents launched, tool
+  calls refused — and goes red when neither can show a review happened.
+- **An agent's own report of success means only that its turn ended.** It
+  is the same reading error as the bullet above and it deserves its own
+  line, because it applies to every job in this repository that runs one.
+  A reviewer refused a tool, a triage that read an issue and gave up, a
+  scan that answered one candidate of four: all three end normally, and
+  the pipeline sees `is_error: false`. What separates them from real work
+  is never the exit status but what the run *did* — a comment posted, a
+  label applied, an agent launched — read back from the transcript or from
+  GitHub's own state. Anything a job asserts about its agent must be a
+  count of one of those.
 - A `CODEOWNERS` entry naming a non-collaborator is **ignored silently**, so
   a protection rule can be enabled, appear active, and match nothing.
 - A local reproduction that runs on the wrong database engine, or without

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -1,0 +1,404 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Claude review` was green 105 times without ever reviewing anything.
+ *
+ * The reviewer really ran — real turns, real subscription usage, a real
+ * model — and it never got past the first step of the command it was
+ * given. Every run spent five turns and was refused exactly one tool, on a
+ * one-line pull request and on a twenty-five-file one alike, and posted no
+ * inline comment on any of them, while CodeRabbit was finding real defects
+ * in the same diffs. Two things made that possible and this file pins
+ * both.
+ *
+ * FIRST, THE REVIEWER COULD NOT DO THE WORK. `claude_args` named one tool,
+ * the one that posts a finding, on the reasoning that the action installs
+ * the inline-comment MCP server only when a tool from it is named. True,
+ * and incomplete: the same list is the permission allowlist. The
+ * code-review command is built entirely on subagents — every one of its
+ * steps begins "launch an agent" — and `Task` was not on the list.
+ *
+ * SECOND, NOTHING COULD SEE THAT. The status job read the action's
+ * `conclusion` output, which answers "did the action start Claude", and
+ * reported "Reviewed, nothing to report" whenever it was set. An agent
+ * that starts, is refused a tool and ends its turn normally sets it. That
+ * was the third reading this check has had and the second one to be wrong
+ * in the same shape — a proxy standing in for the fact — after the
+ * duration heuristic of issue #159.
+ *
+ * So the assertions below are not a description of the file. Each one
+ * names a single edit that would put the repository back where it was on
+ * 2026-09-07, with a check that says everything is fine.
+ *
+ * Like Tests\Architecture\AutoMergeRuleIsWrittenDownTest, this proves the
+ * mechanism is still wired, never that a given review was any good.
+ */
+final class ClaudeReviewIsVerifiableTest extends TestCase
+{
+    private const WORKFLOW = '.github/workflows/claude-review.yml';
+
+    private static function workflow(): string
+    {
+        $path = dirname(__DIR__, 2) . '/' . self::WORKFLOW;
+        $contents = file_get_contents($path);
+
+        self::assertIsString($contents, self::WORKFLOW . ' is unreadable');
+        self::assertNotSame('', trim($contents), self::WORKFLOW . ' is empty');
+
+        return $contents;
+    }
+
+    /**
+     * Everything below reads one half of the file or the other, and a test
+     * that splits on a heading which has been renamed would read the whole
+     * file as the review job and pass over a permission it was meant to
+     * catch.
+     *
+     * @return array{0: string, 1: string} the review job, then the status job
+     */
+    private static function jobs(): array
+    {
+        $workflow = self::workflow();
+        $halves = explode("\n  status:\n", $workflow, 2);
+
+        self::assertCount(
+            2,
+            $halves,
+            'The two jobs can no longer be told apart: `status:` is not where this test expects the second '
+            . 'one to start, so the permission assertions below would read the wrong job.',
+        );
+
+        return [$halves[0], $halves[1]];
+    }
+
+    private static function claudeArgs(): string
+    {
+        [$review] = self::jobs();
+
+        $matched = preg_match('/claude_args:.*?(?=\n\n|\n      -|\n  [a-z])/s', $review, $found);
+
+        self::assertSame(1, $matched, 'The review job passes no `claude_args:` at all.');
+
+        return $found[0];
+    }
+
+    /**
+     * The floor. A test reading a file that is not there passes
+     * vacuously, and would report green over a reviewer nobody runs.
+     */
+    public function testTheReviewWorkflowIsStillThere(): void
+    {
+        $workflow = self::workflow();
+
+        $this->assertStringContainsString('name: Claude review', $workflow);
+        $this->assertStringContainsString('anthropics/claude-code-action@', $workflow);
+        $this->assertStringContainsString('/code-review:code-review --comment', $workflow);
+    }
+
+    /**
+     * THE FIX ITSELF. Drop either name and the reviewing procedure is
+     * refused on its first call again, which is the state this whole file
+     * documents.
+     */
+    public function testTheReviewerMayLaunchItsAgents(): void
+    {
+        $args = self::claudeArgs();
+
+        $this->assertStringContainsString(
+            'Task',
+            $args,
+            'The code-review command launches a subagent at every step. Without `Task` granted, the first '
+            . 'one is refused and the review ends having read nothing — five turns, one denial, no findings.',
+        );
+        $this->assertStringContainsString(
+            'Agent',
+            $args,
+            'Both spellings are granted on purpose: naming a tool that does not exist costs nothing, and '
+            . 'naming none of the ones that do costs the whole run.',
+        );
+    }
+
+    /**
+     * The tool that was already there, and the one thing the old list got
+     * right: the action installs the inline-comment MCP server only when
+     * `claude_args` names a tool from it. Remove it and findings have
+     * nowhere to go — silently, since a reviewer with nothing to say and a
+     * reviewer with no way to say it look identical from outside.
+     */
+    public function testTheReviewerCanStillPostAFinding(): void
+    {
+        $this->assertStringContainsString(
+            'mcp__github_inline_comment__create_inline_comment',
+            self::claudeArgs(),
+            'Without this tool named, the action never starts the inline-comment server and no finding can '
+            . 'reach the pull request.',
+        );
+    }
+
+    /**
+     * The command reads the pull request through `gh`, and its linking
+     * rule needs a full commit sha, which is a `git rev-parse`.
+     */
+    public function testTheReviewerCanReadThePullRequest(): void
+    {
+        $args = self::claudeArgs();
+
+        foreach (['Bash(gh pr view:*)', 'Bash(gh pr diff:*)', 'Bash(git rev-parse:*)'] as $tool) {
+            $this->assertStringContainsString(
+                $tool,
+                $args,
+                $tool . ' is declared by the code-review command itself; not granting it leaves the review '
+                . 'guessing at the diff it was asked to read.',
+            );
+        }
+    }
+
+    /**
+     * Step 1 of the command stops the whole review when it believes Claude
+     * has already commented, and two things on every pull request here
+     * look exactly like that: this workflow's own status comment, headed
+     * "Claude review", and the maintainer's replies, which carry a Claude
+     * Code signature. Neither is a review of the current diff.
+     */
+    public function testThePromptSaysTheStatusCommentIsNotAReview(): void
+    {
+        $args = self::claudeArgs();
+
+        $this->assertStringContainsString(
+            '--append-system-prompt',
+            $args,
+            'Nothing tells the reviewer that the status comment below is written by the workflow, so its '
+            . 'first step can read it as "Claude has already commented" and stop.',
+        );
+        $this->assertStringContainsString(
+            'not by Claude',
+            $args,
+            'The sentence that answers the already-commented gate has been reworded away.',
+        );
+        $this->assertStringContainsString(
+            'fresh review of every push',
+            $args,
+            'The per-push guarantee `synchronize` exists for is no longer stated to the reviewer.',
+        );
+    }
+
+    /**
+     * A run that keeps no transcript cannot explain itself. That is not a
+     * preference: three rounds of fixes to the issue triage could not find
+     * its cause because no run kept one, and the first that did explained
+     * it in a line. This review had the same hole for 105 runs.
+     */
+    public function testTheTranscriptSurvivesTheRun(): void
+    {
+        [$review] = self::jobs();
+
+        $this->assertMatchesRegularExpression(
+            '/^\s+show_full_output:\s*true\s*$/m',
+            $review,
+            'With the full output hidden, the only account of what the reviewer did is the summary line, '
+            . 'and the summary line is what said "success" 105 times.',
+        );
+    }
+
+    /**
+     * The verdict rests on these, and a missing step output in GitHub
+     * Actions is the empty string rather than an error — so an output
+     * dropped here would not fail anything, it would quietly make the
+     * status job's tests compare against nothing.
+     */
+    public function testTheRunPublishesWhatItActuallyDid(): void
+    {
+        [$review] = self::jobs();
+
+        foreach (['evidence', 'turns', 'denials', 'denied_tools', 'agent_calls'] as $output) {
+            $this->assertMatchesRegularExpression(
+                '/^\s+' . preg_quote($output, '/') . ':\s*\$\{\{\s*steps\.evidence\.outputs\./m',
+                $review,
+                'The review job no longer publishes `' . $output . '`, which the status job reads to decide '
+                . 'whether a review happened.',
+            );
+        }
+    }
+
+    /**
+     * A failed review is exactly the one whose numbers matter. Without
+     * `if: always()` the evidence step is skipped on failure, every output
+     * arrives empty, and the status job cannot tell "it broke" from "it
+     * found nothing".
+     */
+    public function testTheEvidenceIsReadEvenWhenTheReviewFails(): void
+    {
+        [$review] = self::jobs();
+
+        $matched = preg_match('/id: evidence\n(.*?)\n        env:/s', $review, $found);
+
+        self::assertSame(1, $matched, 'The step that reads the run back is gone, or no longer carries `id: evidence`.');
+
+        $this->assertStringContainsString(
+            'if: always()',
+            $found[1],
+            'The evidence step is skipped when the review fails, so the run that most needs explaining is '
+            . 'the one that explains nothing.',
+        );
+    }
+
+    /**
+     * A rename on one side of the two jobs is invisible: the reader
+     * silently becomes the empty string. So every value the status job
+     * reads back must be one the review job publishes.
+     */
+    public function testEveryValueTheStatusJobReadsIsOnePublishedByTheReview(): void
+    {
+        [$review, $status] = self::jobs();
+
+        preg_match_all('/needs\.review\.outputs\.([a-z_]+)/', $status, $read);
+        preg_match_all('/^      ([a-z_]+):\s*\$\{\{\s*steps\./m', $review, $published);
+
+        $read = array_values(array_unique($read[1]));
+        sort($read);
+        $published = $published[1];
+
+        $this->assertNotEmpty($read, 'The status job reads nothing back from the review job any more.');
+
+        foreach ($read as $name) {
+            $this->assertContains(
+                $name,
+                $published,
+                'The status job reads `needs.review.outputs.' . $name . '`, which the review job does not '
+                . 'publish. GitHub resolves that to the empty string and the verdict is decided against '
+                . 'nothing.',
+            );
+        }
+    }
+
+    /**
+     * THE OTHER HALF OF THE FIX. A reader that can only ever report good
+     * news is the failure it was built to catch, one level up.
+     */
+    public function testTheStatusJobGoesRedWhenNoReviewCanBeShown(): void
+    {
+        [, $status] = self::jobs();
+
+        $this->assertStringContainsString(
+            'unreviewed=1',
+            $status,
+            'The status job no longer starts from "no review has been shown to have happened".',
+        );
+        $this->assertStringContainsString(
+            'exit 1',
+            $status,
+            'The status job cannot fail any more, so a review that never ran is once again a green check '
+            . 'and a comment saying so.',
+        );
+    }
+
+    /**
+     * Exactly one branch may clear the flag, and it is the one that just
+     * said a review happened. A second `unreviewed=0` anywhere else is how
+     * this guard gets quietly repealed by somebody making a red build go
+     * away.
+     */
+    public function testOnlyAFinishedReviewClearsTheFlag(): void
+    {
+        [, $status] = self::jobs();
+
+        $this->assertSame(
+            1,
+            substr_count($status, 'unreviewed=0'),
+            'More than one branch of the verdict clears the unreviewed flag. Only the branch that can show '
+            . 'agents ran and no tool was refused may do that.',
+        );
+
+        $verdict = strpos($status, 'Reviewed, nothing to report');
+        $cleared = strpos($status, 'unreviewed=0');
+
+        self::assertIsInt($verdict, 'The verdict for a review that found nothing is gone.');
+        self::assertIsInt($cleared, 'Nothing clears the unreviewed flag, so the check can never be green.');
+
+        $this->assertLessThan(
+            $cleared,
+            $verdict,
+            'The flag is cleared before the branch that claims a review happened, so some other outcome '
+            . 'clears it too.',
+        );
+    }
+
+    /**
+     * A red job whose comment never got written says only that something
+     * went wrong here. The comment is the part that says what.
+     */
+    public function testTheCommentIsWrittenBeforeTheJobFails(): void
+    {
+        [, $status] = self::jobs();
+
+        // The LAST write against the FIRST exit, in that order on purpose:
+        // a second `exit 1` inserted above the comment would leave a later
+        // one below it, and reading the last exit would call that fine.
+        $posted = strrpos($status, 'issues/${PR_NUMBER}/comments');
+        $failed = strpos($status, 'exit 1');
+
+        self::assertIsInt($posted, 'The status job no longer posts a comment.');
+        self::assertIsInt($failed, 'The status job no longer fails on an unreviewed pull request.');
+
+        $this->assertLessThan(
+            $failed,
+            $posted,
+            'The job fails before writing its comment, so the pull request carries a red check and no '
+            . 'explanation of it.',
+        );
+    }
+
+    /**
+     * The reason the two jobs are separate at all. `pull-requests: write`
+     * in the review job would hand the write permission to the step that
+     * runs a model over a pull request head this repository does not
+     * control.
+     */
+    public function testTheReviewerStillHoldsNoWritePermission(): void
+    {
+        // The two `permissions:` blocks, in file order, rather than the two
+        // halves of self::jobs(): a job's documentation sits above its key,
+        // so the prose introducing the status job — which quotes the very
+        // permission being looked for — falls on the review job's side of
+        // that split. Reading the block itself is what makes this assertion
+        // about the grant rather than about a sentence describing it.
+        $matched = preg_match_all(
+            '/\n    permissions:\n((?:      [^\n]*\n|      #[^\n]*\n|\n)+)/',
+            self::workflow(),
+            $blocks,
+        );
+
+        $this->assertSame(
+            2,
+            $matched,
+            'This workflow no longer declares exactly two `permissions:` blocks, one per job. Either a job '
+            . 'lost its block — in which case it silently inherits the repository default — or a third job '
+            . 'appeared that this test has never looked at.',
+        );
+
+        $review = $blocks[1][0];
+
+        $this->assertStringContainsString(
+            'pull-requests: read',
+            $review,
+            'The review job no longer declares its read-only access to pull requests.',
+        );
+        $this->assertStringNotContainsString(
+            'pull-requests: write',
+            $review,
+            'The review job has been granted write access to pull requests. That permission belongs to the '
+            . 'status job, which runs no model, and it is why there are two jobs.',
+        );
+        $this->assertStringContainsString(
+            'pull-requests: write',
+            $blocks[1][1],
+            'The status job can no longer write the comment that says whether a review happened.',
+        );
+    }
+}

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -400,5 +400,72 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
             $blocks[1][1],
             'The status job can no longer write the comment that says whether a review happened.',
         );
+        $this->assertStringContainsString(
+            'actions: read',
+            $blocks[1][1],
+            'The status job can no longer read the review job\'s timestamps. That endpoint answers without '
+            . 'this permission on a public repository, so the job would keep working here and stop the day '
+            . 'the repository turns private — before it has written its comment.',
+        );
+    }
+
+    /**
+     * `permission_denials_count` is the ACTION's console summary, computed
+     * in base-action/src/run-claude-sdk.ts as
+     * `resultMsg.permission_denials?.length ?? 0`. The execution file is
+     * written from the RAW SDK messages a few lines later, and those carry
+     * the `permission_denials` ARRAY and no count at all.
+     *
+     * Reading the console's field name out of the file yields null, which
+     * this step turns into `-1`, and the status job would have called every
+     * clean review a refusal — a check red on every pull request forever,
+     * naming no tool. CodeRabbit caught it on the pull request that added
+     * this file.
+     */
+    public function testTheRefusalCountComesFromTheArrayTheSdkActuallyWrites(): void
+    {
+        [$review] = self::jobs();
+
+        $this->assertStringContainsString(
+            'has("permission_denials")',
+            $review,
+            'The evidence step no longer reads the `permission_denials` array the SDK writes.',
+        );
+        $this->assertStringNotContainsString(
+            '$r.permission_denials_count',
+            $review,
+            'The evidence step reads `permission_denials_count` off the execution file. That field exists '
+            . 'only in the action\'s console summary; the file carries the array. The read returns null, '
+            . 'and every clean review is reported as a refusal.',
+        );
+    }
+
+    /**
+     * The evidence step runs under `set -euo pipefail` inside the job that
+     * owns the one required check on `main`. A jq that dies on an
+     * unexpected shape would fail the step, fail the job, and block every
+     * merge — over a reader that could not read a transcript.
+     */
+    public function testAnUnreadableTranscriptCannotFailTheRequiredCheck(): void
+    {
+        [$review] = self::jobs();
+
+        $this->assertStringContainsString(
+            'if ! jq -r',
+            $review,
+            'The evidence extraction is no longer guarded, so a transcript this step cannot parse fails the '
+            . 'review job itself — turning the required check red over the reader rather than the review.',
+        );
+
+        $guarded = strpos($review, 'if ! jq -r');
+        $appended = strpos($review, 'cat evidence.env');
+
+        self::assertIsInt($appended, 'The evidence step no longer appends what jq produced.');
+        $this->assertLessThan(
+            $appended,
+            $guarded,
+            'The outputs are appended before jq has been shown to succeed, so a half-written extraction can '
+            . 'still reach the status job.',
+        );
     }
 }


### PR DESCRIPTION
## Description

`Claude review` était vert sur ses 105 exécutions. Le relecteur tournait vraiment — vrais tours, vraie consommation d'abonnement — et sur chaque exécution examinée depuis, il n'a jamais dépassé l'étape 1 de la commande qu'on lui donnait.

`claude_args` n'accordait qu'un seul outil, celui qui poste une trouvaille, parce que c'est ce qui fait installer le serveur MCP des commentaires en ligne à l'action. Vrai, et incomplet : cette même liste est l'allowlist de permissions, et la commande `code-review` est bâtie entièrement sur des sous-agents — chacune de ses étapes commence par « launch an agent ». `Task` n'y figurait pas.

Chaque exécution dépensait donc cinq tours, se voyait refuser exactement un outil, ne lançait aucun agent de revue et ne postait rien : quatorze secondes sur une PR d'une ligne (#193), dix-neuf sur une de vingt-cinq fichiers (#200), aucun modèle Opus dans `modelUsage` alors que les deux agents chasseurs de bugs de la commande sont des Opus par définition. CodeRabbit trouvait de vrais défauts dans les mêmes diffs.

**Ce qui change**

- Le relecteur reçoit les outils dont sa procédure a besoin — `Task`/`Agent` d'abord — et on lui dit, via `--append-system-prompt`, que le commentaire de statut est écrit par le workflow et non par Claude. L'étape 1 arrête toute la revue quand elle croit que Claude a déjà commenté, et ce commentaire s'intitule « Claude review ».
- `show_full_output: true` : une exécution garde sa transcription. Le triage des issues a dû l'apprendre deux fois — trois séries de correctifs n'ont pas pu trouver sa cause parce qu'aucune exécution n'en gardait, et la première qui l'a fait l'a expliquée en une ligne.
- **Et rien ne pouvait voir tout ça**, ce qui est la moitié qui se généralise. Le job de statut lisait la sortie `conclusion` de l'action : déterministe, et réponse à « l'action a-t-elle démarré Claude », pas à « quelqu'un a-t-il relu la diff ». Un agent qui démarre, se voit refuser un outil et termine son tour normalement la positionne. C'est la troisième lecture de ce contrôle et la deuxième fausse dans la même forme, après l'heuristique de durée de #159.

Il lit maintenant la transcription de l'exécution, via une nouvelle étape `evidence`, et tranche sur deux comptages : **agents de revue lancés** et **appels d'outil refusés**. Des faits sur l'exécution plutôt que des estimations d'elle, et aucun n'a besoin d'un seuil — « des agents ont-ils été lancés » n'a pas de cas limite. Un refus est disqualifiant à lui seul, et le commentaire nomme l'outil.

Et **le job passe au rouge** quand il ne peut pas montrer qu'une revue a eu lieu : un lecteur qui ne sait annoncer que de bonnes nouvelles est exactement l'échec pour lequel il a été construit, un cran au-dessus. Il reste hors de la liste des contrôles requis pour l'instant — il avertit sans bloquer — et `docs/quality-pipeline.md` § Branch ruleset dit ce que sa promotion demanderait.

Pas de `--max-turns` : l'action traite un dépassement de plafond de tours comme un échec même quand l'agent a fini, donc un plafond proche du coût réel fait rougir les bonnes revues — c'est ce qui est arrivé au triage de #181.

**Note sur cette PR elle-même** : elle modifie `claude-review.yml`, donc l'action refusera de tourner dessus (le fichier diffère de la copie sur `main`) et `Claude review` sera vert sans avoir rien relu. `Claude review status` le dira et sera **rouge** — c'est précisément le cas que ce changement rend visible, et non un échec de CI.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 15 828 tests, 56 852 assertions, OK)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — No errors)
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — *sans objet, aucun fichier JavaScript touché*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0191u1p9XrCJEamSCMSmuKpE

---
_Generated by [Claude Code](https://claude.ai/code/session_0191u1p9XrCJEamSCMSmuKpE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Claude review verification now uses detailed execution evidence, including transcripts, tool access, agent activity, and errors.
  * Reviews are marked successful only when a review agent completes without denied tools or other verification failures.
  * Status comments now show what the review actually performed, including failure details.
  * Failed or unverifiable reviews are reported clearly after the status is posted.

* **Documentation**
  * Updated quality-pipeline guidance with the revised review verification rules and failure scenarios.

* **Tests**
  * Added coverage to ensure review evidence, permissions, status reporting, and failure handling remain verifiable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->