### PR TITLE
Rendre les présences d'un animé modifiables date par date

### DIFF
--- a/modules/presences/help/presences-anime.md
+++ b/modules/presences/help/presences-anime.md
@@ -1,18 +1,20 @@
 ---
 id: presences-anime
 title: Préparer un appel à une famille
-summary: La page d'un animé : son taux, sa pente sur l'année, et ce qui a été noté.
+summary: La page d'un animé : son taux, sa pente sur l'année, ce qui a été noté, et la correction date par date.
 category: Espace animateurs
 role_min: chief
 question: Comment voir si un animé vient moins souvent qu'avant ?
 question: Où retrouver ce qui a été noté sur un animé cette année ?
+question: Comment corriger la présence d'un animé à une date précise ?
 paths: /chefs/presences/anime/*
 related: presences-registre
 ---
 
 La page d'un animé rassemble ce qu'on relit avant d'appeler une famille :
 son taux de l'année, l'évolution mois par mois, et l'historique avec les
-commentaires.
+commentaires. Elle ne fait pas que le montrer : chaque date s'y corrige,
+avec les boutons et le commentaire de la feuille de présence.
 
 ## Un taux ne se lit pas seul
 
@@ -31,14 +33,30 @@ descendent ne sont pas trois absences : c'est un décrochage, et c'est ce
 qu'on veut repérer assez tôt pour en parler. Un mois où la section n'a
 rien pointé n'apparaît pas du tout.
 
-## L'historique
+## L'historique, et les corrections
 
-Les dix derniers évènements, du plus récent au plus ancien, avec l'état
-et le commentaire. Une soirée que personne n'a pointée y figure aussi, en
-« Non renseigné » : un trou dans l'historique est un fait sur la section,
-pas une absence de l'animé.
+Les dix derniers évènements, du plus récent au plus ancien. Une soirée que
+personne n'a pointée y figure aussi, en « Non renseigné » : un trou dans
+l'historique est un fait sur la section, pas une absence de l'animé.
 
-Chaque ligne mène à la feuille de sa date, pour corriger sur place.
+Chaque date porte **les mêmes boutons que la feuille de l'évènement** —
+« Présent », « Excusé », « Absent », « Non renseigné » — et le même
+commentaire, sous « Ajouter un commentaire ». On corrige donc là où on
+s'aperçoit de l'erreur, sans ouvrir la feuille de chaque soirée : c'est
+souvent au téléphone avec un parent qu'on apprend que l'absence de samedi
+était annoncée.
+
+L'enregistrement est automatique, exactement comme sur une feuille : chaque
+appui part tout de suite, et sans réseau rien n'est conservé. Le commentaire
+écrit ici est le même que celui de la feuille — il n'y a qu'un commentaire
+par animé et par date, et le staff de la section le voit des deux côtés.
+
+Les taux et le graphique du haut de page, eux, sont calculés à l'ouverture :
+un bandeau apparaît dès qu'une correction les a rendus faux, avec de quoi
+« Recharger la page » pour les recalculer.
+
+Le nom de la soirée reste un lien vers sa feuille complète, pour pointer
+toute la section d'un coup.
 
 > Cette page n'est jamais visible par la famille, pas plus que les
 > commentaires qu'elle porte. Elle sert à préparer une conversation, pas à

--- a/modules/presences/module.json
+++ b/modules/presences/module.json
@@ -2,7 +2,7 @@
   "id": "presences",
   "name": "Présences",
   "description": "Feuille de présence par évènement de section : quatre états par animé, commentaire chiffré, et registre annuel de la section.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "requires": ["calendar"],
   "routes": [
     {

--- a/modules/presences/src/Controller/PresencesController.php
+++ b/modules/presences/src/Controller/PresencesController.php
@@ -170,7 +170,16 @@ class PresencesController extends AbstractController
     }
 
     /**
-     * GET /chefs/presences/anime/{memberId} — one animé's year.
+     * GET /chefs/presences/anime/{memberId} — one animé's year, and the
+     * one screen that corrects it date by date.
+     *
+     * The page is not read-only: each date carries the same four states
+     * and the same comment as an evening's sheet, and writes them to that
+     * evening's OWN endpoint (`record()` below). There is therefore no
+     * second write path to keep in step with the first — and no second
+     * authorization check either, which is the point: `record()` re-derives
+     * the event's section and the animé's membership of it on every call,
+     * whichever screen the request came from.
      *
      * @param array<string, string> $params
      */
@@ -195,6 +204,7 @@ class PresencesController extends AbstractController
         return $this->render('@presences/anime.html.twig', [
             'profile' => $profile,
             'history_limit' => PresenceAnimeService::HISTORY_LIMIT,
+            'statuses' => PresenceStatus::ordered(),
             'scout_year_label' => $year->label,
         ]);
     }
