### PR TITLE
Fixer le backlog, c'est une PR par bloc d'issues — et une instruction décidée se fusionne tout de suite

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -146,7 +146,13 @@ exits non-zero when it could not say so — a comment the API refused, a
 state it could not read back. That red run is on the merge commit rather
 than on the pull request, and it means an issue is fixed and does not say
 so. Finish that one by hand: comment, then close as `completed`, per
-AGENTS.md § Fix the backlog, step 6.
+AGENTS.md § Fix the backlog, its closing step — named rather than
+numbered, because the numbering has already drifted once under it.
+
+Watch it after **each** block's merge rather than only after the last. The
+backlog is fixed one block of issues per pull request now (same section,
+§ Fix the backlog, step 4), so there is no single merge at which every
+issue is meant to close.
 
 The flags are not decoration — each is a failure the shorter command
 cannot show you:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -545,6 +545,28 @@ of them. See § "Fix the backlog" above, which also says not to come back
 for a second confirmation of it. Everything below still applies to each of
 those pull requests unchanged.
 
+**A change to these instructions themselves carries the same standing
+authorization**, granted on 2026-09-08: « une fois que tu as fait le
+changement dans les instructions, tu peux le fusionner et le pousser sur
+main immédiatement, pas besoin d'attendre ma permission ». It covers
+`AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` and `.claude/skills/**` — the
+files that tell the next agent what to do — when the maintainer asked for
+the change. The reason is the same one that makes those files exist: a
+rule agreed in a conversation and left unmerged is a rule the next session
+never sees, so the gap between "we decided this" and "it is on `main`" is
+the whole risk. Asking again to close a gap the maintainer just asked you
+to close is how a decided rule stays undecided.
+
+It authorises the *merge*, nothing else. It is not permission to rewrite
+these files on your own initiative, and a rule you thought of yourself is
+a proposal to the maintainer, never a commit to `main`. Every requirement
+below still holds on such a pull request without exception — green checks,
+answered threads, an honest checklist — and so does the test discipline:
+a rule worth writing into `AGENTS.md` is worth an assertion in
+`tests/Architecture/` pinning it against the edit that would undo it,
+in the manner of `AutoMergeRuleIsWrittenDownTest` and
+`BacklogIsCutIntoBlocksTest`.
+
 With it, arm **auto-merge** rather than watching the pull request:
 
 ```shell

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -431,18 +431,62 @@ backlog » — and it is a standing instruction, not a one-off. It means:
    you, a criterion the code cannot satisfy as written. Do not ask for
    permission to start, and do not save a question for later — see the rule
    at the bottom of this section.
-4. **Fix them** — every one of them, under the rules in this file: a test
+4. **Cut the work into blocks, and one block is one pull request.** This
+   comes straight after the questions and before the first line of code.
+   A block is a set of accepted issues that belong together: the same
+   subject, or the same files. Group them so a reviewer can hold one pull
+   request in their head, and so that its title is a sentence rather than
+   a list — "if I cannot say what this changes in one sentence, it is two
+   blocks" is the test. Say what the blocks are before you start, in the
+   same message as your questions if you have them, so the maintainer sees
+   the shape of the work rather than discovering it at the end.
+
+   **Ceiling: no more than 10 issues and about 50 changed files in one
+   pull request.** Split a theme that outgrows it by sub-theme rather than
+   arbitrarily. The number is not a style preference. On #257 — 40 issues,
+   185 files, 7 000 lines — `Claude review` was cancelled twice on its own
+   timeout with the reviewer still working, and because that check is
+   REQUIRED on `main` the pull request was simply unmergeable; the
+   reviewer's ceiling is 60 minutes now, but a diff nobody can read in an
+   hour is a diff nobody reads. The same size produced the other two
+   defects of that day: a silent semantic conflict with `main` (both sides
+   had fixed the same issue, differently, and `git merge` reported
+   nothing), and a test-harness leak that only showed up under load. All
+   three are size, not content. The measured point of comparison is #217:
+   25 files, reviewed end to end in 10 min 47 s, sixteen agents, five real
+   findings.
+
+5. **Run the blocks, in parallel where they do not touch each other.**
+   Blocks whose files are disjoint may be in flight at once — each on its
+   own branch off `main`, each merged as it goes green, no waiting on a
+   sibling. Blocks that touch the same files are **serialised**: the later
+   one branches from `main` *after* the earlier has merged. Overlapping
+   branches are exactly how the same file gets fixed twice, differently,
+   and merged without a conflict marker.
+
+   Land the block others build on first, and after **each** merge bring
+   `main` into every branch still open, then re-run the checks locally on
+   the merged state — `vendor/bin/phpstan analyse` above all, which is
+   what catches a semantic conflict that compiles on each side and not
+   together. « Require branches up to date » is deliberately off on this
+   repository (docs/quality-pipeline.md § Branch ruleset), so nothing does
+   this for you.
+
+6. **Fix them** — every one of them, under the rules in this file: a test
    alongside each fix, `vendor/bin/phpstan analyse` before committing PHP,
    `npm run typecheck` before committing `public/assets/js/`, French
-   interface and English code.
-5. **Open a pull request and merge it.** The instruction to fix the backlog
-   IS the authorization to merge that § Merging a pull request requires —
-   it is the maintainer saying "do the work and land it", and coming back
-   to ask again is not diligence. Everything that section requires *before*
-   arming auto-merge still holds without exception: every check green on
-   the current head, every review thread answered, the template's checklist
-   honestly filled.
-6. **Name each issue in the pull request body with `Corrige #158`** — that
+   interface and English code. Reproduce the CI job rather than its
+   neighbour: `npm run test:coverage`, which is what `javascript-tests`
+   runs, and not `npm test`, which passes over failures it would catch.
+7. **Open each block's pull request and merge it.** The instruction to fix
+   the backlog IS the authorization to merge that § Merging a pull request
+   requires — for every pull request in the set, not for one of them. It
+   is the maintainer saying "do the work and land it", and coming back to
+   ask again is not diligence. Everything that section requires *before*
+   arming auto-merge still holds without exception, on each: every check
+   green on the current head, every review thread answered, the template's
+   checklist honestly filled.
+8. **Name each issue in the pull request body with `Corrige #158`** — that
    word, one line per issue, when the PR is opened rather than afterwards.
    `Corrige` is deliberately **not** one of GitHub's closing keywords
    (`Closes`, `Fixes`, `Resolves` and their inflections): a keyword makes
