### PR TITLE
Un refus de `Bash` est la liste qui fonctionne, pas une revue amputée

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -190,8 +190,20 @@ them (#208, 2026-09-07; the story is in that file's header and in
 docs/quality-pipeline.md § Code review). Which is why the comment's verdict
 now rests on three rows — **`Review agents launched`**, **`Review agents
 finished`** and **`Tool calls refused`** — read from the run's own
-transcript. Agents launched at zero, fewer finished than launched, or any
-tool refused, and no review happened, whatever the check says.
+transcript. Agents launched at zero, fewer finished than launched, or a
+tool refused **outside `Bash`**, and no review happened, whatever the check
+says.
+
+**`Bash` is the one entry granted command by command**, so a refused shell
+line there is the allowlist working and does not fail the check — the row
+still counts them. Every other tool is granted whole, so a refusal of one
+is a gap in `claude_args`. That distinction was bought on #217: a review
+that launched sixteen agents, finished all sixteen, spent 6.46 USD and
+posted five findings was reported as "not a review" because it had also
+tried nineteen exploratory one-liners and then done without them.
+`python3 -c`, `php -r` and shell loops stay denied on purpose — that job
+carries the maintainer's subscription token past an untrusted diff — and
+the reason is written next to the list.
 
 **`Review agents finished` is the one that catches a run that stopped
 half-way.** Subagents start in the background, and a reviewer that ends its

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -112,6 +112,7 @@ jobs:
       turns: ${{ steps.evidence.outputs.turns }}
       denials: ${{ steps.evidence.outputs.denials }}
       denied_tools: ${{ steps.evidence.outputs.denied_tools }}
+      denials_other: ${{ steps.evidence.outputs.denials_other }}
       agent_calls: ${{ steps.evidence.outputs.agent_calls }}
       subagents_spawned: ${{ steps.evidence.outputs.subagents_spawned }}
       subagents_completed: ${{ steps.evidence.outputs.subagents_completed }}
@@ -252,6 +253,40 @@ jobs:
           # the commit it was asked to read spends its turns working around
           # that instead of reading the diff.
           #
+          # WHAT THE FIRST REAL REVIEW ACTUALLY ASKED FOR, and the reason
+          # the read-only utilities are on the list. #217 was the first run
+          # after the grant above, so the first time a reviewer here got
+          # past its opening call: 16 agents, all of them finished, five
+          # findings posted, 6.46 USD. It was also refused 19 Bash calls,
+          # and none of them was `gh` or a diff — they were the ordinary
+          # work of checking a document's claims against the repository:
+          #
+          #   8  read-only utilities: grep, ls, find, wc, sort, head, cat
+          #   3  jq over modules/*/module.json
+          #   5  INTERPRETERS: python3 -c, php -r
+          #   3  shell loops and command substitution
+          #   2  `git -C <path> log|diff` — granted as `git log`, but the
+          #      allowlist matches a prefix and `git -C` is not one
+          #
+          # The first two groups are granted below. They read, they write
+          # nothing, and refusing them only bought turns spent working
+          # around the gap. The `git -C` form is answered in the prompt
+          # instead: the workspace IS the repository, so `-C` was never
+          # needed.
+          #
+          # THE INTERPRETERS AND THE LOOPS STAY DENIED, and this is the
+          # "say in this file why it must stay denied" branch that the
+          # steward skill offers next to "grant it". `python3 -c` and
+          # `php -r` are arbitrary code execution: granting them is
+          # granting `Bash` whole, under a different spelling. This job
+          # holds CLAUDE_CODE_OAUTH_TOKEN — the maintainer's subscription
+          # — in its environment and `id-token: write` besides, while
+          # reading the one input this repository does not control, a pull
+          # request's diff. `pull-requests: read` bounds what the GitHub
+          # token can do and bounds nothing about either of those. A
+          # reviewer that cannot count with python3 counts with grep; a
+          # leaked subscription token is not recoverable.
+          #
           # `Bash(gh pr comment:*)` IS GRANTED THOUGH THE TOKEN CANNOT USE
           # IT — this job is `pull-requests: read`, so the call returns 403
           # rather than posting. Granted anyway, because the alternative is
@@ -307,8 +342,8 @@ jobs:
           # and `subagents_completed` below, which the run reports about
           # itself whatever the model did.
           claude_args: >-