@@ -273,7 +283,9 @@ class PresencesController extends AbstractController
 
     /**
      * POST /chefs/presences/feuille/{eventId}/enregistrer — one tap, one
-     * save, JSON.
+     * save, JSON. The write path of BOTH screens: an evening's sheet posts
+     * every row here, and an animé's page posts each of its dates to that
+     * date's own event id.
      *
      * The body carries `status` XOR `comment`, never both: two animateurs
      * pointing the same list at once must not have one's tap erase the

--- a/modules/presences/views/anime.html.twig
+++ b/modules/presences/views/anime.html.twig
@@ -46,45 +46,63 @@
         </section>
     {% endif %}
 
-    {# Le détail évènement par évènement, avec les commentaires : c'est ce
-       qu'on relit avant d'appeler une famille, et ça ne tenait pas dans un
-       panneau dépliant. #}
-    <section class="card mb-3">
-        <div class="card-header">
-            <h2 class="h6 mb-0">Historique</h2>
+    {# Les tuiles et le graphique sont calculés à l'ouverture de la page, et
+       rien ne les recalcule sous les doigts : le dire vaut mieux que laisser
+       lire un taux périmé. Masqué tant que rien n'a bougé, et juste sous les
+       chiffres dont il parle. #}
+    <div class="alert alert-info d-none d-flex align-items-start gap-2" role="status" id="presences-stale">
+        <i class="bi bi-arrow-clockwise flex-shrink-0 mt-1" aria-hidden="true"></i>
+        <div>
+            Les taux et le graphique ci-dessus datent de l'ouverture de la page.
+            <a href="/chefs/presences/anime/{{ profile.memberId }}">Recharger la page</a> pour les recalculer.
         </div>
+    </div>
+
+    {# Le détail date par date, avec les commentaires : c'est ce qu'on relit
+       avant d'appeler une famille — et c'est aussi là qu'on corrige, sans
+       ouvrir la feuille de chaque soirée. Les lignes sont exactement celles
+       de la feuille d'un évènement (@presences/partials/_presence_line.html.twig) :
+       une correction se fait du même geste des deux côtés. #}
+    <section class="mb-3">
+        <h2 class="h6">Historique</h2>
+
         {% if profile.history is empty %}
-            <div class="card-body">
-                {% include 'partials/empty_state.html.twig' with {
-                    message: 'Aucun évènement au calendrier de la section cette année scoute.',
-                    compact: true,
-                } only %}
-            </div>
+            {% include 'partials/empty_state.html.twig' with {
+                message: 'Aucun évènement au calendrier de la section cette année scoute.',
+                compact: true,
+            } only %}
         {% else %}
-            <ul class="list-group list-group-flush">
+            <div class="d-flex flex-column gap-2" id="presences-lines">
                 {% for entry in profile.history %}
-                    <li class="list-group-item">
-                        <div class="d-flex align-items-center gap-2">
+                    {% embed '@presences/partials/_presence_line.html.twig' with {
+                        row_id: entry.eventId,
+                        member_id: profile.memberId,
+                        endpoint: '/chefs/presences/feuille/' ~ entry.eventId ~ '/enregistrer',
+                        status: entry.status,
+                        statuses: statuses,
+                        comment: entry.comment,
+                        subject: entry.startDate|date_fr ~ ' — ' ~ entry.title,
+                        entry: entry,
+                    } only %}
+                        {% block heading %}
                             <a href="/chefs/presences/feuille/{{ entry.eventId }}"
-                               class="flex-grow-1 text-truncate text-decoration-none text-body">
+                               class="d-block text-truncate text-decoration-none text-body">
                                 <span class="text-body-secondary small">{{ entry.startDate|date_fr }}</span>
                                 {{ entry.title }}
                             </a>
-                            <span class="badge text-bg-{{ entry.status.tone }} flex-shrink-0">{{ entry.status.label }}</span>
-                        </div>
-                        {% if entry.comment %}
-                            <p class="small text-body-secondary mb-0 mt-1">
-                                <i class="bi bi-chat-left-text" aria-hidden="true"></i> {{ entry.comment }}
-                            </p>
-                        {% endif %}
-                    </li>
+                        {% endblock %}
+                    {% endembed %}
                 {% endfor %}
-            </ul>
-        {% endif %}
-        {% if profile.historyTruncated %}
-            <div class="card-footer small text-body-secondary">
-                {{ history_limit }} derniers évènements. L'export Excel de la section porte l'année entière.
             </div>
+
+            <p class="text-body-secondary small mt-3 mb-0">
+                L'enregistrement est automatique — il n'y a pas de bouton « Enregistrer », et sans réseau rien
+                n'est conservé. Le nom de la soirée mène à sa feuille complète, pour pointer toute la section.
+                {% if profile.historyTruncated %}
+                    Seuls les {{ history_limit }} derniers évènements sont affichés ; l'export Excel de la
+                    section porte l'année entière.
+                {% endif %}
+            </p>
         {% endif %}
     </section>
 
@@ -95,4 +113,8 @@
         Cette page n'est jamais visible par la famille — pas plus que les commentaires qu'elle porte.
         Elle sert à préparer une conversation, pas à la remplacer.
     </p>
+{% endblock %}
+
+{% block scripts %}
+    <script src="{{ asset('/assets/js/presences-lines.js') }}" defer nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/modules/presences/views/anime.html.twig
+++ b/modules/presences/views/anime.html.twig
@@ -50,13 +50,13 @@
        rien ne les recalcule sous les doigts : le dire vaut mieux que laisser
        lire un taux périmé. Masqué tant que rien n'a bougé, et juste sous les
        chiffres dont il parle. #}
-    <div class="alert alert-info d-none d-flex align-items-start gap-2" role="status" id="presences-stale">
+    <output class="alert alert-info d-none d-flex align-items-start gap-2" id="presences-stale">
         <i class="bi bi-arrow-clockwise flex-shrink-0 mt-1" aria-hidden="true"></i>
-        <div>
+        <span>
             Les taux et le graphique ci-dessus datent de l'ouverture de la page.
             <a href="/chefs/presences/anime/{{ profile.memberId }}">Recharger la page</a> pour les recalculer.
-        </div>
-    </div>
+        </span>
+    </output>
 
     {# Le détail date par date, avec les commentaires : c'est ce qu'on relit
        avant d'appeler une famille — et c'est aussi là qu'on corrige, sans

--- a/modules/presences/views/index.html.twig
+++ b/modules/presences/views/index.html.twig
@@ -208,16 +208,6 @@
                 </ul>
             {% endif %}
         </section>
-
-        {# « Comment j'arrive à la page d'un animé » est la première
-           question qu'on se pose : on y répond plutôt que de la laisser
-           chercher. #}
-        <p class="small text-body-secondary">
-            <strong>Une seule entrée dans le menu : « Présences ».</strong> Elle ouvre cette page. De là,
-            trois chemins vers une feuille ou un animé : le raccourci du jour, la recherche ci-dessus, et
-            le graphique dont chaque barre mène à la feuille de sa date. L'agenda d'un animateur de la
-            section porte en plus un lien direct vers la feuille du jour.
-        </p>
     {% endif %}
 {% endblock %}
 

--- a/modules/presences/views/partials/_presence_line.html.twig
+++ b/modules/presences/views/partials/_presence_line.html.twig
@@ -1,0 +1,83 @@
+{#
+ ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+#}
+{#
+  One presence — four states and a comment, each saved the moment it is
+  touched. The SAME row on both screens the module has: one per animé on
+  an evening's sheet, one per date on an animé's page. It is one partial
+  rather than two hand-rolled copies because it is the same gesture on the
+  same row of the same table; the copy nobody is working on is the one
+  that stops matching, and « pareil que la feuille » is exactly what was
+  asked for.
+
+  Params:
+    row_id    -- unique WITHIN the page: the animé on a sheet, the date on
+                 an animé's page. It keys the comment's debounce, which is
+                 why it cannot be the member id — every row of an animé's
+                 page carries the same one.
+    member_id -- whose presence this is; what the write sends.
+    endpoint  -- where this row saves, read off the row rather than off
+                 the page: an animé's page writes each date to that
+                 evening's own endpoint, which is the endpoint its sheet
+                 already writes to.
+    status    -- the Value\PresenceStatus the row is in.
+    statuses  -- the four, in the order every screen offers them.
+    comment   -- string|null, what the staff wrote beside it.
+    subject   -- what the row is about, read after the state's label by a
+                 screen reader (« Hargot, Basile », « 13 septembre —
+                 Réunion »): a page of identically-named « Présent »
+                 buttons is unusable without it.
+
+  Block `heading` -- the row's left-hand side, the one thing the two
+  screens do not share (a name and a totem there, a date and an evening
+  here).
+#}
+<article class="card presence-line"
+         data-row-id="{{ row_id }}"
+         data-member-id="{{ member_id }}"
+         data-endpoint="{{ endpoint }}"
+         data-status="{{ status.value }}">
+    <div class="card-body p-2">
+        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2">
+            <div class="flex-grow-1 text-truncate">
+                {% block heading %}{% endblock %}
+            </div>
+            {# Quatre cibles larges, toujours visibles : un menu déroulant
+               demanderait deux gestes par ligne, debout, pour vingt-cinq
+               noms. #}
+            <div class="btn-group flex-shrink-0">
+                {% for state in statuses %}
+                    <button type="button"
+                            class="btn tap-target presence-state {{ status.value == state.value ? 'btn-' ~ state.tone : 'btn-outline-secondary' }}"
+                            data-status="{{ state.value }}" data-tone="{{ state.tone }}"
+                            aria-pressed="{{ status.value == state.value ? 'true' : 'false' }}"
+                            title="{{ state.label }}"
+                            aria-label="{{ state.label }} — {{ subject }}">
+                        <i class="bi {{ state.icon }}" aria-hidden="true"></i>
+                    </button>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="mt-2 presence-comment-panel{{ comment ? '' : ' d-none' }}">
+            {% include 'partials/form_field.html.twig' with {
+                field_id: 'presence-comment-' ~ row_id,
+                label: 'Commentaire — ' ~ subject,
+                label_visually_hidden: true,
+                type: 'textarea',
+                rows: 2,
+                size: 'sm',
+                value: comment,
+                maxlength: 500,
+                placeholder: 'Commentaire (visible du staff uniquement)',
+                wrapper_class: 'mb-0',
+                control_class_extra: 'presence-comment',
+            } only %}
+        </div>
+        <button type="button"
+                class="btn btn-link btn-sm p-0 mt-1 presence-comment-toggle{{ comment ? ' d-none' : '' }}">
+            <i class="bi bi-chat-left-text" aria-hidden="true"></i> Ajouter un commentaire
+        </button>
+    </div>
+</article>

--- a/modules/presences/views/sheet.html.twig
+++ b/modules/presences/views/sheet.html.twig
@@ -57,53 +57,26 @@
         <div class="d-flex flex-column gap-2" id="presences-lines">
             {% for line in sheet.lines %}
                 {% set line_name = line.lastName|normalize_name ~ ', ' ~ line.firstName|normalize_name %}
-                <article class="card presence-line" data-member-id="{{ line.memberId }}"
-                         data-status="{{ line.status.value }}">
-                    <div class="card-body p-2">
-                        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-2">
-                            <p class="mb-0 flex-grow-1 text-truncate">
-                                <strong>{{ line.lastName|normalize_name }}</strong>, {{ line.firstName|normalize_name }}
-                                {%- if line.totem %} · <span class="text-body-secondary">{{ line.totem|normalize_totem }}</span>{% endif %}
-                            </p>
-                            {# Quatre cibles larges, toujours visibles : un
-                               menu déroulant demanderait deux gestes par
-                               animé, debout, pour vingt-cinq noms. #}
-                            <div class="btn-group flex-shrink-0">
-                                {% for status in statuses %}
-                                    <button type="button"
-                                            class="btn tap-target presence-state {{ line.status.value == status.value ? 'btn-' ~ status.tone : 'btn-outline-secondary' }}"
-                                            data-status="{{ status.value }}" data-tone="{{ status.tone }}"
-                                            aria-pressed="{{ line.status.value == status.value ? 'true' : 'false' }}"
-                                            title="{{ status.label }}"
-                                            aria-label="{{ status.label }} — {{ line_name }}">
-                                        <i class="bi {{ status.icon }}" aria-hidden="true"></i>
-                                    </button>
-                                {% endfor %}
-                            </div>
-                        </div>
-
-                        <div class="mt-2 presence-comment-panel{{ line.comment ? '' : ' d-none' }}">
-                            {% include 'partials/form_field.html.twig' with {
-                                field_id: 'presence-comment-' ~ line.memberId,
-                                label: 'Commentaire — ' ~ line_name,
-                                label_visually_hidden: true,
-                                type: 'textarea',
-                                rows: 2,
-                                size: 'sm',
-                                value: line.comment,
-                                maxlength: 500,
-                                placeholder: 'Commentaire (visible du staff uniquement)',
-                                wrapper_class: 'mb-0',
-                                control_class_extra: 'presence-comment',
-                                data: { 'member-id': line.memberId },
-                            } only %}
-                        </div>
-                        <button type="button"
-                                class="btn btn-link btn-sm p-0 mt-1 presence-comment-toggle{{ line.comment ? ' d-none' : '' }}">
-                            <i class="bi bi-chat-left-text" aria-hidden="true"></i> Ajouter un commentaire
-                        </button>
-                    </div>
-                </article>
+                {# La ligne elle-même est partagée avec la page d'un animé
+                   (@presences/partials/_presence_line.html.twig) : mêmes
+                   boutons, même commentaire, même enregistrement. #}
+                {% embed '@presences/partials/_presence_line.html.twig' with {
+                    row_id: line.memberId,
+                    member_id: line.memberId,
+                    endpoint: '/chefs/presences/feuille/' ~ sheet.eventId ~ '/enregistrer',
+                    status: line.status,
+                    statuses: statuses,
+                    comment: line.comment,
+                    subject: line_name,
+                    line: line,
+                } only %}
+                    {% block heading %}
+                        <p class="mb-0 text-truncate">
+                            <strong>{{ line.lastName|normalize_name }}</strong>, {{ line.firstName|normalize_name }}
+                            {%- if line.totem %} · <span class="text-body-secondary">{{ line.totem|normalize_totem }}</span>{% endif %}
+                        </p>
+                    {% endblock %}
+                {% endembed %}
             {% endfor %}
         </div>
 
@@ -113,16 +86,9 @@
             « Non renseigné » se vide à mesure qu'on la traite. Les commentaires ne sont visibles que
             du staff de la section, jamais de la famille.
         </p>
-
-        <script type="application/json" id="presences-sheet-data">
-            {{ {
-                endpoint: '/chefs/presences/feuille/' ~ sheet.eventId ~ '/enregistrer',
-                total: sheet.total(),
-            }|json_encode|raw }}
-        </script>
     {% endif %}
 {% endblock %}
 
 {% block scripts %}
-    <script src="{{ asset('/assets/js/presences-sheet.js') }}" defer nonce="{{ csp_nonce }}"></script>
+    <script src="{{ asset('/assets/js/presences-lines.js') }}" defer nonce="{{ csp_nonce }}"></script>
 {% endblock %}

--- a/public/assets/js/presences-lines.js
+++ b/public/assets/js/presences-lines.js
@@ -215,7 +215,16 @@
         return api.postJson(endpoint, { member_id: Number(line.dataset.memberId || 0), ...payload })
             .then(function (res) {
                 if (res.data?.success) {
-                    markStale();
+                    // Only a STATE can move the figures the page drew: the
+                    // rate and the monthly graph are computed from statuses
+                    // alone (PresenceAnimeService::months(), and
+                    // PresenceStatus::countsAsAttending() under it), so a
+                    // comment saved on its own leaves them true. Saying
+                    // otherwise would be a false statement, in a live
+                    // region, about the one thing the notice exists to say.
+                    if (payload.status !== undefined) {
+                        markStale();
+                    }
                     return true;
                 }
 

--- a/public/assets/js/presences-lines.js
+++ b/public/assets/js/presences-lines.js
@@ -156,18 +156,32 @@
      * template: `//ailleurs.example` is a URL to another host, not a path
      * on this one. Checked here, at the sink, rather than at each caller.
      *
-     * **The backslash is not paranoia.** WHATWG's URL parser treats `\`
-     * exactly like `/` after a special scheme, so `/\ailleurs.example/x`
-     * reaches the same host as `//ailleurs.example/x` — a leading-`//`
-     * test alone has a spec-documented bypass for the one class of value
-     * this guard exists to catch. Rejecting the character outright costs
-     * nothing: no path this site serves contains one.
+     * **Spelling out the shapes that escape is a losing game, so this asks
+     * the parser instead.** `//host`, `/\host` (WHATWG reads `\` as `/`
+     * after a special scheme) and `/<TAB>/host` (tab, LF and CR are
+     * stripped BEFORE parsing) all resolve to another origin while looking
+     * like a path; a test written character by character closes the three
+     * that somebody thought of. Resolving the value through the very
+     * parser `fetch()` will use, and comparing the origin it lands on,
+     * closes the class — every normalisation the parser performs is
+     * performed here first, by definition.
      *
      * @param {string} url
      * @returns {boolean}
      */
     function isOwnPath(url) {
-        return url.startsWith('/') && !url.startsWith('//') && !url.includes('\\');
+        // A path, not an absolute URL — same-origin or not, this endpoint
+        // is written by a template as a path, and anything else is a
+        // misconfiguration worth refusing.
+        if (!url.startsWith('/')) {
+            return false;
+        }
+
+        try {
+            return new URL(url, document.baseURI).origin === window.location.origin;
+        } catch (error) {
+            return false;
+        }
     }
 
     /**

--- a/public/assets/js/presences-lines.js
+++ b/public/assets/js/presences-lines.js
@@ -3,16 +3,28 @@
  * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
  */
 