@@ -455,7 +499,7 @@ backlog » — and it is a standing instruction, not a one-off. It means:
    on the issue's timeline, and the workflow's comment names the pull
    request and the merge commit outright. **Do not "fix" a body by putting
    a closing keyword back** — that is the bug, not the convention.
-7. **Close the issue once the fix is on `main`.** `issue-fixed-comment.yml`
+9. **Close the issue once the fix is on `main`.** `issue-fixed-comment.yml`
    does it on merge: one comment per issue naming the pull request, the
    commit and the branch, and *then* the closure as `completed`. An issue
    it could not comment on is left open on purpose and the run goes red.
@@ -463,12 +507,16 @@ backlog » — and it is a standing instruction, not a one-off. It means:
    hand any it left open (comment first, then `state_reason: completed` —
    the fix shipped). An accepted issue whose fix is merged and which is
    still open is the backlog lying about itself; one closed with nothing
-   written on it is the backlog being rude.
+   written on it is the backlog being rude. Verify per block, as each one
+   lands, rather than saving it all for the last merge.
 
 **Do not wait for the maintainer at any point of this**, once step 3 is
-behind you. Not to start, not to merge, not to close. The instruction covers the whole sequence — fix,
-open, merge to `main`, close the issue — and asking for a confirmation
-already given is how a backlog stays a backlog. Report what you did
+behind you. Not to start, not to cut the blocks, not to merge, not to
+close. The instruction covers the whole sequence — plan, fix,
+open, merge to `main`, close the issue — for every block, and asking for a
+confirmation already given is how a backlog stays a backlog. Announcing
+the blocks in step 4 is telling, not asking: you say what you are about to
+do and then do it, and you do not stop for an answer. Report what you did
 afterwards; do not ask for permission during. This overrides nothing in
 § Merging a pull request about what must be TRUE before you merge (every
 check green on the current head, every review thread answered, the
@@ -490,10 +538,12 @@ nothing substitutes for it — not a green pipeline, not this file, not your
 reading of what they would probably want. Without it, green and
 merge-ready is where your work stops and you say so.
 
-« Fixe le backlog » **is** that instruction, standing, for the pull request
-that fixes the accepted issues — see § "Fix the backlog" above, which also
-says not to come back for a second confirmation of it. Everything below
-still applies to that pull request unchanged.
+« Fixe le backlog » **is** that instruction, standing, for **every** pull
+request that fixes accepted issues — the work is cut into one pull request
+per block of issues, and the authorization covers the set, not the first
+of them. See § "Fix the backlog" above, which also says not to come back
+for a second confirmation of it. Everything below still applies to each of
+those pull requests unchanged.
 
 With it, arm **auto-merge** rather than watching the pull request:
 

--- a/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
+++ b/tests/Architecture/AutoMergeRuleIsWrittenDownTest.php
@@ -76,6 +76,43 @@ final class AutoMergeRuleIsWrittenDownTest extends TestCase
     }
 
     /**
+     * THE ONE STANDING EXCEPTION THAT IS ABOUT THIS FILE ITSELF.
+     *
+     * A rule agreed in a conversation and left unmerged is a rule the next
+     * session never sees — the gap between "we decided this" and "it is on
+     * `main`" is where an instruction dies, and asking a second time to
+     * close a gap the maintainer just asked you to close is how a decided
+     * rule stays undecided. So a change to the instruction files, when the
+     * maintainer asked for it, carries its own authorization to merge.
+     *
+     * Both halves are pinned, and the second is the one that matters. The
+     * grant is narrow on purpose: it authorises landing a change the
+     * maintainer asked for, never writing one you thought of yourself.
+     * Drop that sentence and what remains reads as a licence to rewrite
+     * the rules an agent is bound by and merge it unasked, which is the
+     * one shape this repository must never let a convenience take.
+     */
+    public function testAnInstructionChangeMayBeMergedWithoutAskingTwice(): void
+    {
+        $rules = self::agentRules();
+
+        $this->assertStringContainsString(
+            'A change to these instructions themselves carries the same standing',
+            $rules,
+            'AGENTS.md no longer says that a maintainer-requested change to the instruction files may '
+            . 'be merged without a second confirmation, so the next agent stops at green and waits — '
+            . 'and the rule that was agreed stays off `main`, where nothing reads it.'
+        );
+
+        $this->assertStringContainsString(
+            'It authorises the *merge*, nothing else.',
+            $rules,
+            'the sentence bounding that authorization is gone. Without it, a grant meant to let a '
+            . 'decided rule land reads as permission to rewrite the rules unasked and merge the result.'
+        );
+    }
+
+    /**
      * The command itself. "Enable auto-merge" without it sends the next
      * agent to the web UI, which is where the polling started.
      */

