### PR TITLE
Ouvrir le chantier « Revue de code » et journaliser son itération 1

### DIFF
--- a/docs/chantiers/CHANTIER-revue-de-code.md
+++ b/docs/chantiers/CHANTIER-revue-de-code.md
@@ -1,0 +1,660 @@
+# Chantier — Revue de code complète
+
+Document de chantier. Il complète `ARCHITECTURE.md`, `SECURITY.md`,
+`AGENTS.md`, `CONTRIBUTING.md` et `docs/quality-pipeline.md`, qui restent la
+source de vérité pour les règles elles-mêmes. Il ne les recopie pas.
+
+Il porte sur **les défauts** : bugs, failles, coûts. Pas sur le style, pas sur
+la duplication, pas sur le nommage — Sonar et CodeRabbit s'en occupent déjà et
+mieux.
+
+Son point de départ n'est pas « relire le code », c'est une question posée à
+`docs/quality-pipeline.md` : **PHPStan, six suites PHPUnit, deux moteurs de
+base, Playwright, la matrice d'autorisation ZAP, CodeQL et Sonar tournent sur
+chaque commit — que reste-t-il qu'aucun d'eux ne peut voir ?** Chaque itération
+ci-dessous est une de ces réponses. C'est ce qui les rend finies : une
+itération ne relit pas un dossier, elle pose une question à tout le code et
+s'arrête quand elle y a répondu partout.
+
+---
+
+## 0. Règles communes à toutes les itérations
+
+### 0.1 On ne corrige rien
+
+**Un défaut trouvé devient une issue GitHub, jamais un correctif.** Sans
+exception, y compris quand la correction tient en une ligne : une revue qui
+corrige au fil de l'eau produit une branche que personne ne peut relire, et
+mélange le constat avec sa réparation au moment précis où il faudrait pouvoir
+discuter du second sans remettre le premier en cause.
+
+La seule chose qu'une itération écrit dans le dépôt est son entrée de journal
+(§0.6). Le reste part dans les issues.
+
+### 0.2 Un constat non reproduit n'est pas un constat
+
+**Avant d'ouvrir une issue, le défaut doit avoir été observé sur une instance
+réelle**, peuplée par le jeu de données de référence :
+
+```bash
+composer install                      # dépendances dev incluses : le builder
+                                      # vit sous autoload-dev
+php tests/fixtures/reference-dataset/build.php --yes --root=/chemin/instance
+```
+
+`--reset` vide d'abord l'installation cible ; ne jamais viser autre chose
+qu'une instance jetable. `scripts/e2e-support.php provision` en fabrique une.
+Les comptes de démonstration et leur mot de passe sont dans
+`tests/fixtures/reference-dataset/README.md`.
+
+La raison est écrite dans `docs/quality-pipeline.md` § *Le mode de défaillance
+que ce dépôt rencontre* : ce dépôt s'est déjà fait avoir par un lecteur de code
+qui n'avait jamais fait tourner le site. Un `bug:confirmed` produit par lecture
+seule est exactement cette erreur, une couche plus haut.
+
+Quand le défaut résiste à la reproduction **alors que la zone est
+reproductible**, une seule forme est honnête : ouvrir le constat en disant ce
+qui a été tenté et ce qui s'est passé à la place. Ne jamais écrire « devrait »
+au passé.
+
+### 0.2 bis — Les zones qu'on ne peut pas faire tourner
+
+Une partie du code ne s'exécute pas sur une instance de test, faute
+d'identifiants ou d'infrastructure : le fournisseur téléphonique OVH
+(`modules/sos_staff`), les fournisseurs d'IA (`modules/llm_connector`), le
+stockage S3 de la galerie, le relais SMTP et la vérification DNS DKIM/SPF/DMARC,
+le webhook GitHub et le client de release, l'envoi Web Push vers un vrai
+endpoint, le site de support et son jeton, Ghostscript quand il est absent,
+les deux dispositions d'installation de `bootstrap.php` sur un hébergement
+mutualisé réel, le vrai crontab, et les contraintes LWS (`open_basedir`,
+`disable_functions`, CageFS).
+
+**Ces zones sont dans le périmètre et leurs défauts se rapportent.** Les en
+exclure reviendrait à ne jamais relire précisément le code que personne ne
+voit tourner — c'est-à-dire celui où un défaut survit le plus longtemps.
+
+Trois règles s'y appliquent à la place de §0.2 :
+
+1. **Reproduire derrière la couture, pas à travers le fournisseur.** Ce dépôt
+   a mis une interface exactement là où passe la frontière :
+   `PhoneProviderInterface`, `GitHubReleaseClientInterface`,
+   `LlmConnectorInterface`, `BackupServiceInterface`, les backends de stockage
+   de la galerie. Un doublon d'essai derrière l'interface exerce **tout le code
+   de ce dépôt** ; ce qui reste hors d'atteinte est le protocole du tiers, pas
+   la logique en cause. Un constat reproduit ainsi est un constat reproduit :
+   dire lequel des deux côtés a été exercé suffit.
+2. **Quand il n'y a pas de couture, c'est un constat en soi.** Un appel réseau
+   émis depuis un Service sans interface interposée rend le comportement
+   invérifiable pour toujours, y compris pour la correction future. L'ouvrir
+   comme tel, séparément du défaut soupçonné derrière.
+3. **Ce qui reste ne s'ouvre que s'il se démontre par lecture seule.** Un
+   ordre d'arguments inversé, un code de retour ignoré, une exception non
+   rattrapée sur un chemin sans repli, une signature qui ne correspond pas à
+   la documentation du tiers : chacun se prouve en citant le code, sans
+   hypothèse sur ce que le tiers répond. « Ça pourrait mal se comporter » n'est
+   pas un constat et reste dans le journal.
+
+Le corps de l'issue porte alors une section **« Non reproduit »** en clair,
+disant ce qui manquait pour le faire et ce qui a été exercé à la place. Elle
+est obligatoire : sans elle, le triage lit une observation là où il y a une
+lecture, et un `bug:confirmed` s'appuie sur une preuve qui n'existe pas.
+
+### 0.3 Une issue par constat, une issue par famille
+
+Un constat = une issue. **Mais la même erreur répétée dans N modules = une
+seule issue qui les liste** — dix issues disant la même chose coûtent dix
+triages et se répondent en une phrase.
+
+Chaque issue est en **français** (les issues font partie de l'interface, comme
+les formulaires de `.github/ISSUE_TEMPLATE/`), porte le label
+`triage:pending` à la création, et contient :
+
+- **Ce qu'on observe**, à l'indicatif, sur l'instance de référence ;
+- **La commande ou le clic exact** qui le reproduit, depuis un dépôt neuf ;
+- **Ce qui était attendu**, et d'où vient cette attente (fichier, section de
+  `ARCHITECTURE.md`, commentaire du code) ;
+- **Le fichier et la fonction** en cause — jamais un numéro de ligne seul, il
+  aura bougé ;
+- **Aucune donnée personnelle**, même issue d'un jeu fictif : la règle ne
+  s'assouplit pas selon la provenance ;
+- une section **« Non reproduit »** quand §0.2 bis s'applique, et rien
+  d'équivalent quand elle ne s'applique pas — c'est ce contraste qui rend
+  l'absence de section lisible comme « observé ».
+
+Ne jamais proposer le correctif dans l'issue. Décrire le défaut suffit ; le
+correctif est une décision, et elle appartient au mainteneur.
+
+**Une faille de sécurité s'ouvre en issue publique comme le reste**, pendant la
+durée de ce chantier : aucune installation n'est en production. Le signalement
+privé de vulnérabilité du dépôt reste le bon canal pour un tiers, et le
+redeviendra pour ce chantier le jour où un site tourne pour de vrai — décision
+à rouvrir ce jour-là, pas avant.
+
+### 0.4 Les issues passent par le triage normal
+
+C'est délibéré : le triage est un second lecteur, et un constat d'audit qu'il
+renvoie en `bug:not-a-bug` mérite d'être relu avant d'être cru.
+
+Conséquence à connaître : `issue-triage.yml` se déclenche sur `issues: opened`,
+donc **chaque issue ouverte consomme un run de triage** et fait apparaître un
+commentaire public. C'est la raison du regroupement en §0.3, pas une raison
+d'ouvrir moins.
+
+Ne jamais appliquer `triage:done`, `bug:*` ou `status:accepted` à la main :
+`docs/quality-pipeline.md` § *Labels* explique pourquoi les labels sont l'état,
+et une itération qui les écrit elle-même rend le triage aveugle.
+
+### 0.5 Ce qu'on n'ouvre pas
+
+- Une remarque de style, de nommage, de duplication → journal, pas issue.
+- Une préférence d'architecture sans conséquence observable → journal.
+- Un manque de test sur un invariant par ailleurs vérifié → **une seule issue
+  par itération** les regroupant, jamais une par invariant. Même traitement
+  pour les coutures manquantes de §0.2 bis, point 2.
+- Ce que `docs/chantiers/CHANTIER-performance.md` a déjà mesuré et tranché.
+- Les éléments explicitement acceptés dans `ARCHITECTURE.md` (les fichiers
+  orphelins de `FullResetHandler`, l'exception `/api/offline/photo/{id}`, la
+  dispense CSRF du webhook GitHub). Les relire pour vérifier que la
+  justification tient encore ; ne pas les rouvrir parce qu'ils surprennent.
+
+### 0.6 Ce qu'une itération livre
+
+Ce fichier n'est pas encore dans le dépôt : il arrive en pièce jointe. **La PR
+de l'itération 1 le dépose en `docs/chantiers/CHANTIER-revue-de-code.md`**, tel
+quel, avant d'y écrire sa propre entrée de journal — comme tous les autres
+chantiers, pour qu'une session ultérieure retrouve les décisions au lieu de les
+réinventer.
+
+Ensuite, une PR contenant **uniquement** l'entrée de journal de l'itération,
+ajoutée au §11 de ce fichier :
+
+- la question posée et le périmètre réellement parcouru ;
+- les issues ouvertes, par numéro, une ligne chacune ;
+- **ce qui a été vérifié et tenu** — c'est la moitié utile du journal : sans
+  elle, personne ne saura jamais si un silence signifie « rien à signaler » ou
+  « pas regardé » ;
+- ce qui n'a pas pu être vérifié, et pourquoi.
+
+Aucun test n'est ajouté : un test qui reproduit un bug est rouge, et une PR
+rouge ne se fusionne pas. La reproduction vit dans l'issue.
+
+La PR est rebasée sur `main`, l'auto-merge est armé une fois `All checks` vert
+sur le head courant, et l'itération suivante démarre depuis `main` à jour.
+
+### 0.7 Ne pas refaire ce qui tourne déjà
+
+Avant de chercher, lire ce qui couvre déjà la question :
+
+| Déjà couvert par | Ne pas re-parcourir |
+|---|---|
+| `tests/Security/SqlInjectionAuditTest` | la concaténation SQL |
+| `tests/Security/AuthorizationMatrixInventoryTest` + `dast.sh --profile=standard` | le `role_min` déclaré de chaque route |
+| `tests/Security/EncryptionAuditTest` | quelles colonnes sont chiffrées |
+| `tests/Security/CsrfGuardCoverageTest` | la présence du jeton sur les POST |
+| `tests/Architecture/ModuleBoundariesTest` | les références hors `Api\` |
+| `tests/Architecture/ModuleSchemaBoundariesTest` | les FK inter-modules |
+| CodeQL | les puits DOM en JavaScript |
+
+Ces couches disent ce qui est **déclaré**. Aucune ne dit ce qui est **fait**.
+C'est là que toutes les itérations travaillent.
+
+---
+
+## 1. Le jeu de données de référence emprunte-t-il le chemin réel ?
+
+**Périmètre** : `tests/fixtures/reference-dataset/` en entier, confronté aux
+contrôleurs et services que chaque seeder prétend rejouer.
+
+**Pourquoi en premier** : le `README.md` du dossier promet que le builder
+« rejoue le tout à travers les vrais services de l'application », et c'est cette
+promesse qui rend la reproduction de §0.2 valable. Un seeder qui court-circuite
+une étape ne produit pas seulement une donnée fausse : il rend **toutes les
+itérations suivantes non concluantes**, puisqu'elles observeront un site que
+personne n'utilise. Cette itération est la fondation des neuf autres.
+
+**Deux constats déjà établis, à ouvrir en l'état** (reproduits par lecture
+croisée, à confirmer sur instance) :
+
+1. **Les images d'articles n'ont pas de dérivés.**
+   `NewsSeeder::upload()` appelle `Core\File\UploadHandler::handle()` et
+   s'arrête là. Le chemin réel,
+   `Modules\News\Controller\NewsController::resolveUploadedImageFileId()`,
+   enchaîne sur `ImageVariantService::generate()` pour chaque
+   `ImageVariantService::VARIANTS`. Or `Core\View\TwigFactory` demande
+   `/files/{id}/thumb` et `/files/{id}/md`, et
+   `Core\Http\Controller\FileController::variant()` répond **404** quand le
+   dérivé manque — il ne retombe jamais sur l'original, et son commentaire dit
+   que c'est délibéré. Une instance fraîchement construite affiche donc des
+   images cassées partout où un article apparaît, jusqu'à ce que
+   `Modules\News\Task\GenerateImageVariantsHandler` passe — c'est-à-dire au
+   bout d'assez de visites pour que le poor man's cron l'atteigne, la tâche
+   n'étant amorcée qu'à `public/index.php` sous le drapeau
+   `news_image_variants_backfilled`.
+   *À vérifier en reproduisant* : combien de visites avant que la liste
+   d'actualités s'affiche complète, et ce que voit un visiteur public entre
+   les deux.
+
+2. **La couverture d'un article réservé est publique.**
+   `NewsSeeder::upload()` passe `'public'` en `role_min` pour toutes les
+   images. Le contrôleur, lui, aligne le `role_min` du fichier sur la
+   visibilité de l'article (`identified` / `chief` / `admin`), avec en
+   commentaire la raison : *« ou l'image dit ce que la page tait »*. Dans le
+   jeu de référence, la couverture d'un article chefs est donc lisible par
+   n'importe qui via `/files/{id}`. Le défaut est dans la fixture, pas dans le
+   produit — mais une assertion d'étanchéité écrite sur cette fixture
+   mesurerait l'inverse de la réalité, ce qui est pire qu'aucune assertion.
+
+**Ce qui doit être vérifié, seeder par seeder** — il y en a une vingtaine
+(`News`, `Gallery`, `Finance`, `Camps`, `Rental`, `Registration`, `Calendar`,
+`Banner`, `Campaign`, `Staff`, `ExtrasApplier`, `PhotoAssigner`…) :
+
+- **Chaque seeder appelle-t-il le service que le contrôleur appelle, ou une
+  couche en dessous ?** Descendre d'un cran (Repository au lieu de Service)
+  saute silencieusement les effets de bord : dérivés d'image, notification,
+  entrée de journal, tâche planifiée, invalidation de cache, mise à jour d'un
+  compteur.
+- **Chaque valeur passée en dur est-elle la même que celle que le contrôleur
+  calcule ?** `role_min`, visibilité, année scoute, `module_id`, propriétaire
+  (`owner_member_id`), état initial. C'est la classe du constat n°2, et elle se
+  cherche argument par argument.
+- **Ce qui est créé est-il visible ?** Pour chaque objet semé, ouvrir la page
+  où il doit apparaître, avec le rôle qui doit le voir et avec celui qui ne le
+  doit pas.
+- **Le drapeau de fin est-il honnête ?** Un seeder qui pose un
+  `…_seeded`/`…_backfilled` que la vraie exécution n'aurait pas posé neutralise
+  une reprise dont l'instance a besoin.
+- **Le builder est-il rejouable ?** Deux exécutions successives sur la même
+  instance : doublons, contrainte violée, ou refus propre.
+- **`--reset` vide-t-il vraiment ce qu'il prétend vider ?** Fichiers de
+  `storage/` compris, pas seulement les tables.
+
+---
+
+## 2. La portée objet, au-delà du `role_min`
+
+**Question** : un utilisateur qui a le bon rôle peut-il atteindre l'objet d'un
+autre en changeant un identifiant dans l'URL ?
+
+**Périmètre** : toutes les routes dont le chemin porte un `{id}` — soit
+l'essentiel des 520 routes déclarées.
+
+**Ce qui est déjà couvert, et pourquoi ça ne suffit pas** : la matrice ZAP
+rejoue chaque route sous chaque rôle et compare au `role_min` déclaré. Elle
+prouve donc qu'un `identified` n'entre pas sur une route `chief`. Elle ne dit
+**rien** de deux `chief` de sections différentes, ni de deux membres d'une même
+famille, ni d'un `intendant` face au compte financier d'un autre. C'est le plus
+gros angle mort de sécurité du dépôt, et il grandit à chaque module.
+
+**Ce qui doit être vérifié** :
+
+- Pour chaque contrôleur prenant un `{id}` : **une vérification d'appartenance
+  existe-t-elle après le garde de rôle ?** `ARCHITECTURE.md` §2 l'autorise
+  explicitement comme second contrôle ; l'absence de ce second contrôle est le
+  défaut recherché.
+- Cette vérification est-elle **côté serveur et non conditionnée par l'écran
+  d'où vient la requête** ? Un contrôle présent dans une page mais absent de la
+  route POST équivalente est le cas classique.
+- Les cas où le dépôt a déjà écrit la règle, à confronter au code :
+  `MemberService::canAccess()`, `MemberEmailService::isOwnMember()`
+  (§8.27, aucun contournement chef/admin), `files.owner_member_id` via
+  `FileAccessGuard` (§8.3, aucun contournement non plus),
+  `BadgeService::toggleAssignment()` (§8.11),
+  `Modules\MassMail\Controller\MemberEmailController` (§8.22),
+  `TreasurerScope` et `GroupAccessService`.
+- **Les identifiants devinables** : réponses de formulaire, pièces jointes de
+  finance, documents de section, réservations, messages entrants,
+  billetterie. Pour chacun : deux comptes de démonstration, l'objet de l'un,
+  l'URL ouverte par l'autre.
+- **La réponse trahit-elle l'existence de l'objet ?** Un 403 sur un objet
+  existant et un 404 sur un objet inexistant énumèrent le contenu.
+
+**Reproduction attendue dans l'issue** : deux comptes du jeu de référence,
+l'URL exacte, le code HTTP obtenu, ce qui s'affiche.
+
+---
+
+## 3. Les données personnelles sortent-elles du Repository ?
+
+**Question** : `EncryptionAuditTest` prouve que les colonnes sont chiffrées.
+Que deviennent les valeurs **après** le `decrypt()` ?
+
+**Périmètre** : tout ce qui écrit ailleurs que dans une page — journal,
+notifications, push, mails, exports, archives de support, messages d'erreur,
+logs.
+
+**Ce qui doit être vérifié** :
+
+- **`JournalService::log()`** : le tableau `context` de chaque appel. La règle
+  (`SECURITY.md` §11) est « jamais de donnée personnelle, seulement un
+  `member_id` ». À confronter appel par appel, y compris dans les modules.
+- **Les notifications** : le titre et le corps passés à
+  `NotificationService::dispatch()`. Une notification stocke sa charge en base
+  et la pousse chez un tiers ; le mode discrétion (§8.24) ne protège que le
+  push, pas la ligne stockée.
+- **Les messages d'erreur rendus à l'utilisateur**, en particulier ceux
+  construits depuis une exception (`UserFacingMessage`) : une exception PDO
+  peut porter la valeur qui a violé une contrainte.
+- **Les exports** : XLSX de réponses de formulaire, PDF de trombinoscope et de
+  liste de section, ICS de calendrier, sauvegardes. Qui peut les demander, ce
+  qu'ils contiennent, où ils atterrissent, et avec quel `role_min` de fichier.
+- **L'archive de support** (§8.49sexies / `SECURITY.md` §18ter) : l'anonymisation
+  est la garantie sur laquelle repose l'accès de l'agent de triage à des
+  journaux de site réel. Vérifier ce qui échappe au remplacement — un nom dans
+  un champ libre, une adresse dans un `context` de journal, un totem.
+- **Les index aveugles** : une recherche exacte sur un champ chiffré passe-t-elle
+  par l'index, ou déchiffre-t-elle en mémoire ? La seconde forme est autorisée
+  mais doit être documentée (`ARCHITECTURE.md`) et **bornée** — sinon elle
+  appartient aussi à l'itération 7.
+- **Le déchiffrement hors Repository** : chercher les appels à
+  `EncryptionService::decrypt()` dans un Service ou un Contrôleur.
+
+---
+
+## 4. Les entrées non fiables
+
+**Question** : que fait le code de ce qu'il n'a pas écrit — fichier téléversé,
+HTML riche, CSV importé, mail entrant, URL distante ?
+
+**Périmètre** : `Core\File\UploadHandler`, `Core\Security\HtmlSanitizer`, les
+imports (Desk, relevés bancaires, factures fédérales), `modules/inbound_mail`,
+`modules/gallery`, tout appel sortant.
+
+**Ce qui doit être vérifié** :
+
+- **Le type MIME est-il vérifié par le contenu et non par l'annonce du
+  client ?** `UploadMimeTrustAuditTest` existe : lire ce qu'il couvre, chercher
+  les chemins qui lui échappent — dont les seeders de l'itération 1, qui
+  passent un `type` en dur.
+- **L'injection de formule dans les exports** : une réponse de formulaire
+  commençant par `=`, `+`, `-` ou `@` s'exécute à l'ouverture du XLSX chez le
+  destinataire. Vérifier ce que fait `phpoffice/phpspreadsheet` ici et si une
+  neutralisation existe.
+- **Le SSRF du scraper Open Graph du module `gallery`** — déjà identifié comme
+  à durcir avant que `groups` ne l'expose à tout membre identifié : absence de
+  contrôle d'IP privée, suivi de redirection non borné. À rouvrir en issue avec
+  sa reproduction, puisque `groups` a avancé depuis.
+- **Toute construction d'URL interne** : `HTTP_HOST` ne doit jamais servir à
+  fabriquer une URL que le serveur appelle lui-même (le saut de continuation du
+  scheduler l'a déjà payé). Chercher chaque usage.
+- **Le HTML riche** : ce que la liste blanche de `HtmlSanitizer` laisse passer,
+  confronté aux 306 `|raw` des gabarits. Chaque `|raw` sur une valeur qui n'est
+  pas passée par le sanitizer est un constat.
+- **Les en-têtes de mail** : un sujet ou un nom d'expéditeur construit depuis
+  une valeur utilisateur.
+- **Le mail entrant** : pièces jointes, encodages, taille, expéditeur usurpé.
+
+---
+
+## 5. Le contrat des modules
+
+**Question** : ce que `module.json` déclare correspond-il à ce que le module
+fait, et le module survit-il à l'absence de ceux dont il dépend ?
+
+**Périmètre** : les 22 `module.json`, les 22 `schema.sql`, et le câblage
+optionnel de `public/index.php` (7 139 lignes).
+
+**Ce qui doit être vérifié** :
+
+- **La règle du bump de version** (`AGENTS.md` § Database) : pour chaque
+  `schema.sql`, l'historique git montre-t-il une modification sans bump de
+  `version` correspondant dans `module.json` ? C'est le seul défaut de cette
+  liste qui a déjà cassé de la production (`Unknown column`), et il est
+  invisible à toute installation neuve — il ne se voit que sur une instance
+  déjà activée. Reproduction : construire l'instance, modifier, réactiver.
+- **Chaque `settings` déclaré a-t-il une `description` non nulle**, et chaque
+  `cookies` déclare-t-il ce que le module pose réellement ? Le second se
+  vérifie en comparant les `setcookie()` du module à sa section `cookies` —
+  la page de préférences prétend être exhaustive.
+- **Les dépendances optionnelles dégradent-elles vraiment ?** Pour chaque
+  consommateur d'une interface `Api\` nullable (§7.5), désactiver le module
+  fournisseur et ouvrir chaque page du consommateur. La matrice de démarrage
+  par module de `npm run e2e:full` prouve que le site **démarre** ; elle ne
+  prouve pas qu'une page rend quelque chose de sensé.
+- **Le câblage est-il conditionné au bon endroit ?** Un service optionnel
+  instancié inconditionnellement dans le composition root ramène la dépendance
+  dure que §7.5 interdit.
+- **Les tâches planifiées déclarées existent-elles**, et sont-elles enregistrées
+  **dans les deux points d'entrée** (`public/index.php` et `public/cron.php`) ?
+  Ce dépôt a déjà eu un `create_backup` absent de `cron.php`, qui échouait
+  silencieusement dès qu'un vrai cron tournait.
+
+---
+
+## 6. L'année scoute effective
+
+**Question** : chaque lecture est-elle bornée à l'année qu'elle croit lire ?
+
+**Périmètre** : toute requête portant — ou omettant — un `scout_year_id`.
+
+**Pourquoi une itération à elle seule** : c'est le défaut le plus spécifique à
+ce produit et le plus invisible à tout le reste. Il ne plante pas, ne déclenche
+aucune alerte et ne se voit pas sur une instance d'une seule année : il affiche
+simplement la donnée d'une autre année. Le jeu de référence en couvre trois,
+c'est précisément ce qui le rend reproductible ici.
+
+**Ce qui doit être vérifié** :
+
+- **Chaque `findBy…` de Repository sur une table portant `scout_year_id`
+  prend-il l'année en paramètre ?** Une méthode qui ne la prend pas est un
+  constat, même si tous ses appelants filtrent ensuite.
+- **L'année utilisée est-elle l'année *effective*** (`ScoutYearResolver`,
+  §8.26) et non « l'année publique » ni « la dernière » ? Les trois divergent
+  pendant la transition, exactement quand le site est le plus regardé.
+- **Le mode aperçu** (session seule, admin) fuit-il ? Une écriture faite sous
+  aperçu doit atterrir dans l'année aperçue, ou être refusée — jamais dans
+  l'année publique.
+- **L'année du staff** : un chef en année N+1 qui écrit sur une page partagée
+  avec les membres en année N.
+- **Les tâches de fond** n'ont pas de session : quelle année lisent-elles ?
+  Une tâche planifiée en septembre et exécutée en octobre a changé d'année
+  entre les deux.
+- **Le cas connu** : `member_functions.start_date` ne doit pas servir à
+  détecter une première année d'animation (il est remis à zéro au changement
+  de section) — `member_section_periods` le fait. Chercher les autres lectures
+  de dates qui font une hypothèse du même genre.
+
+---
+
+## 7. Les requêtes non bornées
+
+**Question** : qu'est-ce qui grandit avec le nombre de membres, d'années,
+d'articles ou de fichiers ?
+
+**Périmètre** : les Repository et les Services qui les enchaînent.
+
+**Frontière avec `CHANTIER-performance.md`** : ce chantier-là a mesuré le
+plancher payé par chaque requête et l'a traité. Celui-ci cherche autre chose :
+les requêtes dont le coût dépend d'une donnée que l'unité fait grossir, y
+compris sur des pages que la campagne de mesure n'a pas ouvertes. Ne pas
+re-mesurer ce qui l'a été ; lire le §5 de ce fichier avant de commencer.
+
+**Ce qui doit être vérifié** :
+
+- **Chaque `findAll()`** (58 fichiers) : borné, ou borné seulement par la
+  taille actuelle du jeu de test ?
+- **Chaque requête dans une boucle** : le N+1 classique. Le compteur
+  d'instructions SQL de `Core\Database\InstrumentedPdo` et
+  `scripts/perf/bench-pages.php` le rendent visible sans lecture.
+- **Chaque déchiffrement en masse** : déchiffrer tous les animés d'une année
+  pour afficher un compteur est le motif que la campagne de perf a déjà trouvé
+  une fois. Chercher les autres.
+- **Les index** : toute colonne servant de filtre — `scout_year_id`, chaque
+  index aveugle, chaque FK — porte-t-elle un index dans le `schema.sql` ? Une
+  colonne d'index aveugle sans index est une recherche séquentielle sur du
+  BLOB.
+- **Ce qui est chargé et jeté** : `SELECT *` (341 occurrences) sur une table
+  portant des BLOB chiffrés, pour n'en lire qu'une colonne claire.
+- **Les pages sans pagination** : journal, membres, réponses de formulaire,
+  messages entrants, galerie.
+- **Ce qui est recalculé à chaque requête** plutôt qu'à l'écriture.
+
+**Ce qui doit être mesuré, pas supposé** : toute issue de cette itération porte
+un chiffre — nombre d'instructions SQL, ou millisecondes médianes sur trois
+requêtes, à l'échelle du jeu de référence. Un constat de performance sans
+mesure n'est pas un constat.
+
+---
+
+## 8. Les tâches de fond
+
+**Question** : que se passe-t-il quand une tâche tourne deux fois, s'arrête au
+milieu, ou ne tourne jamais ?
+
+**Périmètre** : `Core\Scheduler`, tous les `Task\…Handler` du cœur et des
+modules, les deux points d'entrée.
+
+**Ce qui est déjà couvert** : `ChainSeedingInvariantTest`,
+`CronPassSingleFlightTest`, `RecurringTasksRearmTest`,
+`ScheduledTasksAreTestedTest`, `BackgroundWorkIsNotSilentTest`. Le cœur du
+scheduler est donc tenu. Les handlers des modules le sont beaucoup moins.
+
+**Ce qui doit être vérifié, handler par handler** :
+
+- **Idempotence** : le rejouer produit-il le même état, ou un doublon ? Le
+  poor man's cron n'a pas de garantie d'exécution unique en cas de crash après
+  effet et avant marquage.
+- **Reprise** : un handler qui dépasse son budget de temps reprend-il là où il
+  s'est arrêté, ou recommence-t-il ? Un traitement qui recommence sur une
+  unité de 1 500 membres ne finit jamais.
+- **Ce qui se passe quand personne ne visite le site** : `poor_mans_cron`
+  n'avance que sur visite. Toute fonction dépendant d'une heure précise
+  (redirection SOS, digest, rappel) doit le dire dans son écran de
+  configuration. Vérifier que l'avertissement existe là où il est nécessaire.
+- **L'échec est-il visible ?** Une tâche qui échoue en silence est la
+  défaillance que `docs/quality-pipeline.md` documente à longueur de page.
+  Journal, statut, notification : lequel des trois, et est-il lisible par
+  quelqu'un ?
+- **L'ordre** : deux tâches concurrentes sur la même ressource (une sauvegarde
+  pendant une mise à jour, un import pendant une synchronisation).
+- **Le contexte** : `TaskContext` porte-t-il tout ce dont le handler a besoin,
+  ou le handler reconstruit-il un service avec des valeurs par défaut fausses
+  hors requête HTTP (URL du site, année, fuseau) ?
+
+---
+
+## 9. Les écritures partielles
+
+**Question** : quand une opération en plusieurs pas échoue au troisième, dans
+quel état est le site ?
+
+**Périmètre** : tout ce qui écrit en base **et** sur disque, ou dans deux
+tables sans transaction.
+
+**Ce qui doit être vérifié** :
+
+- **Fichier écrit sans ligne, ligne sans fichier** : téléversement, pièce
+  jointe, sauvegarde, export, dérivés d'image. `EncryptedFileStorageService`
+  et `FileRepository` sont deux écritures ; qui les rend atomiques ?
+- **Les transactions** : où commencent-elles, où se terminent-elles, et une
+  exception au milieu déclenche-t-elle un rollback ? Chercher les `beginTransaction()`
+  sans `finally`.
+- **Les exceptions avalées** : chaque `catch` qui ne relance rien et
+  n'enregistre rien, et chaque `@` devant un appel. Certains sont justifiés
+  (`generate()` ne doit pas faire échouer un téléversement) — le constat est
+  celui qui ne l'est pas.
+- **Le nettoyage** : fichiers temporaires supprimés en `finally` et non en fin
+  de chemin heureux. Le CSV Desk et les relevés bancaires doivent disparaître
+  « succès ou échec » (`SECURITY.md` §5).
+- **La suppression** : supprimer un membre, une section, une année, un article,
+  un compte financier — que devient ce qui pointait dessus ? Ligne orpheline,
+  fichier orphelin, ou refus propre.
+- **La restauration** : une sauvegarde restaurée rend-elle un site cohérent ?
+  Ce que `BackupService` exclut (`storage/keys/`, `storage/config/`) est ce qui
+  rend une archive non portable — vérifier que le produit le dit là où
+  quelqu'un le lira.
+
+---
+
+## 10. Le navigateur
+
+**Question** : que fait le code côté client quand le réseau, la session ou le
+cycle de vie de l'application ne coopèrent pas ?
+
+**Périmètre** : `public/assets/js/` (110 fichiers, ~24 000 lignes),
+`public/sw.js`, les gabarits qui les câblent.
+
+**Ce qui est déjà couvert** : CodeQL pour les puits DOM, Vitest pour la logique
+découplée, Playwright pour les parcours. Aucun des trois ne regarde l'état
+après réveil ni la cohérence du cache.
+
+**Ce qui doit être vérifié** :
+
+- **Le cache hors ligne sert-il ce qu'il prétend ?** Une réponse redirigée
+  n'est jamais mise en cache (§8.25) — vérifier que la règle tient sur tous les
+  chemins, y compris ceux ajoutés depuis.
+- **Le retrait du consentement fonctionnel** vide-t-il vraiment les caches
+  `content-*`, et le worker cesse-t-il d'écrire ensuite ?
+- **Le changement de compte sur le même appareil** : la portée de cache par
+  `user_accounts.id` tient-elle aussi quand la session expire sans
+  déconnexion ?
+- **L'application installée au réveil** : une hypothèse de connectivité
+  périmée, un badge non rafraîchi, un formulaire soumis deux fois parce que
+  l'écran est revenu.
+- **Le double envoi** : chaque bouton qui déclenche une écriture est-il
+  désactivé pendant la requête ? La conséquence sur une inscription payante
+  n'est pas la même que sur un filtre.
+- **Ce qui est désactivé côté client seulement** : un bouton grisé, un champ
+  `readonly`, une liste filtrée en JS — pour chacun, la route POST refuse-t-elle
+  aussi ?
+- **La nonce CSP** : `InlineStyleElementNonceTest` couvre les styles. Les
+  scripts injectés dynamiquement, et le blob JSON `#offline-config-data`.
+
+---
+
+## 11. Journal
+
+Une entrée par itération, ajoutée par la PR de fin d'itération (§0.6). Format :
+
+```
+### Itération N — <titre> — <date>
+
+**Périmètre parcouru** : …
+**Issues ouvertes** : #… (une ligne par issue)
+**Vérifié et tenu** : …
+**Non vérifiable, et pourquoi** : …
+```
+
+### Itération 1 — Le jeu de données de référence emprunte-t-il le chemin réel ? — 2026-09-07
+
+**Périmètre parcouru** : `tests/fixtures/reference-dataset/` en entier — les
+seize classes qui écrivent (`DemoAccounts`, `ModuleActivator`,
+`DeskImportReplay`, `FinanceSeeder`, `CampaignSeeder`, `ExtrasApplier`,
+`StaffSeeder`, `CalendarSeeder`, `NewsSeeder`, `CampsSeeder`,
+`RegistrationSeeder`, `BannerSeeder`, `GallerySeeder`, `RentalSeeder`,
+`InstanceReset`, `build.php`), chacune confrontée au contrôleur ou au service
+que le site appelle pour le même geste. Instance construite trois fois au
+commit `1614aee` (provision par `scripts/e2e-support.php`, `build.php --yes
+--reset`, deux fois sur la même instance, une fois sur une seconde instance
+vierge), servie par `php -S`, parcourue avec les six comptes du README §10
+plus un visiteur anonyme : les 138 routes `GET` sans paramètre sous chaque
+rôle, les pages des objets semés (`/news` et chaque article, `/sections`,
+`/trombinoscope`, `/gallery`, `/calendar`, `/locations`, `/inscriptions`,
+`/finance/*`, `/admin/scout-year`, `/admin/journal`), puis une passe de
+`public/cron.php` et l'état d'après.
+
+**Issues ouvertes** :
+- #210 — les images d'articles n'ont pas de dérivés : vignettes en 404 jusqu'à une passe de cron (le poor man's cron n'existe plus), et pour toujours après `--reset` (constat n° 1 du §1, aggravé) ;
+- #211 — couverture et image de corps d'un article `chief`/`identified` en `role_min = public` (constat n° 2 du §1, étendu aux images de corps) ;
+- #212 — `--reset` épargne `settings`, donc `current_scout_year_id` : l'instance de référence affiche 2024-2025 comme année publique (`/admin/scout-year`, `/sections`, 403 du chef d'unité sur `/config/banner`), et sept drapeaux de reprise/d'exécution survivent au vidage ;
+- #213 — `ModuleActivator` résout le profil d'installation depuis un `base_url` que seule la première requête web écrit : 20 modules sur 22, les deux `visible_when` ni activés ni nommés ;
+- #214 — `build.php` n'appelle pas `AppClock::apply()` : tout ce que le builder écrit est daté deux heures avant le site (journal, tâches, fichiers) ;
+- #215 — le formulaire d'inscription « ouvert » est refermé par la première passe du planificateur (marqueur `applied_on` vide + fenêtre de rattrapage), et une ouverture manuelle sur une installation neuve subit la même chose ;
+- #216 — une issue pour la famille « descendu d'un cran » : articles, réponses, demandes d'inscription, badges, décalages, évènements, bannières sans la ligne de journal du vrai chemin ; réponses sans compte sur un formulaire `identified` ; import Desk sans les listeners.
+
+**Vérifié et tenu** :
+- Le refus du builder sur une instance qui a servi, et `--reset` qui l'obtient : 183 tables vidées, 149 fichiers supprimés — tout `storage/` hors `keys/`, `config/`, `maintenance/`, y compris les dérivés d'image et les caches de `temp/` — ; les effectifs (176 / 178 / 178), les identifiants et les compteurs identiques d'une construction à l'autre ; la sauvegarde de sécurité écrite avant le vidage.
+- Les photos : 43 portraits et 14 photos de groupe par `PhotoIngestionService`, le même pipeline que `/upload`, dérivés compris ; le repli d'année de `MemberPhotoService` et de `SectionPhotoService` (le trombinoscope montre 25 portraits et 7 avatars d'initiales ; les sept sections photographiées ont une photo sur `/sections`, seule l'année lue est fausse — #212).
+- La visibilité des articles : `/news` liste 1 et 2 pour un anonyme, 1, 2 et 4 pour un membre ; `/news/3` (chief) refuse animé, intendant et parent ; `/news/4` (identified) refuse l'anonyme ; `/news/5` (`direct_link`) s'ouvre par son adresse pour tous. Les articles `chief` ne sont listés sur `/news` pour personne — `ArticleService::listableVisibilities()` s'arrête à `identified`, et `/news/manage` les porte : un choix, pas un défaut.
+- Les finances : 2 comptes d'unité et 8 comptes de section avec IBAN, 190 mouvements dont 65 de la campagne, 12 doublons reconnus, 10 catégories, 195 créances ; les pages `/finance/*` répondent 200 à l'intendant et 403 à l'animé.
+- Les 520 évènements par `CalendarEventService::createEvent()` et rendus sur `/calendar` ; les 5 lieux et 12 séjours par `PlaceService`/`CampService` avec leur historique d'audit (`AuditSource::System`) ; les 7 réservations par le vrai cycle `received → reviewing → confirmed → closed` (14 changements de statut journalisés) ; l'album externe par `AlbumService::create()`, avec ses balises Open Graph récupérées (le réseau sortant passe ici) ; les 5 bannières par `BannerService` et `EditableContentService`.
+- La matrice des rôles sur les 138 routes `GET` sans paramètre : aucune 500 hors `/test-tools/uncaught-error` (voulue), aucun 200 sous le `role_min` déclaré, aucune page d'erreur PHP dans le journal du serveur. Les 403 de `/config/banner` et `/config/retro` au chef d'unité et au superadmin viennent de `requireUnitChief()` — et de l'année effective (#212) pour le premier ; `/mes-locations` refuse le superadmin, qui n'a pas de membre.
+- Les comptes de démonstration : les six se connectent par mot de passe, et le rôle obtenu est bien dérivé des fonctions confirmées (`RoleResolver`), jamais écrit.
+- La première passe de cron : 24 tâches exécutées sans échec ; la reprise des vignettes fait son travail (#210) ; `purge_desk_imports` supprime l'import de 2024-2025 au premier passage — `import_retention_scout_years = 2`, c'est la règle, mais le README ne dit pas que l'historique des imports d'une instance de référence commence à A2.
+
+**Non vérifiable, et pourquoi** :
+- Le décalage de **date** de #214 (un build entre 22 h et minuit UTC) : la construction a eu lieu à 19:55 UTC ; seul le décalage de deux heures a été observé, la conséquence sur les dates l'a été par le harnais E2E (`e2e_apply_application_clock()`), pas ici.
+- La face « produit » de #215 par le bouton de Configuration › Inscriptions : reproduite par le builder, qui écrit le même réglage au même endroit, pas par le clic.
+- La construction sur une installation faite par l'assistant d'installation plutôt que par `e2e-support.php provision` : #212 et #213 en dépendent (`current_scout_year_id` épinglé par le provisionnement, `module_registry` épargné) ; leur forme sur un vrai `SetupController` est déduite du code, pas observée.
+- Les deux extras que le README §8.3 déclare non couverts (documents de section, groupes de discussion) : rien à confronter.
+- La rejouabilité **sans** `--reset` est un refus propre par construction (README §8) ; une seconde construction ne se teste que par `--reset`, et c'est là que #212 apparaît.
+- Trois écarts de documentation, notés ici plutôt qu'en issue : la réservation « à cheval sur aujourd'hui » du README §8.3 s'est terminée le 4 septembre (dates figées, calendrier qui avance) ; le docblock de `DeskImportReplay` dit encore que `DeskImportService::import()` supprime le fichier ; le §1 du présent chantier parle d'un poor man's cron qui n'existe plus.

--- a/docs/chantiers/CHANTIER-revue-de-code.md
+++ b/docs/chantiers/CHANTIER-revue-de-code.md
@@ -605,7 +605,7 @@ après réveil ni la cohérence du cache.
 
 Une entrée par itération, ajoutée par la PR de fin d'itération (§0.6). Format :
 
-```
+```text
 ### Itération N — <titre> — <date>
 
 **Périmètre parcouru** : …


### PR DESCRIPTION
## Description

Dépose le document de chantier `docs/chantiers/CHANTIER-revue-de-code.md` tel quel (§0.6 : la PR de l'itération 1 le dépose avant d'y écrire sa propre entrée), puis ajoute au §11 l'entrée de journal de l'itération 1 — « Le jeu de données de référence emprunte-t-il le chemin réel ? » :

- le périmètre réellement parcouru (les seize classes qui écrivent, confrontées au chemin réel ; trois constructions au commit `1614aee` ; 138 routes `GET` sous sept identités ; une passe de cron) ;
- les issues ouvertes, en `triage:pending` uniquement : #210, #211, #212, #213, #214, #215, #216 ;
- ce qui a été vérifié et tenu ;
- ce qui n'a pas pu être vérifié, et pourquoi.

Aucun code ni test ne change — la reproduction vit dans les issues, comme le §0.6 du chantier l'impose. Les numéros ci-dessus sont cités comme références, pas comme `Corrige` : rien n'est corrigé ici.

Vérifié localement sur le head : `vendor/bin/phpstan analyse` (aucune erreur), `vendor/bin/phpunit` sur MariaDB (15 840 tests, 0 échec), `npm test` (1 979 tests).

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English (aucun code touché ; le document et le journal sont de l'interface, en français)
- [x] All UI-facing text is in French
- [ ] Automated tests are written/updated for this change — non applicable et voulu : le chantier interdit d'ajouter un test dans une PR d'itération (§0.6)
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [ ] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — non applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uh734xxU83JP5HmGEmYnp5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uh734xxU83JP5HmGEmYnp5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a comprehensive French code-review guide covering defect reproduction, reporting, triage, exclusions, and review deliverables.
  - Documented ten review areas, including authorization, personal-data protection, input handling, data isolation, query limits, background tasks, partial writes, and browser behavior.
  - Added a review journal format with the first iteration’s findings, verified behaviors, and areas that could not be validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->