-// The attendance sheet (modules/presences/views/sheet.html.twig).
+// The presence rows, on both screens that carry them: an evening's sheet
+// (modules/presences/views/sheet.html.twig, one row per animé) and an
+// animé's own page (views/anime.html.twig, one row per date). The markup
+// is literally the same partial, so the behaviour is one file rather than
+// two that drift.
 //
-// This screen is filled in standing up, in a local, at the start of a
-// meeting — which is what decides everything below. Four visible targets
-// per animé rather than a select (a select is two gestures per name, fifty
+// The sheet is what decides everything below, because it is filled in
+// standing up, in a local, at the start of a meeting. Four visible targets
+// per row rather than a select (a select is two gestures per name, fifty
 // for twenty-five names, in the noise); every tap saved on the spot rather
 // than a « Enregistrer » button at the foot of a list somebody would
 // forget one time in three; and the four counters double as the filter,
 // because the real loop is « point as they arrive, then tap Non renseigné
-// and deal with what is left ».
+// and deal with what is left ». The counters are the sheet's alone — an
+// animé's page has no filter to offer and simply does not draw them, which
+// is why everything about them is optional here.
+//
+// **Each row carries its own endpoint**, rather than the page carrying
+// one: a sheet writes every row to the evening it is, an animé's page
+// writes each row to the evening THAT date is — the same endpoint that
+// date's own sheet writes to, so there is one write path and one
+// authorization check for both screens.
 //
 // A save that fails is never silent and never leaves the screen claiming
 // something the server does not have: the button goes back to the state
