### PR TITLE
Un refus est rouge sauf s'il a été décidé — et « décidé » s'écrit là où le verdict le lit

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,6 +17,64 @@ name: Claude review
 # `permissions:` block silently inherits the repository default.
 permissions: {}
 
+# THE REFUSALS THIS FILE HAS DECIDED, in the one place both a reader and
+# the verdict below can see. Everything named here is a tool this workflow
+# refuses ON PURPOSE, so a refusal of it is the allowlist working rather
+# than a gap in it; every other refusal is a tool this file forgot, and
+# `Claude review status` goes red for it.
+#
+# THAT DISTINCTION USED TO LIVE IN A COMMENT THE `jq` COULD NOT READ. The
+# count of "refusals that matter" excluded the single literal `Bash`, and
+# the reason each other tool was refused was written in prose beside it —
+# so every tool decided after `Bash` was decided in a place the verdict
+# never looked. It went red on three reviews that had done their work, in
+# three pull requests, over three different tools (issue #261): `Bash` on
+# #224, `Write` on #260, `WebFetch` on #259. Three in a row is a series,
+# not a coincidence: the real rule is "a refusal is red unless it was
+# decided", and "decided" had nowhere to be written down that counted.
+# It is written here now, and the `jq` reads this list.
+#
+# WHY EACH ONE IS ON IT:
+#
+#   Bash            granted command by command instead of whole, so that
+#                   the interpreters stay out. A refused shell line is
+#                   that grant doing its job — see `claude_args` below.
+#   Write           refused, and NOT granted, which is the choice #261
+#                   left open. The run that settled it is 34260813534:
+#                   two `Write` calls, both a throwaway script to check
+#                   string literals against a file, and both part of a
+#                   run of twenty-three refusals that also included
+#                   `python3`, a heredoc, a shell loop and a pipe.
+#                   Granting `Write` would have cleared two of those
+#                   twenty-three and left the review red at the next
+#                   loop: the reviewer did not need to write, it needed
+#                   to run code, and that is the thing this job will not
+#                   grant while it holds a subscription token.
+#   WebFetch        refused, and the reasoning that makes `Write` cheap
+#                   does NOT carry over. A file in a throwaway workspace
+#                   is inert; an outbound request to a URL the agent
+#                   chose, from a job holding CLAUDE_CODE_OAUTH_TOKEN and
+#                   `id-token: write` while reading an untrusted diff, is
+#                   an exfiltration channel under exactly the threat that
+#                   keeps `python3 -c` denied below.
+#   ScheduleWakeup  refused because it cannot work here and asking for it
+#                   is the symptom of issue #262. It schedules a later
+#                   turn, which is a thing a resumable session has;
+#                   a workflow run is one-shot, so a reviewer that
+#                   schedules a wake-up instead of waiting for its agents
+#                   ends the run on the spot, in `success`, with agents
+#                   still reading. It appeared in the tool list of every
+#                   truncated run of 2026-09-08 and in neither of the
+#                   complete ones.
+#
+# Adding a name here is deciding that a refusal of it is acceptable, so
+# write the reason next to it. Tests\Architecture\ClaudeReviewIsVerifiableTest
+# pins the list against the edit that would empty it, and pins that the
+# prompt below tells the reviewer the same thing this list tells the
+# verdict — a tool refused silently costs turns nobody gets back.
+env:
+  DELIBERATE_DENIALS: "Bash,Write,WebFetch,ScheduleWakeup"
+
 on:
   pull_request:
     # `opened` catches a pull request created ready for review;
@@ -292,6 +350,15 @@ jobs:
           # instead: the workspace IS the repository, so `-C` was never
           # needed.
           #