-            --allowedTools "Skill,Task,Agent,Read,Glob,Grep,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git fetch:*),mcp__github_inline_comment__create_inline_comment"
-            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one. Wait for every subagent you launch — pass run_in_background false — and never end a turn waiting for one: this is a one-shot non-interactive run and nothing will wake it up, so a background agent still working when you stop is a part of the diff nobody read. The workspace is already a full clone checked out for this pull request, so the commits under review are there to read."
+            --allowedTools "Skill,Task,Agent,Read,Glob,Grep,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git fetch:*),Bash(grep:*),Bash(ls:*),Bash(find:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(head:*),Bash(tail:*),Bash(cat:*),Bash(echo:*),Bash(printf:*),Bash(jq:*),mcp__github_inline_comment__create_inline_comment"
+            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one. Wait for every subagent you launch — pass run_in_background false — and never end a turn waiting for one: this is a one-shot non-interactive run and nothing will wake it up, so a background agent still working when you stop is a part of the diff nobody read. The workspace is already a full clone checked out for this pull request, so the commits under review are there to read: run git from it plainly, without -C and a path, which is not granted. Counting and cross-checking the repository is part of reviewing it, and Grep, Glob and Read are granted whole for that; python3 -c, php -r and shell loops are not granted and will not be, so reach for the read-only commands instead of spending turns rediscovering that."
 
       # WHAT THE RUN ACTUALLY DID, read off the transcript the SDK wrote.
       #
@@ -339,6 +374,7 @@ jobs:
               echo "turns=-1"
               echo "denials=-1"
               echo "denied_tools="
+              echo "denials_other=-1"
               echo "agent_calls=-1"
               echo "subagents_spawned=-1"
               echo "subagents_completed=-1"