@@ -24,10 +36,9 @@
     var api = window.ScoutMagicApi;
 
     var container = /** @type {HTMLElement|null} */ (document.getElementById('presences-lines'));
-    var data = api ? api.pageData('presences-sheet-data') : null;
 
     // A no-op on every other page of the site.
-    if (!container || !data?.endpoint) {
+    if (!container || !api) {
         return;
     }
 
@@ -39,22 +50,27 @@
     var filterBar = /** @type {HTMLElement|null} */ (document.getElementById('presences-filter-bar'));
     var filterSummary = /** @type {HTMLElement|null} */ (document.getElementById('presences-filter-summary'));
     var clearFilter = /** @type {HTMLElement|null} */ (document.getElementById('presences-clear-filter'));
+    // An animé's page draws its rate, its monthly slope and its counters
+    // server-side, and nothing here recomputes them — so a page whose rows
+    // have moved says so rather than going on showing a figure that is no
+    // longer true. Absent from the sheet, which has no such figures.
+    var staleNotice = /** @type {HTMLElement|null} */ (document.getElementById('presences-stale'));
 
     /** @type {string|null} the status currently filtered on, null for « tout » */
     var activeFilter = null;
 
     /**
-     * @returns {HTMLElement[]} one element per animé on the sheet
+     * @returns {HTMLElement[]} one element per row on the page
      */
     function lines() {
         return Array.prototype.slice.call(container.querySelectorAll('.presence-line'));
     }
 
     /**
-     * Paint one line's four buttons for the state it is now in. The
-     * chosen one is filled with its own colour; the other three are
-     * outlines — a fill is what can be read on a phone held at arm's
-     * length, where a border cannot.
+     * Paint one row's four buttons for the state it is now in. The chosen
+     * one is filled with its own colour; the other three are outlines — a
+     * fill is what can be read on a phone held at arm's length, where a
+     * border cannot.
      *
      * @param {HTMLElement} line
      * @param {string} status
@@ -134,19 +150,51 @@
     }
 
     /**
+     * Only a path of this very site is ever posted to. The endpoint is
+     * read off the row rather than written into this file, and a value
+     * read from the DOM is not trusted for having been rendered by our own
+     * template: `//ailleurs.example` is a URL to another host, not a path
+     * on this one. Checked here, at the sink, rather than at each caller.
+     *
+     * @param {string} url
+     * @returns {boolean}
+     */
+    function isOwnPath(url) {
+        return url.startsWith('/') && !url.startsWith('//');
+    }
+
+    /**
+     * Say that the page's server-computed figures no longer match its
+     * rows. A no-op on a screen that has none.
+     */
+    function markStale() {
+        if (staleNotice) {
+            staleNotice.classList.remove('d-none');
+        }
+    }
+
+    /**
      * One save. Resolves to whether the server recorded it — the caller
      * is what puts the screen back when it did not.
      *
-     * @param {string} memberId
+     * @param {HTMLElement} line the row being saved, which carries both
+     *        the animé and the evening the write belongs to
      * @param {Record<string, any>} payload `status` XOR `comment`: two
      *        animateurs pointing the same list must not have one's tap
      *        erase the other's comment.
      * @returns {Promise<boolean>}
      */
-    function save(memberId, payload) {
-        return api.postJson(data.endpoint, { member_id: Number(memberId), ...payload })
+    function save(line, payload) {
+        var endpoint = line.dataset.endpoint || '';
+        if (!isOwnPath(endpoint)) {
+            window.ScoutMagicToast.show('Erreur lors de l\'enregistrement.', { variant: 'error' });
+            return Promise.resolve(false);
+        }
+
+        return api.postJson(endpoint, { member_id: Number(line.dataset.memberId || 0), ...payload })
             .then(function (res) {
                 if (res.data?.success) {
+                    markStale();
                     return true;
                 }
 
@@ -184,7 +232,7 @@
             paintLine(line, chosen);
             applyFilter();
 
-            save(line.dataset.memberId || '', { status: chosen }).then(function (recorded) {
+            save(line, { status: chosen }).then(function (recorded) {
                 if (!recorded) {
                     paintLine(line, previous);
                     applyFilter();
@@ -217,11 +265,21 @@
     // an animateur who taps the next name without leaving the field must
     // not lose what they just typed.
     //
-    // The debounce is PER ANIMÉ, not per page: one shared timer would let
-    // a comment typed on the second name cancel the pending save of the
-    // first, and nothing on screen would say the first was lost.
+    // The debounce is PER ROW, not per page: one shared timer would let a
+    // comment typed on the second row cancel the pending save of the
+    // first, and nothing on screen would say the first was lost. The key
+    // is the row's own id rather than the animé's, because every row of an
+    // animé's page is the same animé on a different date.
     /** @type {Record<string, number>} */
     var pendingComments = {};
+
+    /**
+     * @param {HTMLTextAreaElement} field
+     * @returns {HTMLElement|null} the row the comment belongs to
+     */
+    function rowOf(field) {
+        return /** @type {HTMLElement|null} */ (field.closest('.presence-line'));
+    }
 
     /**
      * Is this field still holding the text the page loaded, or the text
@@ -260,14 +318,14 @@
      * @returns {Promise<boolean>|undefined}
      */
     function saveComment(field) {
-        var memberId = field.dataset.memberId || '';
-        if (isUnchanged(field)) {
+        var row = rowOf(field);
+        if (!row || isUnchanged(field)) {
             return undefined;
         }
 
         var sent = field.value;
 
-        return save(memberId, { comment: sent }).then(function (recorded) {
+        return save(row, { comment: sent }).then(function (recorded) {
             if (recorded) {
                 field.dataset.savedComment = sent;
             }
@@ -277,12 +335,22 @@
 
     /**
      * @param {HTMLTextAreaElement} field
+     * @returns {string} what keys this field's pending save
+     */
+    function debounceKeyOf(field) {
+        var row = rowOf(field);
+
+        return row ? (row.dataset.rowId || row.dataset.memberId || '') : '';
+    }
+
+    /**
+     * @param {HTMLTextAreaElement} field
      */
     function scheduleCommentSave(field) {
-        var memberId = field.dataset.memberId || '';
-        clearTimeout(pendingComments[memberId]);
-        pendingComments[memberId] = setTimeout(function () {
-            delete pendingComments[memberId];
+        var key = debounceKeyOf(field);
+        clearTimeout(pendingComments[key]);
+        pendingComments[key] = setTimeout(function () {
+            delete pendingComments[key];
             saveComment(field);
         }, COMMENT_DEBOUNCE_MS);
     }
@@ -311,9 +379,9 @@
             return;
         }
 
-        var memberId = field.dataset.memberId || '';
-        clearTimeout(pendingComments[memberId]);
-        delete pendingComments[memberId];
+        var key = debounceKeyOf(field);
+        clearTimeout(pendingComments[key]);
+        delete pendingComments[key];
         saveComment(field);
     }, true);
 

--- a/public/assets/js/presences-lines.js
+++ b/public/assets/js/presences-lines.js
@@ -156,11 +156,18 @@
      * template: `//ailleurs.example` is a URL to another host, not a path
      * on this one. Checked here, at the sink, rather than at each caller.
      *
+     * **The backslash is not paranoia.** WHATWG's URL parser treats `\`
+     * exactly like `/` after a special scheme, so `/\ailleurs.example/x`
+     * reaches the same host as `//ailleurs.example/x` — a leading-`//`
+     * test alone has a spec-documented bypass for the one class of value
+     * this guard exists to catch. Rejecting the character outright costs
+     * nothing: no path this site serves contains one.
+     *
      * @param {string} url
      * @returns {boolean}
      */
     function isOwnPath(url) {
-        return url.startsWith('/') && !url.startsWith('//');
+        return url.startsWith('/') && !url.startsWith('//') && !url.includes('\\');
     }
 
     /**

--- a/tests/Modules/Presences/Controller/PresencesControllerTest.php
+++ b/tests/Modules/Presences/Controller/PresencesControllerTest.php
@@ -344,6 +344,84 @@ class PresencesControllerTest extends TestCase
         );
     }
 
+    /**
+     * The animé's page is not a read-only report: « je veux aussi être
+     * capable de changer ses présences par date et mettre un commentaire ».
+     * The controls are the sheet's own partial, so what is asserted here is
+     * that the page draws them at all — the four states, the comment field,
+     * and the endpoint each date writes to.
+     */
+    public function testAnAnimesPageIsEditableDateByDate(): void
+    {
+        $this->signIn('akela@test.be', 'chief');
+
+        $body = $this->handle(new Request(
+            'GET', '/chefs/presences/anime/' . $this->animeA, [], [], [], []
+        ))->getBody();
+
+        $this->assertStringContainsString('class="card presence-line"', $body);
+        // The date still names its evening and still leads to its sheet:
+        // the row's heading is the one thing the two screens do not share,
+        // so it is the one thing an embed can silently drop.
+        $this->assertStringContainsString('Réunion', $body);
+        $this->assertStringContainsString('/chefs/presences/feuille/' . $this->eventA . '"', $body);
+        $this->assertStringContainsString('presence-state', $body);
+        $this->assertStringContainsString('presence-comment', $body);
+        $this->assertStringContainsString('Ajouter un commentaire', $body);
+        foreach (['Présent', 'Excusé', 'Absent', 'Non renseigné'] as $label) {
+            $this->assertStringContainsString($label, $body);
+        }
+    }
+
+    /**
+     * The one that ties the page to the write path: the endpoint the page
+     * puts on a date is READ BACK OUT OF THE PAGE and posted to, so a
+     * template that starts writing somewhere else fails here rather than
+     * in a browser. Both screens share `record()` on purpose — one write
+     * path, one authorization check.
+     */
+    public function testADateChangedOnAnAnimesPageIsRecordedThroughTheSheetsEndpoint(): void
+    {
+        $this->signIn('akela@test.be', 'chief');
+
+        $body = $this->handle(new Request(
+            'GET', '/chefs/presences/anime/' . $this->animeA, [], [], [], []
+        ))->getBody();
+        $this->assertSame(1, preg_match('/data-endpoint="([^"]+)"/', $body, $matches));
+        $this->assertSame('/chefs/presences/feuille/' . $this->eventA . '/enregistrer', $matches[1]);
+
+        $response = $this->handle($this->jsonPostTo($matches[1], [
+            'member_id' => $this->animeA,
+            'status' => 'excused',
+            '_csrf_token' => CsrfGuard::generateToken(),
+        ]));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame(
+            PresenceStatus::EXCUSED,
+            (new PresenceRepository($this->pdo, $this->encryption))->find($this->eventA, $this->animeA)?->status
+        );
+    }
+
+    /**
+     * What is already stored comes back INTO the controls rather than
+     * beside them, so a correction starts from what is there.
+     */
+    public function testAnAnimesPageOpensOnWhatWasAlreadyRecorded(): void
+    {
+        $this->signIn('akela@test.be', 'chief');
+        $repository = new PresenceRepository($this->pdo, $this->encryption);
+        $repository->saveStatus($this->eventA, $this->animeA, PresenceStatus::ABSENT, null);
+        $repository->saveComment($this->eventA, $this->animeA, 'Sa maman a prévenu.', null);
+
+        $body = $this->handle(new Request(
+            'GET', '/chefs/presences/anime/' . $this->animeA, [], [], [], []
+        ))->getBody();
+
+        $this->assertStringContainsString('data-status="absent"', $body);
+        $this->assertStringContainsString('Sa maman a prévenu.', $body);
+    }
+
     public function testAnAnimeOfAnotherSectionIsNotFound(): void
     {
         $this->signIn('akela@test.be', 'chief');
@@ -556,10 +634,19 @@ class PresencesControllerTest extends TestCase
      */
     private function jsonPost(int $eventId, array $payload): Request
     {
+        return $this->jsonPostTo('/chefs/presences/feuille/' . $eventId . '/enregistrer', $payload);
+    }
+
+    /**
+     * The same write, aimed at a path taken from somewhere else — a page
+     * that says where it writes, rather than a path this file spells.
+     *
+     * @param array<string, mixed> $payload
+     */
+    private function jsonPostTo(string $path, array $payload): Request
+    {
         $request = $this->getMockBuilder(Request::class)
-            ->setConstructorArgs([
-                'POST', '/chefs/presences/feuille/' . $eventId . '/enregistrer', [], [], [], [],
-            ])
+            ->setConstructorArgs(['POST', $path, [], [], [], []])
             ->onlyMethods(['getRawBody'])
             ->getMock();
         $request->method('getRawBody')->willReturn((string) json_encode($payload));

--- a/tests/js/presences-lines.test.js
+++ b/tests/js/presences-lines.test.js
@@ -68,7 +68,7 @@ const SHEET = `
 
 // One animé, three dates: the member id repeats and the endpoint does not.
 const ANIME = `
-    <div class="alert d-none" id="presences-stale"></div>
+    <output class="alert d-none" id="presences-stale"></output>
     <div id="presences-lines">
         ${line({ rowId: '31', memberId: '12', endpoint: '/chefs/presences/feuille/31/enregistrer', status: 'present' })}
         ${line({ rowId: '32', memberId: '12', endpoint: '/chefs/presences/feuille/32/enregistrer', status: 'unset' })}

--- a/tests/js/presences-lines.test.js
+++ b/tests/js/presences-lines.test.js
@@ -496,11 +496,18 @@ describe('presences-lines.js', () => {
     });
 
     describe('the endpoint a row carries', () => {
-        it('is never posted to when it is not a path of this site', async () => {
-            // Read off the DOM, so it is validated at the sink rather than
-            // trusted for having been rendered by our own template.
+        // Read off the DOM, so it is validated at the sink rather than
+        // trusted for having been rendered by our own template. The
+        // backslash form is the one a leading-`//` test alone lets
+        // through: WHATWG's URL parser reads `/\\hôte/x` as the same
+        // cross-origin destination as `//hôte/x`.
+        it.each([
+            ['a protocol-relative URL', '//ailleurs.example/vol'],
+            ['a backslash the URL parser reads as a second slash', '/\\ailleurs.example/vol'],
+            ['an absolute URL', 'https://ailleurs.example/vol'],
+        ])('is never posted to when it is %s', async (_label, endpoint) => {
             document.body.innerHTML = `<div id="presences-lines">${line({
-                rowId: '41', memberId: '12', endpoint: '//ailleurs.example/vol', status: 'unset',
+                rowId: '41', memberId: '12', endpoint, status: 'unset',
             })}</div>`;
             await boot();
 

--- a/tests/js/presences-lines.test.js
+++ b/tests/js/presences-lines.test.js
@@ -457,6 +457,21 @@ describe('presences-lines.js', () => {
             expect(notice.classList.contains('d-none')).toBe(false);
         });
 
+        it('leaves the notice alone when only a comment was saved', async () => {
+            // The rate and the monthly graph are computed from states
+            // alone, so a comment changes nothing about them — and the
+            // notice is a live region, where a false claim is announced.
+            await boot();
+
+            const field = row('33').querySelector('.presence-comment');
+            field.value = 'Prévenu jeudi.';
+            field.dispatchEvent(new Event('focusout', { bubbles: true }));
+            await flush();
+
+            expect(lastRequest().body.comment).toBe('Prévenu jeudi.');
+            expect(document.getElementById('presences-stale').classList.contains('d-none')).toBe(true);
+        });
+
         it('leaves the notice alone when the server refused the change', async () => {
             global.fetch = vi.fn(() => jsonResponse({ success: false, error: 'Pas la vôtre.' }, 403));
             await boot();

--- a/tests/js/presences-lines.test.js
+++ b/tests/js/presences-lines.test.js
@@ -1,12 +1,16 @@
 // Isolated JavaScript unit test — jsdom-simulated DOM only. No PHP
 // server, no MySQL, no real network: fetch is mocked, and so is the
 // site-wide toast toolbox. Exercises the REAL implementation in
-// public/assets/js/presences-sheet.js (imported below, never
+// public/assets/js/presences-lines.js (imported below, never
 // reimplemented here). That file is an IIFE reading the DOM at import
 // time, so each test builds its fixture first and then imports it via
 // vi.resetModules() + await import().
 //
-// The fixture mirrors modules/presences/views/sheet.html.twig.
+// Two fixtures, because the file drives two screens off the same partial:
+// SHEET mirrors modules/presences/views/sheet.html.twig (one row per
+// animé, four counters that filter) and ANIME mirrors views/anime.html.twig
+// (one row per date, the same animé throughout, no counters at all, and a
+// notice saying the figures above have gone stale).
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const STATUSES = [
@@ -24,58 +28,73 @@ function tile([status, tone]) {
         </button>`;
 }
 
-function line(memberId, status, comment = null) {
+// The shared row, exactly as @presences/partials/_presence_line.html.twig
+// renders it: its own endpoint, its own row id, and the animé it writes.
+function line({ rowId, memberId, endpoint, status, comment = null }) {
     const buttons = STATUSES.map(([value, tone]) => `
         <button type="button" data-status="${value}" data-tone="${tone}"
                 class="btn presence-state ${value === status ? 'btn-' + tone : 'btn-outline-secondary'}"
                 aria-pressed="${value === status}"></button>`).join('');
 
     return `
-        <article class="card presence-line" data-member-id="${memberId}" data-status="${status}">
+        <article class="card presence-line" data-row-id="${rowId}" data-member-id="${memberId}"
+                 data-endpoint="${endpoint}" data-status="${status}">
             <div class="card-body">
                 ${buttons}
                 <div class="presence-comment-panel${comment ? '' : ' d-none'}">
-                    <textarea class="presence-comment" data-member-id="${memberId}">${comment ?? ''}</textarea>
+                    <textarea class="presence-comment">${comment ?? ''}</textarea>
                 </div>
                 <button type="button" class="presence-comment-toggle${comment ? ' d-none' : ''}"></button>
             </div>
         </article>`;
 }
 
-const PAGE = `
+const SHEET_ENDPOINT = '/chefs/presences/feuille/7/enregistrer';
+
+function sheetLine(memberId, status, comment = null) {
+    return line({ rowId: memberId, memberId, endpoint: SHEET_ENDPOINT, status, comment });
+}
+
+const SHEET = `
     <div id="presences-counters">${STATUSES.map(tile).join('')}</div>
     <p class="d-none" id="presences-filter-bar">
         <button type="button" id="presences-clear-filter"><span id="presences-filter-summary"></span></button>
     </p>
     <div id="presences-lines">
-        ${line('11', 'present')}
-        ${line('12', 'unset')}
-        ${line('13', 'unset', 'Malade.')}
-    </div>
-    <script type="application/json" id="presences-sheet-data">
-        {"endpoint": "/chefs/presences/feuille/7/enregistrer", "total": 3}
-    </script>`;
+        ${sheetLine('11', 'present')}
+        ${sheetLine('12', 'unset')}
+        ${sheetLine('13', 'unset', 'Malade.')}
+    </div>`;
+
+// One animé, three dates: the member id repeats and the endpoint does not.
+const ANIME = `
+    <div class="alert d-none" id="presences-stale"></div>
+    <div id="presences-lines">
+        ${line({ rowId: '31', memberId: '12', endpoint: '/chefs/presences/feuille/31/enregistrer', status: 'present' })}
+        ${line({ rowId: '32', memberId: '12', endpoint: '/chefs/presences/feuille/32/enregistrer', status: 'unset' })}
+        ${line({ rowId: '33', memberId: '12', endpoint: '/chefs/presences/feuille/33/enregistrer', status: 'absent', comment: 'Malade.' })}
+    </div>`;
 
 function jsonResponse(body, status = 200) {
     return Promise.resolve({ ok: status < 400, status, json: () => Promise.resolve(body) });
 }
 
-describe('presences-sheet.js', () => {
+describe('presences-lines.js', () => {
     beforeEach(() => {
         vi.resetModules();
         vi.useRealTimers();
         document.head.innerHTML = '<meta name="csrf-token" content="tok-123">';
-        document.body.innerHTML = PAGE;
+        document.body.innerHTML = SHEET;
         global.fetch = vi.fn(() => jsonResponse({ success: true }));
         window.ScoutMagicToast = { show: vi.fn() };
     });
 
     async function boot() {
         await import('../../public/assets/js/api.js');
-        await import('../../public/assets/js/presences-sheet.js');
+        await import('../../public/assets/js/presences-lines.js');
     }
 
-    const row = (id) => document.querySelector(`.presence-line[data-member-id="${id}"]`);
+    const row = (id) => document.querySelector(`.presence-line[data-row-id="${id}"]`);
     const stateButton = (id, status) => row(id).querySelector(`.presence-state[data-status="${status}"]`);
     const tileFor = (status) => document.querySelector(`.presence-filter[data-status="${status}"]`);
     const countOf = (status) => tileFor(status).querySelector('.presence-filter-count').textContent;
@@ -86,7 +105,7 @@ describe('presences-sheet.js', () => {
     const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
     describe('entry guard', () => {
-        it('does nothing at all on a page with no sheet', async () => {
+        it('does nothing at all on a page with no presence rows', async () => {
             document.body.innerHTML = '<p>Une autre page</p>';
             await expect(boot()).resolves.not.toThrow();
             expect(fetch).not.toHaveBeenCalled();
@@ -341,7 +360,7 @@ describe('presences-sheet.js', () => {
             expect(fetch).not.toHaveBeenCalled();
         });
 
-        it('debounces typing per animé, so one comment never cancels another', async () => {
+        it('debounces typing per row, so one comment never cancels another', async () => {
             vi.useFakeTimers();
             await boot();
 
@@ -380,6 +399,120 @@ describe('presences-sheet.js', () => {
             await vi.runAllTimersAsync();
 
             expect(fetch).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // The animé's page: the same rows, one per date, with no counters to
+    // recount and no filter to apply. Everything the sheet does with them
+    // has to keep working with none of that on the page.
+    describe("on an animé's page", () => {
+        beforeEach(() => {
+            document.body.innerHTML = ANIME;
+        });
+
+        it('writes each date to its own evening, with the animé of the page', async () => {
+            await boot();
+
+            stateButton('32', 'present').click();
+            await flush();
+
+            expect(lastRequest().url).toBe('/chefs/presences/feuille/32/enregistrer');
+            expect(lastRequest().body).toEqual({
+                member_id: 12,
+                status: 'present',
+                _csrf_token: 'tok-123',
+            });
+        });
+
+        it('paints the tapped date without a counter to lean on', async () => {
+            await boot();
+
+            stateButton('32', 'excused').click();
+            await flush();
+
+            expect(row('32').dataset.status).toBe('excused');
+            expect(stateButton('32', 'excused').classList.contains('btn-warning')).toBe(true);
+            expect(row('31').dataset.status).toBe('present');
+        });
+
+        it('puts a refused date back, exactly as a sheet does', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ success: false, error: 'Pas la vôtre.' }, 403));
+            await boot();
+
+            stateButton('32', 'absent').click();
+            await flush();
+
+            expect(row('32').dataset.status).toBe('unset');
+            expect(window.ScoutMagicToast.show).toHaveBeenCalledWith('Pas la vôtre.', { variant: 'error' });
+        });
+
+        it('says the rates above have stopped matching the rows, once something moves', async () => {
+            await boot();
+            const notice = document.getElementById('presences-stale');
+            expect(notice.classList.contains('d-none')).toBe(true);
+
+            stateButton('32', 'present').click();
+            await flush();
+
+            expect(notice.classList.contains('d-none')).toBe(false);
+        });
+
+        it('leaves the notice alone when the server refused the change', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ success: false, error: 'Pas la vôtre.' }, 403));
+            await boot();
+
+            stateButton('32', 'present').click();
+            await flush();
+
+            expect(document.getElementById('presences-stale').classList.contains('d-none')).toBe(true);
+        });
+
+        it('debounces one comment per DATE, not per animé', async () => {
+            // Every row here carries the same member id, so a debounce
+            // keyed on it would have the second date cancel the first
+            // date's pending save — and nothing on screen would say the
+            // first was lost.
+            vi.useFakeTimers();
+            await boot();
+
+            const first = row('33').querySelector('.presence-comment');
+            first.value = 'Malade depuis mardi.';
+            first.dispatchEvent(new Event('input', { bubbles: true }));
+
+            row('32').querySelector('.presence-comment-toggle').click();
+            const second = row('32').querySelector('.presence-comment');
+            second.value = 'Rentre plus tôt.';
+            second.dispatchEvent(new Event('input', { bubbles: true }));
+
+            vi.advanceTimersByTime(1000);
+            await vi.runAllTimersAsync();
+
+            const sent = fetch.mock.calls.map(([url, opts]) => [url, JSON.parse(opts.body).comment]);
+            expect(sent).toEqual([
+                ['/chefs/presences/feuille/33/enregistrer', 'Malade depuis mardi.'],
+                ['/chefs/presences/feuille/32/enregistrer', 'Rentre plus tôt.'],
+            ]);
+        });
+    });
+
+    describe('the endpoint a row carries', () => {
+        it('is never posted to when it is not a path of this site', async () => {
+            // Read off the DOM, so it is validated at the sink rather than
+            // trusted for having been rendered by our own template.
+            document.body.innerHTML = `<div id="presences-lines">${line({
+                rowId: '41', memberId: '12', endpoint: '//ailleurs.example/vol', status: 'unset',
+            })}</div>`;
+            await boot();
+
+            stateButton('41', 'present').click();
+            await flush();
+
+            expect(fetch).not.toHaveBeenCalled();
+            expect(row('41').dataset.status).toBe('unset');
+            expect(window.ScoutMagicToast.show).toHaveBeenCalledWith(
+                expect.stringContaining('Erreur'),
+                { variant: 'error' }
+            );
         });
     });
 });

--- a/tests/js/presences-lines.test.js
+++ b/tests/js/presences-lines.test.js
@@ -497,13 +497,17 @@ describe('presences-lines.js', () => {
 
     describe('the endpoint a row carries', () => {
         // Read off the DOM, so it is validated at the sink rather than
-        // trusted for having been rendered by our own template. The
-        // backslash form is the one a leading-`//` test alone lets
-        // through: WHATWG's URL parser reads `/\\hôte/x` as the same
-        // cross-origin destination as `//hôte/x`.
+        // trusted for having been rendered by our own template. Every
+        // form below LOOKS like a path and resolves to another origin:
+        // WHATWG's parser reads `\\` as a second slash, and strips tab,
+        // LF and CR before parsing at all. They are the reason the guard
+        // resolves the value instead of spelling out characters.
         it.each([
             ['a protocol-relative URL', '//ailleurs.example/vol'],
             ['a backslash the URL parser reads as a second slash', '/\\ailleurs.example/vol'],
+            ['a tab the URL parser strips before parsing', '/\t/ailleurs.example/vol'],
+            ['a newline the URL parser strips before parsing', '/\n/ailleurs.example/vol'],
+            ['a carriage return the URL parser strips before parsing', '/\r/ailleurs.example/vol'],
             ['an absolute URL', 'https://ailleurs.example/vol'],
         ])('is never posted to when it is %s', async (_label, endpoint) => {
             document.body.innerHTML = `<div id="presences-lines">${line({


### PR DESCRIPTION
## Description

La page d'un animé (`/chefs/presences/anime/{memberId}`) était un rapport : l'historique montrait une pastille d'état et le commentaire, et corriger l'un ou l'autre voulait dire ouvrir la feuille de la soirée. Elle porte maintenant, sur chaque date, les contrôles de la feuille — les quatre états et le commentaire — avec le même enregistrement immédiat. On corrige donc là où on s'aperçoit de l'erreur, ce qui est en général au téléphone avec un parent.

**La ligne est un seul partial** (`@presences/partials/_presence_line.html.twig`) que les deux écrans embarquent via `{% embed %}`, plutôt qu'une seconde copie écrite à la main : mêmes boutons, même champ commentaire, même enregistrement, et rien qui puisse diverger. Seul l'en-tête de ligne diffère — un nom et un totem sur la feuille, une date et le nom de la soirée sur la page de l'animé, qui reste un lien vers la feuille complète.

**Aucun nouvel endpoint d'écriture, donc aucune seconde surface d'autorisation.** Chaque ligne porte son propre endpoint : la feuille écrit toutes ses lignes sur la soirée qu'elle est, la page de l'animé écrit chaque date sur la soirée que cette date est — le même endpoint que la feuille de cette date. `PresencesController::record()` re-dérive la section de l'évènement et l'appartenance de l'animé à cette section à chaque appel, quel que soit l'écran d'origine ; rien de ce que la page soumet n'est cru.

Ce qui devait changer avec :

- `presences-sheet.js` devient `presences-lines.js` : il pilote les deux écrans, ses compteurs et sa barre de filtre sont optionnels (la page d'un animé n'en dessine aucun), il lit l'endpoint sur la ligne plutôt que dans un bloc de données de page, et il **valide cet endpoint au sink** — une valeur lue dans le DOM n'est pas sûre parce qu'elle vient de notre propre template.
- Le debounce du commentaire est keyé sur **la ligne**, plus sur l'animé : toutes les lignes d'une page d'animé portent le même `member_id`, et un minuteur keyé dessus laisserait la deuxième date annuler la sauvegarde en attente de la première — sans que rien à l'écran ne dise que la première est perdue.
- Les taux et le graphique du haut de page sont calculés côté serveur et rien ne les recalcule sous les doigts : un bandeau discret apparaît dès qu'une correction les a rendus faux, plutôt que de laisser lire un chiffre périmé.

Retire aussi le paragraphe de la page Présences qui expliquait les trois chemins vers une feuille : le sujet d'aide `presences-registre` les documente déjà, et une page qui doit expliquer sa propre navigation est un écran de trop.

Sujet d'aide `presences-anime` mis à jour (une question de plus, la section « L'historique, et les corrections »), version du module 1.5.0 → 1.6.0.

### Tests

- Trois tests de contrôleur : la page dessine bien les contrôles et son en-tête de ligne, ce qui est déjà enregistré revient **dans** les contrôles, et l'endpoint que la page imprime est relu depuis le HTML puis posté — un template qui se mettrait à écrire ailleurs échoue ici plutôt que dans un navigateur.
- La suite Vitest gagne une fixture « page d'un animé » : endpoints par date, debounce par ligne, bandeau de péremption (posé sur un succès, pas sur un refus), et une ligne dont l'endpoint n'est pas un chemin de ce site.

### Note sur CodeQL

`ci.yml` ne se déclenche pas sur un push de branche, donc le scan n'avait rien vu avant cette PR ; il tourne ici. Le diff a été relu pour les sinks en attendant : aucun `innerHTML`/`href`/`src`/`window.open`, et la seule valeur lue du DOM utilisée comme URL est validée avant le `fetch`.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 16 031 tests, verts)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally (2 022 tests, verts ; `npm run typecheck` sans nouveau finding)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JxW2HfbfeuAFuJrC4gQBDW

---
_Generated by [Claude Code](https://claude.ai/code/session_01JxW2HfbfeuAFuJrC4gQBDW)_