--- a/tests/Architecture/BacklogIsCutIntoBlocksTest.php
+++ b/tests/Architecture/BacklogIsCutIntoBlocksTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * « Fixe le backlog » once meant one pull request, and one pull request
+ * meant #257: 40 issues, 188 files, 7 000 lines.
+ *
+ * Every defect of that day came from the size rather than from any of the
+ * forty fixes.
+ *
+ * `Claude review` was cancelled at 20m20s and again at 20m21s with the
+ * reviewer still working. That check is REQUIRED on `main` and a cancelled
+ * required check is unmergeable, so a ceiling written to bound a runaway
+ * had become an undeclared size limit on pull requests — and it announced
+ * itself as a merge refusal rather than as anything about the reviewer.
+ * The ceiling is an hour now (see .github/workflows/claude-review.yml),
+ * which buys room and does not buy a reader: nobody reads 188 files well,
+ * neither an agent nor a person.
+ *
+ * Then `main` moved under the branch. Both sides had fixed issue #226 —
+ * one with a private method, one with a class — and `git merge` reported
+ * no conflict at all: it kept one side's call and the other side's file.
+ * Sixteen thousand tests were green on the branch before the merge and
+ * twelve of them failed after it. Only `phpstan` on the merge result saw
+ * it, and only in CI.
+ *
+ * And the composer's 500 ms debounce, harmless while it wrote to a
+ * detached node, became a `ReferenceError` the moment #234 made it read
+ * `document.cookie` first — 118 test files green, 2 047 tests green, exit
+ * code 1 on an unhandled error nobody can find from the summary.
+ *
+ * A smaller pull request would have been reviewed, would have merged
+ * before `main` moved, and would have shown each of these on its own
+ * rather than three at once at the end. So the instruction now cuts the
+ * work into blocks, and this file pins the three sentences that make that
+ * real: the ceiling, the parallel-vs-serialised rule, and the merge
+ * authorization covering every pull request in the set rather than the
+ * first one.
+ *
+ * Like Tests\Architecture\AutoMergeRuleIsWrittenDownTest, this proves only
+ * that the rule is still there to obey. No test can check that anybody
+ * obeyed it.
+ */
+final class BacklogIsCutIntoBlocksTest extends TestCase
+{
+    private static function agentRules(): string
+    {
+        $path = dirname(__DIR__, 2) . '/AGENTS.md';
+        $contents = file_get_contents($path);
+
+        self::assertIsString($contents, 'AGENTS.md is unreadable');
+
+        return $contents;
+    }
+
+    /**
+     * The floor. Everything below reads one section, and a test reading a
+     * section that has been renamed passes vacuously.
+     */
+    public function testTheBacklogInstructionStillHasItsOwnSection(): void
+    {
+        $this->assertStringContainsString(
+            '## "Fix the backlog" — what that instruction asks for, exactly',
+            self::agentRules(),
+            'AGENTS.md no longer says what « fixe le backlog » asks for, so none of the rules below are '
+            . 'anywhere an agent would read them.',
+        );
+    }
+
+    /**
+     * THE STEP ITSELF. Without it the next agent does what the last one
+     * did, which is open one pull request and put everything in it.
+     */
+    public function testTheWorkIsCutIntoBlocksBeforeAnyCodeIsWritten(): void
+    {
+        $rules = self::agentRules();
+
+        $this->assertStringContainsString(
+            'Cut the work into blocks, and one block is one pull request',
+            $rules,
+            'the step that splits the backlog into several pull requests is gone from AGENTS.md',
+        );
+    }
+
+    /**
+     * The number. "Keep pull requests small" is advice nobody can be held
+     * to; a ceiling is a thing you can be over.
+     */
+    public function testTheCeilingIsANumberRatherThanAnAdjective(): void
+    {
+        $rules = self::agentRules();
+
+        $this->assertStringContainsString(
+            'no more than 10 issues and about 50 changed files in one',
+            $rules,
+            'the size ceiling on a backlog pull request is no longer stated as a number, so nothing '
+            . 'distinguishes a pull request that is too big from one that merely feels big.',
+        );
+    }
+
+    /**
+     * The half that is easy to drop, because it costs wall-clock time and
+     * buys something invisible. Overlapping branches are how the same
+     * issue gets fixed twice and merged without a conflict marker.
+     */
+    public function testBlocksTouchingTheSameFilesAreSerialised(): void
+    {
+        $rules = self::agentRules();
+
+        $this->assertStringContainsString(
+            'Blocks that touch the same files are **serialised**',
+            $rules,
+            'AGENTS.md no longer says that overlapping blocks wait for each other, which is the rule '
+            . 'that stops a second branch from fixing an issue the first one already fixed differently.',
+        );
+
+        $this->assertStringContainsString(
+            'bring
+   `main` into every branch still open, then re-run the checks locally on
+   the merged state',
+            $rules,
+            'AGENTS.md no longer says to merge `main` back into the branches still open after each '
+            . 'block lands. Nothing else does it: « require branches up to date » is deliberately off '
+            . 'on this repository, so a branch can be green against a base that no longer exists.',
+        );
+    }
+
+    /**
+     * The authorization. § Merging a pull request grants it per pull
+     * request, so cutting one pull request into six without saying so
+     * would leave five of them unauthorised — and an agent obeying this
+     * file to the letter would stop after the first.
+     */
+    public function testTheMergeAuthorizationCoversEveryBlockRatherThanTheFirst(): void
+    {
+        $rules = self::agentRules();
+
+        $this->assertStringContainsString(
+            '**is** that instruction, standing, for **every** pull',
+            $rules,
+            '§ Merging a pull request no longer says that « fixe le backlog » authorises every pull '
+            . 'request in the set. Cut into blocks and read literally, that leaves every block after '
+            . 'the first waiting for an authorization the maintainer has already given.',
+        );
+    }
+
+    /**
+     * Announcing the blocks is not a question, and the one moment a
+     * question is welcome is step 3. Without this sentence the new step 4
+     * reads like a second checkpoint, which is the thing the whole section
+     * exists to prevent.
+     */
+    public function testAnnouncingTheBlocksIsNotAnotherPlaceToStopAndWait(): void
+    {
+        $rules = self::agentRules();
+
+        $this->assertStringContainsString(
+            'Announcing
+the blocks in step 4 is telling, not asking',
+            $rules,
+            'AGENTS.md no longer says that naming the blocks is not a request for approval, so the '
+            . 'step added to make the work smaller reads as one more place to wait for the maintainer.',
+        );
+    }
+}