@@ -431,6 +467,7 @@ jobs:
                 "turns=" + (($r.num_turns // -1) | tostring),
                 "denials=" + ((if ($r | has("permission_denials")) then (($r.permission_denials // []) | length) else -1 end) | tostring),
                 "denied_tools=" + ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed")] | unique | join(", ") | flat),
+                "denials_other=" + ((if ($r | has("permission_denials")) then ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed") | select(. != "Bash")] | length) else -1 end) | tostring),
                 "agent_calls=" + ($agents | tostring),
                 "subagents_spawned=" + ($sub.spawned | tally | tostring),
                 "subagents_completed=" + ($sub.completed | tally | tostring),
@@ -496,9 +533,23 @@ jobs:
   # refused. All three come from the transcript, all three are facts about
   # this run rather than estimates of it, and none needs a threshold — the
   # question "were any agents launched at all" has no borderline, and
-  # neither has "did they all come back". A refusal is disqualifying on its
-  # own: the agent asked for a tool this workflow did not grant, so whatever
-  # it concluded, it concluded without something it judged it needed.
+  # neither has "did they all come back".
+  #
+  # A REFUSAL IS DISQUALIFYING ONLY WHERE IT MEANS SOMETHING. Until #217
+  # any refusal was, and the rule read: the agent asked for a tool this
+  # workflow did not grant, so it concluded without something it judged it
+  # needed. That is true of every tool on the allowlist except one. `Bash`
+  # is granted command by command on purpose — the interpreters stay denied
+  # while this job carries a subscription token past an untrusted diff — so
+  # a refused shell line there is the allowlist working, not a gap in it.
+  # #217 was the first review that ever got far enough to show the
+  # difference: 16 agents launched and 16 finished, five findings posted,
+  # 6.46 USD, and 19 refused one-liners it went on to do with `Grep` and
+  # `Read` instead. Calling that "not a review" would have taught everyone
+  # here to ignore this comment, which is the only way a check like this
+  # actually dies. So the verdict now reads refusals OUTSIDE `Bash`; the
+  # total still gets a row, because it named `Skill` on #208 and that is
+  # how the reviewer's real defect was found.
   #
   # THE FINISHED COUNT WAS ADDED ON 2026-09-07 AFTER THE OTHER TWO WOULD
   # HAVE PASSED A RUN THAT REVIEWED NOTHING. On #208 the reviewer spawned
@@ -558,6 +609,11 @@ jobs:
           TURNS: ${{ needs.review.outputs.turns }}
           DENIALS: ${{ needs.review.outputs.denials }}
           DENIED_TOOLS: ${{ needs.review.outputs.denied_tools }}
+          # Refusals of a tool OTHER than `Bash`. `Bash` is the one entry
+          # granted in part on purpose, so a refused command is a normal
+          # outcome of exploring; every other tool is granted whole, and a
+          # refusal of one is a gap in this file.
+          DENIALS_OTHER: ${{ needs.review.outputs.denials_other }}
           AGENT_CALLS: ${{ needs.review.outputs.agent_calls }}
           # How many review agents the run started, and how many it
           # collected. Equal is the only reading that says the procedure
@@ -606,14 +662,23 @@ jobs:
             verdict="**Unverified.** The action reported success but left no readable transcript, so nothing here can say whether the reviewer did any work. Read the run log."
           elif [[ "${IS_ERROR}" == "true" || "${SUBTYPE}" != "success" ]]; then
             verdict="**The reviewer stopped on an error** (\`${SUBTYPE:-unknown}\`). Whatever it had read when it stopped, it did not finish reading the diff."
-          elif [[ "${DENIALS}" == "-1" || "${AGENT_CALLS}" == "-1" ]]; then
+          elif [[ "${DENIALS}" == "-1" || "${DENIALS_OTHER}" == "-1" || "${AGENT_CALLS}" == "-1" ]]; then
             # `-1` is the evidence step saying it could not find the field,
             # never that it found a zero. Reading it as a count would call a
             # transcript this reader does not understand a refusal, and name
             # no tool while doing it.
             verdict="**Unverified.** The transcript did not carry what this check reads — refused tool calls, agents launched — so it cannot say whether a review happened. That is a defect in the reader, not a verdict on the diff: the shape of the run's own record has changed under it."
-          elif [[ "${DENIALS}" != "0" ]]; then
-            verdict="**A tool was refused, so this is not a review.** The agent asked for \`${DENIED_TOOLS:-a tool this run did not name}\` and this workflow had not granted it, so it worked around the gap or gave up — either way it reached its conclusion without something it judged it needed. Grant the tool in \`claude_args\` or say in this file why it must stay denied."
+          elif [[ "${DENIALS_OTHER}" != "0" ]]; then
+            # NOT `DENIALS`. Every tool on the allowlist is granted whole
+            # except `Bash`, which is granted command by command on
+            # purpose — so a refused `Bash` line is the allowlist working,
+            # while a refusal of anything else is a tool this file forgot.
+            # That distinction is what #217 cost: a review that launched
+            # 16 agents, finished all 16, spent 6.46 USD and posted five
+            # findings was called "not a review" over 19 exploratory shell
+            # one-liners it then did without. `Skill` on #208 was the
+            # opposite case and stays red here.
+            verdict="**A tool was refused, so this is not a review.** The agent asked for \`${DENIED_TOOLS:-a tool this run did not name}\` and this workflow had not granted it, so it worked around the gap or gave up — either way it reached its conclusion without something it judged it needed. Every tool here but \`Bash\` is granted whole, so this is a gap: grant it in \`claude_args\` or say in this file why it must stay denied."
           elif [[ "${AGENT_CALLS}" == "0" ]]; then
             verdict="**The review agents never ran.** Every step of the code-review command launches a subagent, and this run launched none, so nothing read the diff for bugs. The run log carries the full transcript; start at the first tool call."
           elif [[ "${SUBAGENTS_SPAWNED}" == "-1" || "${SUBAGENTS_COMPLETED}" == "-1" ]]; then
@@ -634,7 +699,7 @@ jobs:
             # spawned, two collected, no comment posted).
             verdict="**The review stopped part-way through.** ${SUBAGENTS_SPAWNED} review agents were launched and ${SUBAGENTS_COMPLETED} finished, so at least one was still reading when the run ended — and whatever it would have found is not on this pull request. Read the run log from the last agent launched."
           else
-            verdict="**Reviewed, nothing to report.** ${AGENT_CALLS} review agents ran over ${TURNS} turns, all of them finished, and no tool was refused. Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran."
+            verdict="**Reviewed, nothing to report.** ${AGENT_CALLS} review agents ran over ${TURNS} turns and all of them finished, with no tool refused that this workflow grants whole. Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran. Refused \`Bash\` commands, counted in the row below, are the allowlist doing its job — see \`claude_args\` for what stays denied and why."
             unreviewed=0
           fi
 
@@ -671,12 +736,23 @@ jobs:
             turns_cell="unknown"
           fi
 
+          # The total, then which tools, then how many of them were NOT
+          # `Bash` — because that last number is the one the verdict turns
+          # on, and a row showing only "19" invites the reading that just
+          # cost a real review its green.
           denials_cell="${DENIALS:--}"
           if [[ "${denials_cell}" == "-1" ]]; then
             denials_cell="unknown"
           fi
           if [[ -n "${DENIED_TOOLS}" ]]; then
             denials_cell="${denials_cell} (${DENIED_TOOLS})"
+          fi
+          if [[ "${DENIALS_OTHER}" == "-1" ]]; then
+            denials_cell="${denials_cell} — outside \`Bash\`: unknown"
+          elif [[ "${DENIALS_OTHER}" == "0" ]]; then
+            denials_cell="${denials_cell} — none outside \`Bash\`"
+          else
+            denials_cell="${denials_cell} — ${DENIALS_OTHER} outside \`Bash\`"
           fi
 
           cost_cell="${COST:--}"

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -522,10 +522,29 @@ generalises:
   **goes red when it cannot show a review happened**. Its signals are how
   many review agents were launched, how many of them finished, and how many
   tool calls were refused: facts about the run, not estimates of it, and
-  none needs a threshold. A refusal is disqualifying on its own — the agent
-  asked for something this workflow had not granted.
+  none needs a threshold. A refusal is disqualifying when it falls outside
+  `Bash` — the one entry granted command by command rather than whole, so
+  that a refused shell line is the allowlist working and a refusal of
+  anything else is a gap.
   `tests/Architecture/ClaudeReviewIsVerifiableTest` pins each of these
   against the single edit that would undo it.
+
+**The first review that ever ran end to end was #217**, the first pull
+request after that fix landed: 10 min 47 s against the 13 seconds a
+declined run takes, `Skill` in its tool list, sixteen agents launched and
+sixteen finished, `claude-opus-5` among its models for the first time, five
+inline findings posted — a stale SSRF claim, a route count off by 130, two
+paragraphs describing a cron that no longer exists. It also **failed the
+status check**, over nineteen refused `Bash` one-liners (`grep`, `ls`,
+`find`, `wc`, `jq`, and five `python3 -c` / `php -r`) that it went on to do
+with `Grep` and `Read` instead. The read-only utilities are granted now;
+the interpreters are not and will not be, because that job carries
+`CLAUDE_CODE_OAUTH_TOKEN` and `id-token: write` past a diff this repository
+does not control, and `pull-requests: read` bounds neither. That is the
+"say in this file why it must stay denied" branch the steward skill offers
+next to "grant it", and it is why the verdict counts refusals outside
+`Bash` rather than all of them: a check that cries wolf over its first real
+review is a check people learn to skip.
 
 **SonarQube Cloud** — posts a Quality Gate on each pull request. It is
 skipped entirely on pull requests from forks, because `SONAR_TOKEN` is not

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -255,7 +255,10 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
     {
         [$review] = self::jobs();
 
-        $outputs = ['evidence', 'turns', 'denials', 'denied_tools', 'agent_calls', 'subagents_spawned', 'subagents_completed'];
+        $outputs = [
+            'evidence', 'turns', 'denials', 'denied_tools', 'denials_other',
+            'agent_calls', 'subagents_spawned', 'subagents_completed',
+        ];
 
         foreach ($outputs as $output) {
             $this->assertMatchesRegularExpression(
@@ -461,6 +464,98 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
             $status,
             'The status job cannot fail any more, so a review that never ran is once again a green check '
             . 'and a comment saying so.',
+        );
+    }
+
+    /**
+     * REVIEWING A REPOSITORY MEANS COUNTING THINGS IN IT. The first run
+     * that ever got past its opening call (#217) was refused nineteen
+     * shell commands, and not one of them was a `gh` call or a diff: they
+     * were `grep`, `ls`, `find`, `wc`, `jq` — checking a document's claims
+     * against the code, which is the work. `Grep` and `Read` cover reading;
+     * these cover counting, and refusing them only bought turns spent
+     * rediscovering the gap.
+     */
+    public function testTheReviewerCanCountWhatItReads(): void
+    {
+        $args = self::claudeArgs();
+
+        foreach (['grep', 'ls', 'find', 'wc', 'sort', 'head', 'cat', 'jq'] as $tool) {
+            $this->assertStringContainsString(
+                'Bash(' . $tool . ':*)',
+                $args,
+                'The reviewer was refused `' . $tool . '` on #217 while checking a document against the '
+                . 'repository. It reads and writes nothing.',
+            );
+        }
+    }
+
+    /**
+     * THE OTHER BRANCH THE STEWARD SKILL OFFERS: "grant it in
+     * `claude_args`, or say in this file why it must stay denied."
+     *
+     * `python3 -c` and `php -r` are arbitrary code execution — granting
+     * them is granting `Bash` whole under another spelling — and this job
+     * holds the maintainer's subscription token and `id-token: write`
+     * while reading the one input this repository does not control. So
+     * they stay denied, and the file has to say so, or the next person to
+     * see them in `denied_tools` grants them to make a red go away.
+     */
+    public function testWhatStaysDeniedIsWrittenDown(): void
+    {
+        [$review] = self::jobs();
+
+        $this->assertStringNotContainsString(
+            'Bash(python3',
+            self::claudeArgs(),
+            'The reviewer has been granted `python3`, which runs anything. That is `Bash` whole, in a job '
+            . 'holding CLAUDE_CODE_OAUTH_TOKEN and reading an untrusted diff.',
+        );
+        $this->assertStringNotContainsString(
+            'Bash(php',
+            self::claudeArgs(),
+            'The reviewer has been granted `php`, which runs anything through `php -r`.',
+        );
+        $this->assertStringContainsString(
+            'CLAUDE_CODE_OAUTH_TOKEN',
+            $review,
+            'The reason the interpreters stay denied is no longer written next to the list. Without it the '
+            . 'next refusal in `denied_tools` reads as an oversight to be granted.',
+        );
+    }
+
+    /**
+     * WHY THE VERDICT COUNTS REFUSALS OUTSIDE `Bash` RATHER THAN ALL OF
+     * THEM. Every tool on the allowlist is granted whole except `Bash`,
+     * which is granted command by command on purpose — so a refused shell
+     * line is the allowlist working, and a refusal of anything else is a
+     * gap in this file.
+     *
+     * #217 is what the old rule cost: 16 agents launched, 16 finished,
+     * 6.46 USD, five findings posted on the diff — reported as "not a
+     * review" because it had also tried nineteen exploratory one-liners
+     * and then done without them. A check that cries wolf over its first
+     * real review is a check people learn to skip, which is how one dies.
+     * `Skill` on #208 is the case that must stay red, and does.
+     */
+    public function testOnlyARefusalOutsideBashDisqualifiesTheReview(): void
+    {
+        [, $status] = self::jobs();
+
+        $matched = preg_match('/elif \[\[ "\$\{DENIALS_OTHER\}" != "0" \]\]; then/', $status);
+
+        $this->assertSame(
+            1,
+            $matched,
+            'The verdict no longer turns on refusals outside `Bash`. Reading `DENIALS` instead marks every '
+            . 'review that explored with a shell one-liner as no review at all.',
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/\| Tool calls refused \|/',
+            $status,
+            'The refusal row is gone. It is what named `Skill` on #208, which is how the reviewer’s real '
+            . 'defect was found — demoting it from the verdict must not remove it from the report.',
         );
     }
 


### PR DESCRIPTION
## Description

La #217 est la première PR après la fusion de la #209, donc **la première où l'action a accepté de tourner**. Elle montre les deux choses à la fois.

### Ce qui marche enfin

| | avant | #217 |
|---|---|---|
| Durée | 13 s | **10 min 47 s** |
| Coût | — | **6,46 $** |
| `Skill` utilisé | ✗ | **✓** |
| Agents lancés / terminés | 3 / 2 | **16 / 16** |
| Modèles | haiku, sonnet | haiku, sonnet, **opus-5** |
| Trouvailles postées | 0 | **5** |

Et ce sont de vraies trouvailles : un SSRF décrit comme non corrigé alors que le code a la validation d'IP privées, un compte de routes faux de 130, deux paragraphes décrivant un cron supprimé, une référence croisée ambiguë. Le relecteur a en outre écarté quatre pistes après vérification.

### Ce qui ne marche pas

Le job de statut l'a déclarée **« pas une revue »**, pour dix-neuf appels `Bash` refusés. Aucun n'était un `gh` ni un diff :

| Cause | Nb |
|---|---|
| Utilitaires de lecture (`grep`, `ls`, `find`, `wc`, `sort`, `head`, `cat`) | 8 |
| `jq` sur `modules/*/module.json` | 3 |
| **Interpréteurs** (`python3 -c`, `php -r`) | 5 |
| Boucles `for` et substitutions `$( )` | 3 |
| `git -C <chemin> log\|diff` — accordés comme `git log`, mais la liste compare un **préfixe** et `git -C` n'en est pas un | 2 |

Le relecteur les a tous contournés avec `Grep` et `Read`. Il a d'ailleurs trouvé le bon compte de routes sans eux.

### Pourquoi aucune liste d'outils ne peut corriger ça

Même en accordant généreusement les utilitaires, il resterait `python3 -c` et `php -r`. Ce sont de **l'exécution de code arbitraire** : les accorder, c'est accorder `Bash` en entier sous une autre orthographe — dans un job qui porte `CLAUDE_CODE_OAUTH_TOKEN` (l'abonnement du mainteneur) et `id-token: write` **en lisant la seule entrée que ce dépôt ne contrôle pas**, le diff d'une PR. `pull-requests: read` ne borne ni l'un ni l'autre.

### Le défaut est dans la règle

Tous les outils de la liste sont accordés **en entier**, sauf `Bash`, accordé commande par commande à dessein. Une ligne shell refusée y est donc **la liste qui fonctionne** ; un refus ailleurs est un oubli de ce fichier. Le verdict lit maintenant `denials_other` — les refus hors `Bash`.

Le total **garde sa ligne** dans le commentaire : c'est lui qui a nommé `Skill` sur la #208, et c'est ainsi que le vrai défaut du relecteur a été trouvé. Il est rétrogradé du verdict, pas retiré du rapport.

### Ce que change cette PR

- **Accordés** : `grep`, `ls`, `find`, `wc`, `sort`, `uniq`, `head`, `tail`, `cat`, `echo`, `printf`, `jq`. Ils lisent, ils n'écrivent rien.
- **Refusés, et écrit noir sur blanc à côté de la liste** : les interpréteurs et les boucles. C'est la branche « *dire dans ce fichier pourquoi cela doit rester refusé* » que le skill `steward` propose à côté de « *l'accorder* », et que le garde-fou n'avait jamais implémentée.
- **Prompt** : appeler git sans `-C`, l'espace de travail étant déjà le dépôt.
- **Lecteur** : nouveau champ `denials_other`, même discipline que le reste (`-1` quand il est illisible).
- **Ligne du tableau** : `19 (Bash) — none outside \`Bash\`` — le nombre sur lequel le verdict repose est désormais visible, au lieu d'un « 19 » nu qui invite exactement la lecture qui vient de coûter son vert à une vraie revue.

### Vérifications

Les six branches du verdict ont été rejouées hors CI avec les valeurs réelles des deux PR :

- **#217** (19 refus, tous `Bash`, 16/16 agents) → **vert**
- **#208** (`Skill` refusé) → **rouge**, inchangé
- `Skill` refusé avec agents complets → **rouge**
- revue interrompue sans aucun refus → **rouge**
- aucun agent lancé → **rouge**
- lecteur incapable de lire les refus hors `Bash` → **rouge, non vérifié**

Les nouveaux tests ont été vérifiés par mutation du workflow : remettre `DENIALS` à la place de `DENIALS_OTHER` fait échouer `testOnlyARefusalOutsideBashDisqualifiesTheReview`.

Un garde-fou qui crie au loup sur sa première vraie revue est un garde-fou qu'on apprend à ignorer ; c'est la seule façon dont une vérification comme celle-ci meurt vraiment.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French — aucun texte d'interface touché
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 15 848 tests, verts)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: sans objet

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N5cMGCovVxojb3v9Dk3inz

---
_Generated by [Claude Code](https://claude.ai/code/session_01N5cMGCovVxojb3v9Dk3inz)_