### PR TITLE
Le relecteur n'a jamais chargé la procédure qu'on lui donnait

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -182,15 +182,23 @@ one did. Read that comment; it is the answer the check alone cannot give.
 
 **And a green `Claude review` did not always mean a review happened even
 when Claude ran.** For its first 105 runs the reviewer was refused one tool
-call per run — which one is still not known, the summary counts them
-without naming them — and on every run anybody has looked at, it launched
-no review agent, posted nothing, and reported success (2026-09-07, the
-tools its procedure needs now granted
-in `claude_args`; the story is in that file's header and in
+call per run, launched no review agent, posted nothing, and reported
+success. The first transcript that named the refusal named `Skill`: the
+`prompt:` is a slash command, a slash command is invoked through that tool,
+and the code-review procedure had therefore never been loaded on any of
+them (#208, 2026-09-07; the story is in that file's header and in
 docs/quality-pipeline.md § Code review). Which is why the comment's verdict
-now rests on two rows — **`Review agents launched`** and **`Tool calls
-refused`** — read from the run's own transcript. Agents launched at zero,
-or any tool refused, and no review happened, whatever the check says.
+now rests on three rows — **`Review agents launched`**, **`Review agents
+finished`** and **`Tool calls refused`** — read from the run's own
+transcript. Agents launched at zero, fewer finished than launched, or any
+tool refused, and no review happened, whatever the check says.
+
+**`Review agents finished` is the one that catches a run that stopped
+half-way.** Subagents start in the background, and a reviewer that ends its
+turn waiting for one ends the run — nothing wakes a workflow up, so the SDK
+closes it a success with part of the diff unread. That is what #208 did:
+three spawned, two collected, no comment.
+
 A refusal names the tool: grant it in `claude_args`, or write down in that
 file why it must stay denied.
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -96,12 +96,14 @@ jobs:
     # So the rest of these outputs come from the action's `execution_file`,
     # the transcript the SDK writes: how many turns were spent, how many
     # tool calls were REFUSED and which ones, and how many review agents
-    # were actually launched. The command this job runs
+    # were launched and how many came back. The command this job runs
     # (plugins/code-review in anthropics/claude-code) is built entirely on
     # subagents — "Launch a haiku agent", "Launch 4 agents in parallel" —
-    # so zero agent calls means the procedure never started, whatever the
-    # exit status says. That signal needs no threshold, which is the point:
-    # the previous two readers were both a number standing in for a fact.
+    # so zero agent calls means the procedure never started, and fewer
+    # finished than launched means it stopped in the middle, whatever the
+    # exit status says. Neither signal needs a threshold, which is the
+    # point: the previous two readers were both a number standing in for a
+    # fact.
     outputs:
       conclusion: ${{ steps.claude.outputs.conclusion }}
       evidence: ${{ steps.evidence.outputs.evidence }}
@@ -111,6 +113,8 @@ jobs:
       denials: ${{ steps.evidence.outputs.denials }}
       denied_tools: ${{ steps.evidence.outputs.denied_tools }}
       agent_calls: ${{ steps.evidence.outputs.agent_calls }}
+      subagents_spawned: ${{ steps.evidence.outputs.subagents_spawned }}
+      subagents_completed: ${{ steps.evidence.outputs.subagents_completed }}
       tools_used: ${{ steps.evidence.outputs.tools_used }}
       models: ${{ steps.evidence.outputs.models }}
       cost: ${{ steps.evidence.outputs.cost }}
@@ -227,19 +231,26 @@ jobs:
           # and left everything the reviewing procedure needs to reach it
           # ungranted.
           #
-          # WHETHER THAT IS WHAT THE ONE DENIAL WAS IS NOT PROVEN, and this
-          # file is not going to pretend otherwise on a change whose whole
-          # subject is claims nobody checked. What is established: one tool
-          # call was refused in every run sampled, no review agent was ever
-          # launched, and the console summary does not name the tool. What
-          # is NOT established is that the refused tool was `Task` —
-          # issue-triage.yml records the opposite-looking observation, an
-          # agent running `date` and `ls` with --allowedTools naming only
-          # the GitHub MCP server, so built-in tools may not be gated by
-          # this list at all. Granting them eliminates the hypothesis
-          # rather than confirming it; `show_full_output` and the
-          # `denied_tools` output below are what will name the tool on the
-          # next run that is not this pull request's own.
+          # THE FIRST RUN THAT NAMED ITS DENIALS SETTLED IT, and the answer
+          # was not `Task`. Pull request #208, run 34155412607: four
+          # refusals, and the first one is the entire review.
+          #
+          #   Skill{skill: "code-review:code-review",
+          #         args: "--comment xdubois-57/scoutmagic/pull/208"}
+          #
+          # `prompt:` above is a slash command, and a slash command is
+          # invoked through the `Skill` tool. Refusing it does not stop the
+          # run — the agent improvises a review of its own out of whatever
+          # it does have — so the procedure this file spends four hundred
+          # lines describing had never once been loaded. It also answers
+          # the question issue-triage.yml left open: built-in tools ARE
+          # gated by this list.
+          #
+          # The other three denials were one `git fetch` of
+          # `pull/208/head`, refused and then retried twice. Granted below:
+          # it reads, it writes nothing, and a reviewer that cannot reach
+          # the commit it was asked to read spends its turns working around
+          # that instead of reading the diff.
           #
           # `Bash(gh pr comment:*)` IS GRANTED THOUGH THE TOKEN CANNOT USE
           # IT — this job is `pull-requests: read`, so the call returns 403
@@ -280,9 +291,24 @@ jobs:
           # written. Neither is a review of the current diff. The rule the
           # step is really there for — do not review the same commit twice
           # — is already held by `concurrency` above.
+          #
+          # THE SECOND SENTENCE ANSWERS A DIFFERENT WAY TO REVIEW NOTHING,
+          # found on that same run 34155412607. It ended with `result`
+          # reading "Waiting for the background diff-summary agent to
+          # complete before proceeding to the parallel review step", having
+          # spawned three subagents and collected two, and posted no
+          # comment. A subagent starts in the background unless the caller
+          # says otherwise, and ending a turn to wait for one is how that
+          # works in a session a person can resume. Nothing resumes this
+          # one: the SDK ends there and records `subtype: success`.
+          #
+          # The sentence is a mitigation and not the guard, because it asks
+          # a model to remember something. The guard is `subagents_spawned`
+          # and `subagents_completed` below, which the run reports about
+          # itself whatever the model did.
           claude_args: >-
-            --allowedTools "Task,Agent,Read,Glob,Grep,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),mcp__github_inline_comment__create_inline_comment"
-            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one."
+            --allowedTools "Skill,Task,Agent,Read,Glob,Grep,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git fetch:*),mcp__github_inline_comment__create_inline_comment"
+            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one. Wait for every subagent you launch — pass run_in_background false — and never end a turn waiting for one: this is a one-shot non-interactive run and nothing will wake it up, so a background agent still working when you stop is a part of the diff nobody read. The workspace is already a full clone checked out for this pull request, so the commits under review are there to read."
 
       # WHAT THE RUN ACTUALLY DID, read off the transcript the SDK wrote.
       #
@@ -314,6 +340,8 @@ jobs:
               echo "denials=-1"
               echo "denied_tools="
               echo "agent_calls=-1"
+              echo "subagents_spawned=-1"
+              echo "subagents_completed=-1"
               echo "tools_used="
               echo "models="
               echo "cost="
@@ -360,6 +388,13 @@ jobs:
           # The array is what the SDK documents, so its absence means the
           # message is not the shape this step knows — `-1`, never `0`.
           #
+          # `subagent_stats` IS READ THE SAME WAY AND FOR THE SAME REASON.
+          # `spawned` counts the review agents the run started, `completed`
+          # the ones it collected, and a run that ends between the two
+          # ended in the middle of reading the diff. Both are absent-means
+          # `-1`: a nested field this step cannot find must never be
+          # allowed to look like agreement between two zeros.
+          #
           # WRITTEN ASIDE FIRST, appended only once jq has succeeded. This
           # step runs under `set -euo pipefail`, so a jq that dies partway
           # — a `modelUsage` that is not an object, any shape this filter
@@ -376,6 +411,7 @@ jobs:
                 | .name
               ] as $calls
             | ($calls | map(select(. == "Task" or . == "Agent")) | length) as $agents