+          # WHAT STAYS DENIED IS DECLARED AT THE TOP OF THIS FILE, in
+          # `DELIBERATE_DENIALS`, with the reason for each written next to
+          # it — `Write`, `WebFetch` and `ScheduleWakeup` among them. That
+          # list is not decoration: the verdict job reads it, so a tool
+          # named there is a refusal the check accepts and a tool missing
+          # from it is a red build. The paragraphs below are the older half
+          # of the same decision, kept because they are what the `Bash`
+          # entry means in practice.
+          #
           # THE INTERPRETERS AND THE LOOPS STAY DENIED, and this is the
           # "say in this file why it must stay denied" branch that the
           # steward skill offers next to "grant it". `python3 -c` and
@@ -361,7 +428,7 @@ jobs:
           # itself whatever the model did.
           claude_args: >-
             --allowedTools "Skill,Task,Agent,Read,Glob,Grep,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git fetch:*),Bash(grep:*),Bash(ls:*),Bash(find:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(head:*),Bash(tail:*),Bash(cat:*),Bash(echo:*),Bash(printf:*),Bash(jq:*),mcp__github_inline_comment__create_inline_comment"
-            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one. Wait for every subagent you launch — pass run_in_background false — and never end a turn waiting for one: this is a one-shot non-interactive run and nothing will wake it up, so a background agent still working when you stop is a part of the diff nobody read. The workspace is already a full clone checked out for this pull request, so the commits under review are there to read: run git from it plainly, without -C and a path, which is not granted. Counting and cross-checking the repository is part of reviewing it, and Grep, Glob and Read are granted whole for that; python3 -c, php -r and shell loops are not granted and will not be, so reach for the read-only commands instead of spending turns rediscovering that."
+            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one. Wait for every subagent you launch — pass run_in_background false — and never end a turn waiting for one: this is a one-shot non-interactive run and nothing will wake it up, so a background agent still working when you stop is a part of the diff nobody read. For the same reason ScheduleWakeup is not granted and cannot help you: there is no later turn to schedule, and a run that reaches for it ends immediately with its agents still reading. If you find yourself with work outstanding and nothing to do but wait, block on the agents themselves rather than ending the turn. The workspace is already a full clone checked out for this pull request, so the commits under review are there to read: run git from it plainly, without -C and a path, which is not granted. Counting and cross-checking the repository is part of reviewing it, and Grep, Glob and Read are granted whole for that; python3 -c, php -r, shell loops, pipes and redirections are not granted and will not be, so reach for the read-only commands instead of spending turns rediscovering that. Write, WebFetch and ScheduleWakeup are refused on purpose too — checking a literal against a file is what Grep and Read are for, one call per question, and no answer you need is outside this checkout."
 
       # WHAT THE RUN ACTUALLY DID, read off the transcript the SDK wrote.
       #
@@ -467,7 +534,8 @@ jobs:
           # reader that cannot read a transcript must say so, never take
           # every merge down with it.
           if ! jq -r '