### PR DESCRIPTION
## Description

Deux changements d'instructions, tous deux demandés par le mainteneur aujourd'hui, tous deux tirés de ce que #257 a coûté.

### Une pull request par bloc d'issues

« Fixe le backlog » voulait dire une seule pull request, et une seule pull request a voulu dire **#257 : 40 issues, 188 fichiers, 7 000 lignes**. Aucun des quarante correctifs n'était en cause — les trois défauts de cette journée viennent tous de la taille :

- `Claude review` annulé à **20m20s** puis à **20m21s**, le relecteur encore au travail. Ce contrôle est requis sur `main` et un contrôle requis annulé rend la PR non fusionnable : un plafond écrit pour borner un emballement était devenu une limite de taille que personne n'avait déclarée. Il est à une heure maintenant, ce qui achète de la marge et n'achète pas un lecteur.
- Puis `main` a bougé sous la branche. Les deux côtés avaient corrigé `#226`, l'un avec une méthode privée, l'autre avec une classe, et **`git merge` n'a signalé aucun conflit** : il a gardé le site d'appel d'un côté et le fichier de l'autre. Seize mille tests verts avant la fusion, douze en échec après. Seul `phpstan` sur le résultat de la fusion l'a vu, et seulement en CI.
- Et le debounce de 500 ms du composeur, inoffensif tant qu'il écrivait dans un nœud détaché, est devenu un `ReferenceError` dès que `#234` lui a fait lire `document.cookie` en premier : 2 047 tests verts, sortie 1 sur une erreur non rattrapée illisible depuis le résumé.