+            | (if ($r.subagent_stats | type) == "object" then $r.subagent_stats else {} end) as $sub
             | def flat: gsub("[\r\n]"; " ");
               [
                 "evidence=present",
@@ -385,6 +421,8 @@ jobs:
                 "denials=" + ((if ($r | has("permission_denials")) then (($r.permission_denials // []) | length) else -1 end) | tostring),
                 "denied_tools=" + ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed")] | unique | join(", ") | flat),
                 "agent_calls=" + ($agents | tostring),
+                "subagents_spawned=" + ((if ($sub | has("spawned")) and ($sub.spawned | type) == "number" then $sub.spawned else -1 end) | tostring),
+                "subagents_completed=" + ((if ($sub | has("completed")) and ($sub.completed | type) == "number" then $sub.completed else -1 end) | tostring),
                 "tools_used=" + ($calls | unique | join(", ") | flat),
                 "models=" + ((($r.modelUsage // {}) | keys | join(", ")) | flat),
                 "cost=" + (($r.total_cost_usd // 0) | tostring)
@@ -443,12 +481,21 @@ jobs:
   # ends its turn normally is a successful agent.
   #
   # SO IT NOW READS THE RUN'S OWN RECORD: how many review agents were
-  # launched, and how many tool calls were refused. Both come from the
-  # transcript, both are facts about this run rather than estimates of it,
-  # and neither needs a threshold — the question "were any agents launched
-  # at all" has no borderline. A refusal is disqualifying on its own: the
-  # agent asked for a tool this workflow did not grant, so whatever it
-  # concluded, it concluded without something it judged it needed.
+  # launched, how many of them FINISHED, and how many tool calls were
+  # refused. All three come from the transcript, all three are facts about
+  # this run rather than estimates of it, and none needs a threshold — the
+  # question "were any agents launched at all" has no borderline, and
+  # neither has "did they all come back". A refusal is disqualifying on its
+  # own: the agent asked for a tool this workflow did not grant, so whatever
+  # it concluded, it concluded without something it judged it needed.
+  #
+  # THE FINISHED COUNT WAS ADDED ON 2026-09-07 AFTER THE OTHER TWO WOULD
+  # HAVE PASSED A RUN THAT REVIEWED NOTHING. On #208 the reviewer spawned
+  # three agents, collected two, and ended on "Waiting for the background
+  # diff-summary agent to complete" with no comment posted. Agents launched
+  # was 3 and, once the tools it had been refused were granted, refusals
+  # would have been 0 — "Reviewed, nothing to report" over a review that
+  # stopped in the middle. Launched is not finished.
   #
   # AND IT GOES RED when it cannot say a review happened. A reader that can
   # only ever report good news is the failure it was built to catch, one
@@ -501,6 +548,11 @@ jobs:
           DENIALS: ${{ needs.review.outputs.denials }}
           DENIED_TOOLS: ${{ needs.review.outputs.denied_tools }}
           AGENT_CALLS: ${{ needs.review.outputs.agent_calls }}
+          # How many review agents the run started, and how many it
+          # collected. Equal is the only reading that says the procedure
+          # ran to its end.
+          SUBAGENTS_SPAWNED: ${{ needs.review.outputs.subagents_spawned }}
+          SUBAGENTS_COMPLETED: ${{ needs.review.outputs.subagents_completed }}
           TOOLS_USED: ${{ needs.review.outputs.tools_used }}
           MODELS: ${{ needs.review.outputs.models }}
           COST: ${{ needs.review.outputs.cost }}
@@ -553,8 +605,25 @@ jobs:
             verdict="**A tool was refused, so this is not a review.** The agent asked for \`${DENIED_TOOLS:-a tool this run did not name}\` and this workflow had not granted it, so it worked around the gap or gave up — either way it reached its conclusion without something it judged it needed. Grant the tool in \`claude_args\` or say in this file why it must stay denied."
           elif [[ "${AGENT_CALLS}" == "0" ]]; then
             verdict="**The review agents never ran.** Every step of the code-review command launches a subagent, and this run launched none, so nothing read the diff for bugs. The run log carries the full transcript; start at the first tool call."
+          elif [[ "${SUBAGENTS_SPAWNED}" == "-1" || "${SUBAGENTS_COMPLETED}" == "-1" ]]; then
+            # AFTER the two branches above, not folded into the `-1` test
+            # they share. A run that launched no agent at all may well
+            # carry no `subagent_stats` either, and "the review agents
+            # never ran" is the more useful of the two things to be told;
+            # reaching here means agents did run and only their tally is
+            # missing.
+            verdict="**Unverified.** ${AGENT_CALLS} review agents were launched with no tool refused, but the transcript does not say how many of them finished — so this check cannot rule out a run that ended mid-review. That is a defect in the reader: \`subagent_stats\` is not where it expects."
+          elif [[ "${SUBAGENTS_COMPLETED}" != "${SUBAGENTS_SPAWNED}" ]]; then
+            # Launched is not finished, and the gap between them is a whole
+            # way to review nothing that the two signals above cannot see.
+            # A subagent starts in the background, so an agent that ends its
+            # turn to wait for one leaves this run with nobody to resume it:
+            # the SDK closes it `subtype: success`, and the part of the diff
+            # that agent was reading was never read (PR #208, three agents
+            # spawned, two collected, no comment posted).
+            verdict="**The review stopped part-way through.** ${SUBAGENTS_SPAWNED} review agents were launched and ${SUBAGENTS_COMPLETED} finished, so at least one was still reading when the run ended — and whatever it would have found is not on this pull request. Read the run log from the last agent launched."
           else
-            verdict="**Reviewed, nothing to report.** ${AGENT_CALLS} review agents ran over ${TURNS} turns with no tool refused. Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran."
+            verdict="**Reviewed, nothing to report.** ${AGENT_CALLS} review agents ran over ${TURNS} turns, all of them finished, and no tool was refused. Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran."
             unreviewed=0
           fi
 
@@ -571,6 +640,19 @@ jobs:
           agents_cell="${AGENT_CALLS:--}"
           if [[ "${agents_cell}" == "-1" ]]; then
             agents_cell="unknown"
+          fi
+
+          # Reported as "finished of spawned" so the row carries its own
+          # denominator: a bare "2" says nothing about whether that was all
+          # of them, and that gap is the whole point of the row.
+          finished_cell="${SUBAGENTS_COMPLETED:--}"
+          if [[ "${finished_cell}" == "-1" ]]; then
+            finished_cell="unknown"
+          fi
+          if [[ "${SUBAGENTS_SPAWNED:--1}" == "-1" ]]; then
+            finished_cell="${finished_cell} of unknown"
+          else
+            finished_cell="${finished_cell} of ${SUBAGENTS_SPAWNED}"
           fi
 
           turns_cell="${TURNS:--}"
@@ -590,8 +672,8 @@ jobs:
           models_cell="${MODELS:--}"
           tools_cell="${TOOLS_USED:--}"
 
-          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Claude ran | `%s` |\n| Review agents launched | %s |\n| Tool calls refused | %s |\n| Turns | %s |\n| Tools used | %s |\n| Models | %s |\n| Cost | %s USD |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. The verdict comes from what the run recorded — agents launched, tools refused — never from its duration or its exit status, both of which have already been wrong here. See `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
-            "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${conclusion_cell}" "${agents_cell}" "${denials_cell}" "${turns_cell}" "${tools_cell}" "${models_cell}" "${cost_cell}" "${elapsed}" "${RUN_URL}")"
+          body="$(printf '%s\n\n## Claude review\n\n%s\n\n| | |\n|---|---|\n| Commit | `%s` |\n| Job result | `%s` |\n| Claude ran | `%s` |\n| Review agents launched | %s |\n| Review agents finished | %s |\n| Tool calls refused | %s |\n| Turns | %s |\n| Tools used | %s |\n| Models | %s |\n| Cost | %s USD |\n| Took | %s |\n| Run | %s |\n\nPosted by `.github/workflows/claude-review.yml`, rewritten in place on every run. The verdict comes from what the run recorded — agents launched, agents finished, tools refused — never from its duration or its exit status, both of which have already been wrong here. See `docs/quality-pipeline.md` for what each layer does and does not prove.\n' \
+            "${MARKER}" "${verdict}" "${HEAD_SHA}" "${REVIEW_RESULT}" "${conclusion_cell}" "${agents_cell}" "${finished_cell}" "${denials_cell}" "${turns_cell}" "${tools_cell}" "${models_cell}" "${cost_cell}" "${elapsed}" "${RUN_URL}")"
 
           jq -n --arg body "${body}" '{body: $body}' > payload.json
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -395,6 +395,16 @@ jobs:
           # `-1`: a nested field this step cannot find must never be
           # allowed to look like agreement between two zeros.
           #
+          # `tally` REQUIRES A NON-NEGATIVE INTEGER, not merely a number.
+          # The status job decides "did they all come back" by comparing
+          # the two, so any pair that is equal reaches the green branch —
+          # and `-2` equals `-2`, as does `1.5`. Testing for `number`
+          # alone would let a `subagent_stats` this reader does not
+          # understand agree with itself into "Reviewed, nothing to
+          # report", which is the exact failure the whole reader exists to
+          # stop. Anything that is not a count becomes the `-1` the status
+          # job already knows how to refuse. (CodeRabbit, PR #209.)
+          #
           # WRITTEN ASIDE FIRST, appended only once jq has succeeded. This
           # step runs under `set -euo pipefail`, so a jq that dies partway
           # — a `modelUsage` that is not an object, any shape this filter
@@ -413,6 +423,7 @@ jobs:
             | ($calls | map(select(. == "Task" or . == "Agent")) | length) as $agents
             | (if ($r.subagent_stats | type) == "object" then $r.subagent_stats else {} end) as $sub
             | def flat: gsub("[\r\n]"; " ");
+              def tally: if type == "number" and . >= 0 and floor == . then . else -1 end;
               [
                 "evidence=present",
                 "subtype=" + (($r.subtype // "") | tostring | flat),
@@ -421,8 +432,8 @@ jobs:
                 "denials=" + ((if ($r | has("permission_denials")) then (($r.permission_denials // []) | length) else -1 end) | tostring),
                 "denied_tools=" + ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed")] | unique | join(", ") | flat),
                 "agent_calls=" + ($agents | tostring),
-                "subagents_spawned=" + ((if ($sub | has("spawned")) and ($sub.spawned | type) == "number" then $sub.spawned else -1 end) | tostring),
-                "subagents_completed=" + ((if ($sub | has("completed")) and ($sub.completed | type) == "number" then $sub.completed else -1 end) | tostring),
+                "subagents_spawned=" + ($sub.spawned | tally | tostring),
+                "subagents_completed=" + ($sub.completed | tally | tostring),
                 "tools_used=" + ($calls | unique | join(", ") | flat),
                 "models=" + ((($r.modelUsage // {}) | keys | join(", ")) | flat),
                 "cost=" + (($r.total_cost_usd // 0) | tostring)

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -480,16 +480,32 @@ agents are by definition. Meanwhile CodeRabbit was finding real defects in
 the same diffs. What the reader above said about all of it was "Reviewed,
 nothing to report".
 
-**Which tool was refused is still not known**, and that is worth stating
-plainly on a page about claims nobody checked. The action's console summary
-counts denials without naming them, and no run kept a transcript. `Task`
-was the leading candidate and is now granted, but this document is not
-going to record a hypothesis as the cause: `issue-triage.yml` records an
-agent running `date` and `ls` with `--allowedTools` naming only the GitHub
-MCP server, which suggests built-in tools may not be gated by that list at
-all. The grant eliminates the hypothesis; the `denied_tools` row of the
-status comment is what will settle it, on the first pull request that does
-not edit this workflow.
+**The refused tool was `Skill`, and it was not `Task`.** The first run that
+kept a transcript naming its denials was #208, and it named four. The first
+is the whole story: `Skill{skill: "code-review:code-review"}`. The `prompt:`
+this workflow passes is a slash command, and a slash command is invoked
+through the `Skill` tool — so on all 105 runs the code-review procedure was
+never loaded, and what ran was an agent improvising a review from the diff
+with whatever tools it happened to hold. It also settles the question
+`issue-triage.yml` left open: built-in tools **are** gated by
+`--allowedTools`. The other three denials were one `git fetch` of the pull
+request head, refused and retried twice; both are granted now.
+
+**And that same run found a third way to review nothing.** It ended with
+`result` reading *"Waiting for the background diff-summary agent to
+complete before proceeding to the parallel review step"* — three review
+agents spawned, two collected, no comment posted, `subtype: success`. A
+subagent starts in the background unless the caller says otherwise, and
+ending a turn to wait for one works in a session a person can resume;
+nothing resumes a workflow run. Launched was 3 and, with the refused tools
+granted, refusals would have been 0 — so **both signals added on 2026-09-07
+would have passed it**, and the comment would have read "Reviewed, nothing
+to report" over a review that stopped in the middle. The status job now
+reads a third number, `subagent_stats.completed` against `spawned`, and
+goes red when they differ; the reviewer is also told in
+`--append-system-prompt` to wait for the agents it launches, which is a
+mitigation rather than the guard, because it asks a model to remember
+something.
 
 Three things changed on 2026-09-07, and the third is the one that
 generalises:
@@ -503,12 +519,13 @@ generalises:
   fixes to the issue triage could not find its cause because no run kept
   one; the first that did explained it in a line.
 - **The status job reads that transcript instead of the exit status**, and
-  **goes red when it cannot show a review happened**. Its two signals are
-  how many review agents were launched and how many tool calls were
-  refused: facts about the run, not estimates of it, and neither needs a
-  threshold. A refusal is disqualifying on its own — the agent asked for
-  something this workflow had not granted. `tests/Architecture/ClaudeReviewIsVerifiableTest`
-  pins each of these against the single edit that would undo it.
+  **goes red when it cannot show a review happened**. Its signals are how
+  many review agents were launched, how many of them finished, and how many
+  tool calls were refused: facts about the run, not estimates of it, and
+  none needs a threshold. A refusal is disqualifying on its own — the agent
+  asked for something this workflow had not granted.
+  `tests/Architecture/ClaudeReviewIsVerifiableTest` pins each of these
+  against the single edit that would undo it.
 
 **SonarQube Cloud** — posts a Quality Gate on each pull request. It is
 skipped entirely on pull requests from forks, because `SONAR_TOKEN` is not
@@ -781,7 +798,8 @@ an error.
   — and `All checks` already waits for all of them.
   **`Claude review status` is deliberately not on the list**, though since
   2026-09-07 it can go red (§ Code review). It warns rather than blocks
-  while its two signals — review agents launched, tool calls refused —
+  while its signals — review agents launched, review agents finished, tool
+  calls refused —
   build a run history: a check that has never been wrong on this repository
   is not yet a check worth deadlocking every merge on. Promoting it is a
   one-line change here and in the ruleset, and it is the maintainer's call.
@@ -1069,8 +1087,9 @@ nothing**:
   and ends its turn normally sets it, which is what every run sampled on
   2026-09-07 was doing — see § Code review. A heuristic standing in for a fact,
   then a fact standing in for a different fact: the same defect one level
-  up, twice. It now reads the run's own transcript — agents launched, tool
-  calls refused — and goes red when neither can show a review happened.
+  up, twice. It now reads the run's own transcript — agents launched,
+  agents finished, tool calls refused — and goes red when none of them can
+  show a review happened.
 - **An agent's own report of success means only that its turn ended.** It
   is the same reading error as the bullet above and it deserves its own
   line, because it applies to every job in this repository that runs one.

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -125,6 +125,45 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
     }
 
     /**
+     * WHAT THE 106th RUN TURNED OUT TO BE. The first run whose transcript
+     * named its refusals named `Skill` first, on #208, and the input said
+     * what it wanted: `code-review:code-review`. The `prompt:` this
+     * workflow passes is a slash command, and a slash command is invoked
+     * through the `Skill` tool — so the reviewing procedure had never been
+     * loaded at all, and every "review" so far was an agent improvising
+     * from the diff with the tools it happened to have.
+     *
+     * The failure is silent by construction: a refused `Skill` call does
+     * not stop the run, it just leaves the command unread.
+     */
+    public function testTheReviewerMayRunTheCommandItWasGiven(): void
+    {
+        $this->assertStringContainsString(
+            'Skill',
+            self::claudeArgs(),
+            'The `prompt:` above is a slash command, which the agent invokes through the `Skill` tool. '
+            . 'Ungranted, that call is refused, the code-review procedure is never loaded, and the run '
+            . 'improvises a review instead of failing — which is exactly how the first 105 looked.',
+        );
+    }
+
+    /**
+     * The other three refusals on that run were one `git fetch` of the
+     * pull request head, retried after each one. It reads and writes
+     * nothing; a reviewer that cannot reach the commit it was asked to
+     * read spends its turns working around that.
+     */
+    public function testTheReviewerCanFetchTheCommitItReviews(): void
+    {
+        $this->assertStringContainsString(
+            'Bash(git fetch:*)',
+            self::claudeArgs(),
+            'The reviewer was refused `git fetch` of the pull request ref three times in a row on #208 '
+            . 'before giving up on reading the commit locally.',
+        );
+    }
+
+    /**
      * The tool that was already there, and the one thing the old list got
      * right: the action installs the inline-comment MCP server only when
      * `claude_args` names a tool from it. Remove it and findings have
@@ -216,7 +255,9 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
     {
         [$review] = self::jobs();
 
-        foreach (['evidence', 'turns', 'denials', 'denied_tools', 'agent_calls'] as $output) {
+        $outputs = ['evidence', 'turns', 'denials', 'denied_tools', 'agent_calls', 'subagents_spawned', 'subagents_completed'];
+
+        foreach ($outputs as $output) {
             $this->assertMatchesRegularExpression(
                 '/^\s+' . preg_quote($output, '/') . ':\s*\$\{\{\s*steps\.evidence\.outputs\./m',
                 $review,
@@ -295,6 +336,61 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
             $status,
             'The status job cannot fail any more, so a review that never ran is once again a green check '
             . 'and a comment saying so.',
+        );
+    }
+
+    /**
+     * LAUNCHED IS NOT FINISHED, and the gap between them is a third way to
+     * review nothing that the first two signals cannot see.
+     *
+     * On #208 the reviewer spawned three agents, collected two, and ended
+     * its turn on "Waiting for the background diff-summary agent to
+     * complete before proceeding to the parallel review step". A subagent
+     * runs in the background unless the caller says otherwise, and waiting
+     * for one by ending a turn works in a session somebody can resume;
+     * nothing resumes a workflow run, so the SDK closed it `subtype:
+     * success` with no comment posted. Agents launched said 3, and with
+     * the tools that run had been refused now granted, refusals would say
+     * 0 — the two signals of 2026-09-07 would both have passed it.
+     */
+    public function testAnUnfinishedReviewIsNotAReview(): void
+    {
+        [, $status] = self::jobs();
+
+        $this->assertStringContainsString(
+            'SUBAGENTS_COMPLETED',
+            $status,
+            'The status job no longer reads how many review agents came back, so a run that stopped '
+            . 'half-way through the diff is once again indistinguishable from one that finished it.',
+        );
+
+        $matched = preg_match(
+            '/elif \[\[ "\$\{SUBAGENTS_COMPLETED\}" != "\$\{SUBAGENTS_SPAWNED\}" \]\]; then\n(?:\s+#[^\n]*\n)*\s+verdict=/',
+            $status,
+            $found,
+        );
+
+        $this->assertSame(
+            1,
+            $matched,
+            'Nothing compares the review agents launched against the ones that finished, so the verdict '
+            . 'can again read "Reviewed, nothing to report" over a run that ended mid-review.',
+        );
+    }
+
+    /**
+     * The mitigation for the same failure, on the other side of the same
+     * run. It asks a model to remember something, so it is not the guard —
+     * the comparison above is — but a reviewer told to wait for its agents
+     * does not reach that guard in the first place.
+     */
+    public function testTheReviewerIsToldNotToWaitOnABackgroundAgent(): void
+    {
+        $this->assertStringContainsString(
+            'run_in_background',
+            self::claudeArgs(),
+            'The prompt no longer tells the reviewer to wait for the agents it launches. Subagents start '
+            . 'in the background, and a turn ended waiting for one ends this run — nothing will wake it.',
         );
     }
 

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -268,6 +268,131 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
     }
 
     /**
+     * The jq program the evidence step reads the transcript with, lifted
+     * out of the workflow so a test can run it. Every other assertion here
+     * reads the file as text; this one runs the thing itself, because what
+     * it is being asked is what the reader DOES with a shape, which no
+     * amount of string matching answers.
+     */
+    private static function jqProgram(): string
+    {
+        $workflow = self::workflow();
+        $opens = strpos($workflow, "if ! jq -r '");
+
+        self::assertIsInt($opens, 'The evidence step no longer reads the transcript with jq.');
+
+        $start = $opens + strlen("if ! jq -r '");
+        $closes = strpos($workflow, "' \"\${EXECUTION_FILE}\"", $start);
+
+        self::assertIsInt($closes, 'The jq program is no longer closed where this test expects to find its end.');
+
+        return substr($workflow, $start, $closes - $start);
+    }
+
+    /**
+     * Runs that program over a one-message transcript carrying
+     * `$subagentStats`, and returns the `key=value` lines it wrote.
+     *
+     * @param  array<string, mixed>|null $subagentStats null omits the key entirely
+     * @return array<string, string>
+     */
+    private static function evidenceFor(?array $subagentStats): array
+    {
+        $result = [
+            'type' => 'result',
+            'subtype' => 'success',
+            'is_error' => false,
+            'num_turns' => 5,
+            'permission_denials' => [],
+            'total_cost_usd' => 0.1,
+        ];
+
+        if ($subagentStats !== null) {
+            $result['subagent_stats'] = $subagentStats;
+        }
+
+        $transcript = tempnam(sys_get_temp_dir(), 'claude-review-transcript-');
+        $program = tempnam(sys_get_temp_dir(), 'claude-review-filter-');
+
+        self::assertIsString($transcript);
+        self::assertIsString($program);
+
+        try {
+            file_put_contents($transcript, (string) json_encode([$result]));
+            file_put_contents($program, self::jqProgram());
+
+            $output = [];
+            $status = 0;
+            exec(
+                'jq -r -f ' . escapeshellarg($program) . ' ' . escapeshellarg($transcript) . ' 2>&1',
+                $output,
+                $status,
+            );
+
+            self::assertSame(
+                0,
+                $status,
+                "The evidence reader died on this transcript instead of describing it:\n" . implode("\n", $output),
+            );
+
+            $evidence = [];
+
+            foreach ($output as $line) {
+                [$key, $value] = explode('=', $line, 2);
+                $evidence[$key] = $value;
+            }
+
+            return $evidence;
+        } finally {
+            unlink($transcript);
+            unlink($program);
+        }
+    }
+
+    /**
+     * THE STATUS JOB DECIDES "DID THEY ALL COME BACK" BY COMPARING TWO
+     * NUMBERS, so any pair that is equal reaches the branch that claims a
+     * review happened — and `-2` equals `-2`, as does `1.5`. Testing the
+     * transcript's counts for `number` alone would let a `subagent_stats`
+     * this reader does not understand agree with itself into "Reviewed,
+     * nothing to report", which is the failure the whole reader exists to
+     * stop, arriving through the very field added to stop it. Anything
+     * that is not a count has to become the `-1` the status job already
+     * knows how to refuse. (CodeRabbit, PR #209.)
+     */
+    public function testAMalformedSubagentCountIsRefusedRatherThanBelieved(): void
+    {
+        if (shell_exec('command -v jq') === null) {
+            self::markTestSkipped('jq is not installed, so the evidence reader cannot be run here.');
+        }
+
+        $real = self::evidenceFor(['spawned' => 3, 'completed' => 2]);
+
+        $this->assertSame('3', $real['subagents_spawned'], 'A genuine count no longer survives the reader.');
+        $this->assertSame('2', $real['subagents_completed'], 'A genuine count no longer survives the reader.');
+
+        $malformed = [
+            'equal negatives' => ['spawned' => -2, 'completed' => -2],
+            'equal fractions' => ['spawned' => 1.5, 'completed' => 1.5],
+            'counts as strings' => ['spawned' => '3', 'completed' => '3'],
+            'counts as null' => ['spawned' => null, 'completed' => null],
+            'no counts at all' => [],
+            'no subagent_stats' => null,
+        ];
+
+        foreach ($malformed as $label => $stats) {
+            $evidence = self::evidenceFor($stats);
+
+            $this->assertSame(
+                ['-1', '-1'],
+                [$evidence['subagents_spawned'], $evidence['subagents_completed']],
+                'With ' . $label . ' the reader published something other than "unreadable". Equal values '
+                . 'agree with each other, and agreement is what the status job reads as a finished review.',
+            );
+        }
+    }
+
+    /**
      * A failed review is exactly the one whose numbers matter. Without
      * `if: always()` the evidence step is skipped on failure, every output
      * arrives empty, and the status job cannot tell "it broke" from "it


### PR DESCRIPTION
## Description

`Claude review status` est passé au rouge sur la PR #208 : `Tool calls refused: 4 (Bash, Skill)`. C'est la **première exécution dont la transcription nomme ses refus** — les 105 précédentes les comptaient sans les nommer — et le premier des quatre est toute l'histoire.

### Ce qui était refusé

```
Skill{skill: "code-review:code-review", args: "--comment xdubois-57/scoutmagic/pull/208"}
```

Le `prompt:` passé à l'action est une commande slash, et une commande slash s'invoque par l'outil `Skill`, que `--allowedTools` n'accordait pas. Un `Skill` refusé n'arrête rien : l'agent improvise une revue avec les outils qu'il a. **La procédure que ce fichier décrit sur quatre cents lignes n'avait donc jamais été chargée**, sur aucune exécution.

Cela répond aussi à la question laissée ouverte par `issue-triage.yml` et reprise dans l'en-tête du workflow : les outils intégrés **sont** filtrés par `--allowedTools`. L'hypothèse `Task` était fausse.

Les trois autres refus étaient un même `git fetch` de `pull/208/head`, réessayé deux fois après chaque refus. Il lit et n'écrit rien ; les deux sont accordés.

### La troisième façon de ne rien relire

La même exécution se termine sur :

> `result: "Waiting for the background diff-summary agent to complete before proceeding to the parallel review step"`

Trois sous-agents lancés, deux récupérés, aucun commentaire posté, `subtype: success`. Un sous-agent démarre en arrière-plan sauf mention contraire, et finir son tour en en attendant un fonctionne dans une session qu'une personne peut reprendre — rien ne reprend une exécution de workflow, donc le SDK s'arrête là.

Le point qui compte : `Review agents launched` valait 3 et, les outils refusés une fois accordés, `Tool calls refused` aurait valu 0. **Les deux signaux ajoutés le 2026-09-07 auraient tous deux laissé passer cette exécution**, sous le verdict « Reviewed, nothing to report », sur une revue arrêtée au milieu. Lancé n'est pas terminé.

### Ce que change cette PR

- **`claude_args`** : `Skill` et `Bash(git fetch:*)` accordés. Le paragraphe « ce n'est pas prouvé » de l'en-tête est remplacé par ce que la transcription établit.
- **Étape `evidence`** : publie `subagents_spawned` et `subagents_completed`, lus dans `subagent_stats` avec la même discipline que le reste — un champ introuvable vaut `-1`, jamais `0`.
- **Job de statut** : nouvelle branche, moins d'agents terminés que lancés n'est pas une revue. Placée **après** « les agents de revue n'ont jamais tourné », qui reste le diagnostic le plus utile quand aucun agent n'a démarré. Nouvelle ligne `Review agents finished`, rendue « 2 of 3 » pour que la ligne porte son dénominateur.
- **Prompt** : demande d'attendre ses sous-agents. C'est une atténuation, pas la garde — cela demande à un modèle de s'en souvenir, là où la comparaison des compteurs ne dépend de personne.
- **Documentation** : `docs/quality-pipeline.md` § Code review et le skill `steward` disaient tous deux que l'outil refusé restait inconnu.

### Vérifications

Le filtre `jq` a été rejoué hors CI sur la forme réelle de la transcription (il reproduit `3` / `2`, et retombe sur `-1` quand `subagent_stats` est absent), et les six branches du verdict ont été exercées avec les valeurs de l'exécution 34155412607 — dont le cas « outils accordés » qui, sans cette PR, ressortait vert. Les deux nouveaux tests ont été vérifiés par mutation du workflow : ils échouent bien quand le correctif est retiré.

### Une limite à connaître

L'action refuse de tourner quand `claude-review.yml` diffère de la copie sur `main`, et sort en *success*. **Le `Claude review` de cette PR-ci sera donc vert sans revue** — c'est le trou déjà documenté dans l'en-tête du fichier. Le correctif ne se prouve que sur la première PR qui suit la fusion.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French — aucun texte d'interface touché
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 15 844 tests, verts)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: sans objet, aucun fichier sous `public/assets/js/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5cMGCovVxojb3v9Dk3inz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5cMGCovVxojb3v9Dk3inz)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude review status now verifies that all launched review agents complete successfully.
  * Review status reports agent and subagent execution counts and identifies incomplete or unverifiable reviews.
  * Automated reviews can use required skills, fetch reviewed commits, and access approved read-only tools.

* **Documentation**
  * Updated review guidance and failure criteria to reflect tool refusals and unfinished background agents.

* **Tests**
  * Added coverage for tool access, commit retrieval, subagent completion, and reviewer instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->