-            ([.[] | select(.type == "result")] | last) as $r
+            ($deliberate | split(",") | map(select(. != ""))) as $decided
+            | ([.[] | select(.type == "result")] | last) as $r
             | [ .[]
                 | select(.type == "assistant")
                 | .message.content[]?
@@ -485,7 +553,7 @@ jobs:
                 "turns=" + (($r.num_turns // -1) | tostring),
                 "denials=" + ((if ($r | has("permission_denials")) then (($r.permission_denials // []) | length) else -1 end) | tostring),
                 "denied_tools=" + ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed")] | unique | join(", ") | flat),
-                "denials_other=" + ((if ($r | has("permission_denials")) then ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed") | select(. != "Bash")] | length) else -1 end) | tostring),
+                "denials_other=" + ((if ($r | has("permission_denials")) then ([$r.permission_denials[]? | (.tool_name // .toolName // .name // "unnamed") | . as $tool | select(($decided | index($tool)) | not)] | length) else -1 end) | tostring),
                 "agent_calls=" + ($agents | tostring),
                 "subagents_spawned=" + ($sub.spawned | tally | tostring),
                 "subagents_completed=" + ($sub.completed | tally | tostring),
@@ -493,7 +561,7 @@ jobs:
                 "models=" + ((($r.modelUsage // {}) | keys | join(", ")) | flat),
                 "cost=" + (($r.total_cost_usd // 0) | tostring)
               ] | .[]
-          ' "${EXECUTION_FILE}" | cut -c 1-400 > evidence.env; then
+          ' --arg deliberate "${DELIBERATE_DENIALS:-}" "${EXECUTION_FILE}" | cut -c 1-400 > evidence.env; then
             unknown "The execution file did not read as this step expects."
             exit 0
           fi
@@ -627,10 +695,11 @@ jobs:
           TURNS: ${{ needs.review.outputs.turns }}
           DENIALS: ${{ needs.review.outputs.denials }}
           DENIED_TOOLS: ${{ needs.review.outputs.denied_tools }}
-          # Refusals of a tool OTHER than `Bash`. `Bash` is the one entry
-          # granted in part on purpose, so a refused command is a normal
-          # outcome of exploring; every other tool is granted whole, and a
-          # refusal of one is a gap in this file.
+          # Refusals of a tool this file did NOT decide to refuse — the
+          # count the evidence step takes against `DELIBERATE_DENIALS` at
+          # the top of this workflow, which is where each decided refusal
+          # is named and its reason written. A refusal on that list is the
+          # allowlist working; a refusal off it is a tool this file forgot.
           DENIALS_OTHER: ${{ needs.review.outputs.denials_other }}
           AGENT_CALLS: ${{ needs.review.outputs.agent_calls }}
           # How many review agents the run started, and how many it
@@ -687,16 +756,21 @@ jobs:
             # no tool while doing it.
             verdict="**Unverified.** The transcript did not carry what this check reads — refused tool calls, agents launched — so it cannot say whether a review happened. That is a defect in the reader, not a verdict on the diff: the shape of the run's own record has changed under it."
           elif [[ "${DENIALS_OTHER}" != "0" ]]; then
-            # NOT `DENIALS`. Every tool on the allowlist is granted whole
-            # except `Bash`, which is granted command by command on
-            # purpose — so a refused `Bash` line is the allowlist working,
-            # while a refusal of anything else is a tool this file forgot.
+            # NOT `DENIALS`, and not a single hard-coded tool name either.
+            # The refusals this file has DECIDED are listed in
+            # `DELIBERATE_DENIALS` at the top of the workflow, with the
+            # reason for each written beside it; a refusal on that list is
+            # the allowlist working, and only a refusal off it is a tool
+            # this file forgot.
+            #
             # That distinction is what #217 cost: a review that launched
             # 16 agents, finished all 16, spent 6.46 USD and posted five
             # findings was called "not a review" over 19 exploratory shell
-            # one-liners it then did without. `Skill` on #208 was the
-            # opposite case and stays red here.
-            verdict="**A tool was refused, so this is not a review.** The agent asked for \`${DENIED_TOOLS:-a tool this run did not name}\` and this workflow had not granted it, so it worked around the gap or gave up — either way it reached its conclusion without something it judged it needed. Every tool here but \`Bash\` is granted whole, so this is a gap: grant it in \`claude_args\` or say in this file why it must stay denied."
+            # one-liners it then did without. Naming ONLY `Bash` then cost
+            # the same thing three more times, on three more tools, in
+            # three more pull requests — issue #261. `Skill` on #208 is
+            # the case that must stay red, and does: it is not on the list.
+            verdict="**A tool was refused, so this is not a review.** The agent asked for \`${DENIED_TOOLS:-a tool this run did not name}\` and this workflow had not granted it, so it worked around the gap or gave up — either way it reached its conclusion without something it judged it needed. The refusals this file has decided are \`${DELIBERATE_DENIALS:-none}\`, and this is not one of them: grant it in \`claude_args\`, or add it to that list with the reason written next to it."
           elif [[ "${AGENT_CALLS}" == "0" ]]; then
             verdict="**The review agents never ran.** Every step of the code-review command launches a subagent, and this run launched none, so nothing read the diff for bugs. The run log carries the full transcript; start at the first tool call."
           elif [[ "${SUBAGENTS_SPAWNED}" == "-1" || "${SUBAGENTS_COMPLETED}" == "-1" ]]; then
@@ -717,7 +791,7 @@ jobs:
             # spawned, two collected, no comment posted).
             verdict="**The review stopped part-way through.** ${SUBAGENTS_SPAWNED} review agents were launched and ${SUBAGENTS_COMPLETED} finished, so at least one was still reading when the run ended — and whatever it would have found is not on this pull request. Read the run log from the last agent launched."
           else
-            verdict="**Reviewed, nothing to report.** ${AGENT_CALLS} review agents ran over ${TURNS} turns and all of them finished, with no tool refused that this workflow grants whole. Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran. Refused \`Bash\` commands, counted in the row below, are the allowlist doing its job — see \`claude_args\` for what stays denied and why."
+            verdict="**Reviewed, nothing to report.** ${AGENT_CALLS} review agents ran over ${TURNS} turns and all of them finished, with no tool refused that this workflow grants whole. Findings, when there are any, arrive as inline comments on the diff rather than here; this comment is only the proof that the reviewer ran. Refused calls to \`${DELIBERATE_DENIALS:-Bash}\`, counted in the row below, are the allowlist doing its job — see \`DELIBERATE_DENIALS\` at the top of this workflow for what stays denied and why."
             unreviewed=0
           fi
 
@@ -755,9 +829,11 @@ jobs:
           fi
 
           # The total, then which tools, then how many of them were NOT
-          # `Bash` — because that last number is the one the verdict turns
-          # on, and a row showing only "19" invites the reading that just
-          # cost a real review its green.
+          # among the decided refusals — because that last number is the
+          # one the verdict turns on, and a row showing only "19" invites
+          # the reading that just cost a real review its green. The cell
+          # names the list rather than describing it, so a reader can see
+          # what was decided without opening the workflow.
           denials_cell="${DENIALS:--}"
           if [[ "${denials_cell}" == "-1" ]]; then
             denials_cell="unknown"
@@ -766,11 +842,11 @@ jobs:
             denials_cell="${denials_cell} (${DENIED_TOOLS})"
           fi
           if [[ "${DENIALS_OTHER}" == "-1" ]]; then
-            denials_cell="${denials_cell} — outside \`Bash\`: unknown"
+            denials_cell="${denials_cell} — outside the decided refusals: unknown"
           elif [[ "${DENIALS_OTHER}" == "0" ]]; then
-            denials_cell="${denials_cell} — none outside \`Bash\`"
+            denials_cell="${denials_cell} — none outside \`${DELIBERATE_DENIALS:-none}\`"
           else
-            denials_cell="${denials_cell} — ${DENIALS_OTHER} outside \`Bash\`"
+            denials_cell="${denials_cell} — ${DENIALS_OTHER} outside \`${DELIBERATE_DENIALS:-none}\`"
           fi
 
           cost_cell="${COST:--}"

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -523,9 +523,11 @@ generalises:
   many review agents were launched, how many of them finished, and how many
   tool calls were refused: facts about the run, not estimates of it, and
   none needs a threshold. A refusal is disqualifying when it falls outside
-  `Bash` — the one entry granted command by command rather than whole, so
-  that a refused shell line is the allowlist working and a refusal of
-  anything else is a gap.
+  the refusals this workflow has **decided** — declared once, in
+  `DELIBERATE_DENIALS` at the top of the file, so that a refused call the
+  allowlist meant to refuse is the allowlist working and a refusal of
+  anything else is a gap. See below for why that is a declared list rather
+  than one tool name.
   `tests/Architecture/ClaudeReviewIsVerifiableTest` pins each of these
   against the single edit that would undo it.
 
@@ -545,6 +547,42 @@ does not control, and `pull-requests: read` bounds neither. That is the
 next to "grant it", and it is why the verdict counts refusals outside
 `Bash` rather than all of them: a check that cries wolf over its first real
 review is a check people learn to skip.
+
+**"A refusal is red unless it was decided" needed somewhere to write
+"decided".** The rule above shipped as a single literal — the count
+excluded `Bash` and nothing else — and every tool decided after it was
+decided in a comment the check could not read. So the check called three
+complete reviews "not a review", in three pull requests, over three
+different tools: `Bash` on #224 (fixed by #254), `Write` on #260,
+`WebFetch` on #259. That is a series rather than a coincidence, and
+naming a fourth tool in the `jq` would only have added a term to it
+(issue #261). The decided refusals are now one list at the top of the
+workflow, read by the `jq` that counts and named in the comment that
+reports, with the reason for each written beside it. `Write` and
+`WebFetch` are on it as refusals rather than grants: the run that settled
+it (34260813534) was refused `Write` twice, both times for a throwaway
+script to check string literals against a file, inside a run of
+twenty-three refusals that also included `python3`, a heredoc, a loop and
+a pipe — granting `Write` would have cleared two of twenty-three and left
+the review red at the next loop. The reviewer did not need to write; it
+needed to run code, which is the one thing this job will not grant. And
+`WebFetch` does not inherit `Write`'s cheapness at all: a file in a
+throwaway workspace is inert, while an outbound request to a URL the
+agent chose, from a job holding `CLAUDE_CODE_OAUTH_TOKEN` and
+`id-token: write` past an untrusted diff, is an exfiltration channel.
+
+**The truncated reviews had a tell, and it was in the tool list.** On
+2026-09-08 the same commit was reviewed twice and stopped part-way both
+times — 7 agents launched, 3 collected, three minutes and two dollars
+against the 11 min 37 s and 8-of-8 of a complete pass on the same pull
+request. `ScheduleWakeup` appears in the tool list of every one of those
+runs and in neither of the two complete reviews of that day (issue #262).
+A reviewer that schedules a wake-up has ended its turn, and nothing wakes
+a workflow run up: the SDK closes it a success with four agents still
+reading, which is the #208 failure in a new spelling. It is refused now,
+declared on the same list, and the prompt says why — there is no later
+turn to schedule. The `spawned` against `completed` comparison remains
+the guard; this only stops the reviewer walking into it.
 
 **Then a working reviewer found the ceiling.** #217 took 10 min 47 s
 against a `timeout-minutes: 20` written when a review took a few minutes

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -77,6 +77,27 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
         return [$halves[0], $halves[1]];
     }
 
+    /**
+     * The refusals this file has decided, as the verdict reads them:
+     * from `DELIBERATE_DENIALS` itself, never from the prose beside it.
+     *
+     * @return list<string>
+     */
+    private static function deliberateDenials(): array
+    {
+        $matched = preg_match('/^env:\n  DELIBERATE_DENIALS: "([^"]*)"$/m', self::workflow(), $found);
+
+        self::assertSame(
+            1,
+            $matched,
+            'The workflow no longer declares `DELIBERATE_DENIALS` as a single top-level env string. That '
+            . 'declaration is the only place a refusal can be decided in a way the verdict reads, so '
+            . 'without it every decision goes back into a comment nothing checks.',
+        );
+
+        return array_values(array_filter(explode(',', $found[1]), static fn (string $t): bool => $t !== ''));
+    }
+
     private static function claudeArgs(): string
     {
         [$review] = self::jobs();
@@ -327,7 +348,11 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
         self::assertIsInt($opens, 'The evidence step no longer reads the transcript with jq.');
 
         $start = $opens + strlen("if ! jq -r '");
-        $closes = strpos($workflow, "' \"\${EXECUTION_FILE}\"", $start);
+        // The program ends where its arguments begin, and the first of
+        // those is the decided-refusal list — see
+        // testTheDecidedRefusalsAreReadByTheVerdictRatherThanOnlyByAReader,
+        // which is what fails first if that argument is dropped.
+        $closes = strpos($workflow, "' --arg deliberate", $start);
 
         self::assertIsInt($closes, 'The jq program is no longer closed where this test expects to find its end.');
 
@@ -368,8 +393,13 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
 
             $output = [];
             $status = 0;
+            // The real declaration, not a stand-in: a program run without
+            // the argument the workflow passes it is not the program the
+            // workflow runs.
             exec(
-                'jq -r -f ' . escapeshellarg($program) . ' ' . escapeshellarg($transcript) . ' 2>&1',
+                'jq -r -f ' . escapeshellarg($program)
+                . ' --arg deliberate ' . escapeshellarg(implode(',', self::deliberateDenials()))
+                . ' ' . escapeshellarg($transcript) . ' 2>&1',
                 $output,
                 $status,
             );
@@ -825,5 +855,138 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
             'The outputs are appended before jq has been shown to succeed, so a half-written extraction can '
             . 'still reach the status job.',
         );
+    }
+
+    /**
+     * A REFUSAL IS RED UNLESS IT WAS DECIDED, and "decided" needs
+     * somewhere to be written that the verdict actually reads.
+     *
+     * It did not have one. The refusal count excluded the single literal
+     * `Bash`, and every other tool's reason lived in a comment — so each
+     * tool decided after `Bash` was decided where the check could not see
+     * it, and the check called three working reviews "not a review" over
+     * three different tools in three pull requests: `Bash` on #224,
+     * `Write` on #260, `WebFetch` on #259 (issue #261). Three in a row is
+     * a series, and naming a fourth tool in the `jq` would only have
+     * added a term to it.
+     */
+    public function testTheDecidedRefusalsAreReadByTheVerdictRatherThanOnlyByAReader(): void
+    {
+        [$review] = self::jobs();
+
+        $this->assertNotEmpty(
+            self::deliberateDenials(),
+            'The list of decided refusals is empty, so every refusal counts as a gap — including the '
+            . '`Bash` lines the allowlist refuses on purpose, on every review.',
+        );
+
+        $this->assertStringContainsString(
+            '--arg deliberate "${DELIBERATE_DENIALS:-}"',
+            $review,
+            'The evidence step no longer passes the decided refusals to `jq`, so the count it publishes '
+            . 'is taken against something other than what this file declared.',
+        );
+
+        $this->assertStringContainsString(
+            '($deliberate | split(",")',
+            $review,
+            'The `jq` filter no longer reads the decided refusals as a list. A single hard-coded tool name '
+            . 'in its place is what issue #261 was: correct for one tool and one pull request at a time.',
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/select\(\. != "Bash"\)/',
+            $review,
+            'The refusal count is filtering on a hard-coded `Bash` again. Every tool decided after it '
+            . 'would be counted as a gap this file forgot, which is the defect, not the fix.',
+        );
+    }
+
+    /**
+     * `Write` AND `WebFetch` ARE REFUSED, NOT GRANTED, and that is a
+     * decision rather than an omission.
+     *
+     * Issue #261 left the choice open and run 34260813534 settled it: the
+     * two `Write` calls it was refused were both a throwaway script to
+     * check string literals against a file, in a run of twenty-three
+     * refusals that also included `python3`, a heredoc, a loop and a pipe.
+     * Granting `Write` would have cleared two of twenty-three and left the
+     * review red at the next loop — the reviewer did not need to write, it
+     * needed to run code, and that is the thing this job will not grant.
+     *
+     * `WebFetch` is not the same call at all: a file in a throwaway
+     * workspace is inert, an outbound request to a URL the agent chose,
+     * from a job holding CLAUDE_CODE_OAUTH_TOKEN and `id-token: write`
+     * while reading an untrusted diff, is an exfiltration channel.
+     */
+    public function testTheToolsThatStayRefusedAreNotQuietlyGrantedInstead(): void
+    {
+        $args = self::claudeArgs();
+        $decided = self::deliberateDenials();
+
+        foreach (['Write', 'WebFetch', 'ScheduleWakeup'] as $tool) {
+            $this->assertContains(
+                $tool,
+                $decided,
+                'The refusal of `' . $tool . '` is no longer declared, so the next review that asks for it '
+                . 'goes red as a gap in this file rather than as the decision it is.',
+            );
+        }
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/--allowedTools "[^"]*\bWebFetch\b/',
+            $args,
+            '`WebFetch` has been granted. This job holds the maintainer\'s subscription token and '
+            . '`id-token: write` while reading a diff anybody can write, and an outbound request to a URL '
+            . 'the agent chose is the one refusal in this file that cannot be traded for convenience.',
+        );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/--allowedTools "[^"]*\bScheduleWakeup\b/',
+            $args,
+            '`ScheduleWakeup` has been granted. A workflow run is one-shot: there is no later turn to '
+            . 'schedule, and a reviewer that reaches for one ends the run with its agents still reading.',
+        );
+    }
+
+    /**
+     * THE OTHER HALF OF ISSUE #262, and the cheap half. The guard that
+     * catches a truncated review is the launched-against-finished
+     * comparison above; this is what stops the reviewer reaching that
+     * guard in the first place.
+     *
+     * `ScheduleWakeup` appeared in the tool list of every truncated run of
+     * 2026-09-08 — 7 agents launched and 3 collected, twice on the same
+     * commit — and in neither of the two complete reviews of the same day.
+     * A reviewer that schedules a wake-up has ended its turn, and nothing
+     * wakes a workflow up: the SDK closes the run a success with four
+     * agents still reading. Telling it so costs a sentence.
+     */
+    public function testTheReviewerIsToldWhyItCannotScheduleAWakeUp(): void
+    {
+        $args = self::claudeArgs();
+
+        $this->assertStringContainsString(
+            'ScheduleWakeup is not granted and cannot help you',
+            $args,
+            'The prompt no longer tells the reviewer that scheduling a wake-up cannot work here. That is '
+            . 'what every truncated review of 2026-09-08 did instead of waiting for its agents.',
+        );
+
+        foreach (self::deliberateDenials() as $tool) {
+            if ($tool === 'Bash') {
+                // Granted command by command, and the prompt says which
+                // shapes are refused rather than naming the tool itself.
+                continue;
+            }
+
+            $this->assertStringContainsString(
+                $tool,
+                $args,
+                'The prompt never mentions `' . $tool . '`, which this workflow refuses on purpose. A '
+                . 'refusal the reviewer cannot anticipate costs it the turns it spends rediscovering it — '
+                . 'six tries at one question, on run 34260813534.',
+            );
+        }
     }
 }


### PR DESCRIPTION
## Description

Bloc 1 de « fixe le backlog » : les deux défauts du relecteur, qui vivent dans le même fichier.

Corrige #261
Corrige #262

### Le défaut commun

`Claude review status` comptait les refus en excluant **le seul littéral `Bash`**, et la raison de chaque autre refus vivait dans un commentaire que le `jq` ne lit pas. Tout outil tranché après `Bash` l'était donc à un endroit où le contrôle ne regardait pas. Résultat : trois revues **complètes** déclarées « pas une revue », dans trois pull requests, sur trois outils différents — `Bash` (#224, corrigé par #254), `Write` (#260), `WebFetch` (#259). Trois d'affilée est une série, et nommer un quatrième outil dans le `jq` n'aurait fait qu'y ajouter un terme.

La vraie règle est « un refus est rouge sauf s'il a été décidé ». Elle est appliquée telle quelle : les refus décidés sont une **liste unique**, `DELIBERATE_DENIALS`, déclarée en tête du workflow avec la raison de chacun écrite à côté, **lue par le `jq`** qui compte et **nommée dans le commentaire** qui rapporte. C'est l'option 1bis de #261.

### `Write` et `WebFetch` : refusés, pas accordés

Le premier geste que #261 réclamait avait été fait par le mainteneur (run [34260813534](https://github.com/xdubois-57/scoutmagic/actions/runs/34260813534)) et il tranche contre l'option 2 : les deux `Write` refusés visaient un script jetable vérifiant des littéraux dans un fichier, au sein de 23 refus qui comprenaient aussi `python3`, un heredoc, une boucle et un tube. Accorder `Write` aurait effacé 2 refus sur 23 et laissé la revue rouge à la boucle suivante — le relecteur n'avait pas besoin d'écrire, il avait besoin d'exécuter du code, et c'est ce que ce job n'accordera pas.

`WebFetch` n'hérite pas du raisonnement de `Write`, comme le ticket le souligne : un fichier dans un workspace jetable est inerte, une requête sortante vers une URL choisie par l'agent — depuis un job qui porte `CLAUDE_CODE_OAUTH_TOKEN` et `id-token: write` en lisant la seule entrée que le dépôt ne contrôle pas — est un canal d'exfiltration sous exactement la menace qui garde `python3 -c` refusé.

Une précision sur la recommandation ajoutée en commentaire de #261 : **`Bash(grep:*)` est déjà accordé** (ligne de l'allowlist, depuis #217). Les six tentatives du run 34260813534 n'ont pas buté sur `grep` mais sur la boucle et le tube qui l'entouraient. Le prompt nomme donc explicitement les formes refusées (boucles, tubes, redirections) plutôt que d'ajouter une entrée redondante.

### #262 : `ScheduleWakeup`

Il figure dans les outils de **chaque** revue tronquée du 2026-09-08 (7 lancés / 3 collectés, deux fois sur le même commit) et dans **aucune** des deux revues complètes du même jour. Un relecteur qui programme un réveil a terminé son tour, et rien ne réveille un run de workflow : le SDK ferme en succès avec quatre agents encore en lecture. Il rejoint la liste des refus décidés, et le prompt dit pourquoi — il n'y a pas de tour suivant à programmer.

C'est l'option 1 du ticket. L'option 3 (faire échouer le job `Claude review` lui-même) n'est **pas** prise ici, comme le ticket le demande : « à ne faire qu'après l'option 1, sinon chaque pull request se retrouve coincée ». La comparaison `spawned`/`completed` reste le garde-fou ; ce changement évite seulement d'y arriver.

### Ce que ce changement ne prouvera pas

Cette pull request modifie `.github/workflows/claude-review.yml`, donc l'action **refusera de tourner** et `Claude review` sortira vert sans avoir rien relu. C'est le prix connu, écrit dans l'en-tête du fichier et dans les deux tickets, et il vaut mieux le payer sur ce diff que sur un autre. `Claude review status` le dira explicitement (« Green without a review »). La vérification est le run suivant, sur une vraie pull request — celle du bloc 2.

### Vérification

`tests/Architecture/ClaudeReviewIsVerifiableTest` gagne trois assertions, chacune épinglant l'édition unique qui déferait ceci : que la liste est lue par le `jq` et non par un lecteur seul, qu'un `select(. != "Bash")` en dur n'y revient pas, que `WebFetch` et `ScheduleWakeup` ne sont pas discrètement accordés à la place, et que le prompt nomme chaque refus décidé. Le harnais existant qui exécute le filtre `jq` pour de vrai lui passe désormais la vraie déclaration.

`docs/quality-pipeline.md` § Code review est mis à jour dans le même changement (AGENTS.md § Pipeline documentation maintenance).

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`) — 16 237 tests, 0 échec
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, aucun fichier JS touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1

---
_Generated by [Claude Code](https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1)_