Une PR plus petite aurait été relue, aurait fusionné avant que `main` ne bouge, et aurait montré chacun de ces défauts séparément.

L'instruction découpe donc désormais le travail en **blocs**, entre le tour de questions et la première ligne de code :

- un bloc = une pull request, **plafond de 10 issues et d'environ 50 fichiers modifiés** — chiffre ancré sur du mesuré, #217 ayant été relue de bout en bout en 10 min 47 s sur 25 fichiers ;
- **parallèle** quand les fichiers sont disjoints, chaque bloc sur sa branche depuis `main` ; **sérialisé** quand ils se recouvrent, ce qui est très exactement ce qui a produit le conflit silencieux ;
- après **chaque** fusion, ramener `main` dans les branches encore ouvertes et rejouer les contrôles sur l'état fusionné, `phpstan` en premier. Rien ne le fait à votre place : « require branches up to date » est volontairement désactivé.

Deux garde-fous explicites : annoncer les blocs est **dire, pas demander** — l'étape 3 reste le seul moment où une question est bienvenue — et l'autorisation de fusion couvre désormais **l'ensemble** des PR et non la première, sans quoi un agent lisant le fichier à la lettre s'arrêterait après le bloc 1.

### Une instruction décidée se fusionne immédiatement

Même forme que « fixe le backlog », et même raison : ces fichiers existent parce qu'une décision prise en conversation ne survit pas à la session. L'écart entre « on a décidé ça » et « c'est sur `main` » est tout le risque.

L'autorisation couvre `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` et `.claude/skills/**`, **quand le mainteneur a demandé le changement**. Elle est bornée dans la phrase suivante, et c'est la moitié qui compte : elle autorise la **fusion**, rien d'autre — pas de réécriture de ces fichiers de sa propre initiative ; une règle qu'on a pensée soi-même est une proposition au mainteneur, jamais un commit sur `main`.

### Ce qui épingle tout ça

`tests/Architecture/BacklogIsCutIntoBlocksTest` (nouveau, 6 tests) et deux assertions ajoutées à `AutoMergeRuleIsWrittenDownTest`, chacune contre l'édition unique qui l'annulerait. Vérifié par mutation : reformuler la phrase qui borne l'autorisation fait rougir le test.

`.claude/skills/steward/SKILL.md` désignait l'étape de clôture par son numéro, qui avait déjà dérivé ; elle est nommée maintenant, et le skill dit de surveiller `issue-fixed-comment.yml` après **chaque** fusion de bloc plutôt qu'une seule fois à la fin.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 16 194 tests, 58 359 assertions, aucun échec)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: sans objet, aucun fichier sous `public/assets/js/` n'est touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uh734xxU83JP5HmGEmYnp5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uh734xxU83JP5HmGEmYnp5)_