### PR TITLE
La fenêtre qui a demandé le lien magique cesse d'attendre quand c'est le même navigateur qui l'ouvre

### DIFF
--- a/core/Http/Controller/AuthController.php
+++ b/core/Http/Controller/AuthController.php
@@ -173,6 +173,10 @@ class AuthController extends AbstractController
      * anyway through its own poll, and it has now additionally proven
      * possession of the emailed token.
      *
+     * That case is also the one where the tab is usually NOT discarded,
+     * and this request must leave its poll working — see the comment on
+     * the branch itself.
+     *
      * @param array<string, string> $params
      */
     public function verifyMagicLink(Request $request, array $params): Response
@@ -202,7 +206,25 @@ class AuthController extends AbstractController
             $role = $this->resolveRole($verified->email, $verified->userAccountId);
             AuthSession::login($verified->userAccountId, $verified->email, $role);
             $this->storeLinkedMembers($verified->email);
-            PendingMagicLink::forget();
+            // AND THE PENDING LINK IS LEFT ALONE, deliberately. This
+            // branch runs when the link opened in the SAME session that
+            // asked for it — which, on a phone, is the ordinary case:
+            // Safari opens the mail's link in a new tab of the same
+            // browser, so it carries the same session cookie as the tab
+            // still showing "En attente de confirmation…".
+            //
+            // Forgetting it here spent the one thing that tab has. Its
+            // next GET /auth/poll/{id} found `matches()` false — the
+            // pending had just been dropped by the other tab — and got
+            // `{confirmed: false}` for ever, over a session that was
+            // already authenticated. The visitor saw "En attente de
+            // confirmation…" until they reloaded by hand, every time
+            // (issue #263).
+            //
+            // pollMagicLink() below is what forgets it, once the window
+            // that asked has been told. That is also the order the
+            // docblock above describes: this request confirms, that one
+            // collects.
         }
 
         return $this->render('auth/verify.html.twig', [
@@ -239,7 +261,11 @@ class AuthController extends AbstractController
             return $this->json(['confirmed' => false]);
         }
 
-        // If this device (Device A) is not yet authenticated, create session
+        // If this device (Device A) is not yet authenticated, create the
+        // session. It already is in the same-browser case — verifyMagicLink()
+        // signed this very session in when the mail's link opened in another
+        // tab of it — and then there is nothing left to do but say so, which
+        // is what stops the "En attente de confirmation…" screen (issue #263).
         if (!AuthSession::isAuthenticated()) {
             $user = $this->authService->getUserForConfirmedLink($id);
             if ($user !== null && $this->isMemberAuthorized($user->email)) {

--- a/tests/Integration/MagicLinkWindowIdentityTest.php
+++ b/tests/Integration/MagicLinkWindowIdentityTest.php
@@ -183,6 +183,43 @@ class MagicLinkWindowIdentityTest extends TestCase
     }
 
     /**
+     * AND THE TAB IT LEFT BEHIND STOPS WAITING. On a phone the link opens
+     * in a new tab of the same browser, so the tab still showing « En
+     * attente de confirmation… » holds the same session that
+     * verifyMagicLink() has just signed in — and its next poll has to say
+     * so.
+     *
+     * It did not. Confirming the link forgot the pending id, so
+     * `matches()` was false from then on and GET /auth/poll/{id} answered
+     * `{confirmed: false}` for ever, to a session that was already
+     * authenticated. The visitor had to reload by hand, every time
+     * (issue #263, Safari on iPhone, « à chaque fois »).
+     */
+    public function testTheWaitingWindowIsToldWhenTheSameBrowserOpensTheLink(): void
+    {
+        $this->startTestSession();
+        $magicLinkId = $this->requestLink(self::EMAIL);
+
+        // The mail's link, opened in another tab of the same browser:
+        // same session, same cookie.
+        $this->controller->verifyMagicLink($this->verifyRequestFor($magicLinkId), []);
+
+        // The tab that asked, polling on its timer.
+        $response = $this->controller->pollMagicLink(
+            new Request('GET', '/auth/poll/' . $magicLinkId, [], [], [], []),
+            ['id' => (string) $magicLinkId]
+        );
+
+        $this->assertTrue(
+            json_decode($response->getBody(), true)['confirmed'],
+            'The window that asked for the link is still being told to wait, in a session that is already '
+            . 'signed in — so it shows « En attente de confirmation… » until the visitor reloads by hand.'
+        );
+        $this->assertTrue(AuthSession::isAuthenticated());
+        $this->assertSame(self::EMAIL, AuthSession::getEmail());
+    }
+
+    /**
      * A second browser cannot collect what the first one asked for: the
      * poll endpoint answers "not confirmed yet" to anyone but the
      * requesting session, whatever the id (Core\Security\PendingMagicLink).


### PR DESCRIPTION
## Description

Bloc 3 de « fixe le backlog ».

Corrige #263

### Le mécanisme

Sur un téléphone, le lien du mail s'ouvre dans un nouvel onglet du **même** navigateur : il porte donc le même cookie de session que l'onglet resté sur « En attente de confirmation… ». `verifyMagicLink()` reconnaît ce cas (`PendingMagicLink::matches()`), identifie la session — et appelait `PendingMagicLink::forget()` dans la foulée.

C'est la seule chose que l'onglet en attente possédait. Son `GET /auth/poll/{id}` suivant trouvait `matches()` faux, puisque l'autre onglet venait de l'oublier, et répondait `{confirmed: false}` indéfiniment, à une session **déjà authentifiée**. D'où le « à chaque fois » du rapport : rien de réseau, rien d'aléatoire, une invariante consommée trop tôt.

### Le correctif

Le `forget()` disparaît de cette branche : le pending est laissé en place, et `pollMagicLink()` est ce qui l'oublie — une fois la fenêtre qui a demandé prévenue. C'est aussi l'ordre que le docblock de `verifyMagicLink()` décrit déjà : *cette requête confirme, l'autre collecte*.

La piste proposée par le triage (traiter `AuthSession::isAuthenticated()` comme une confirmation valable dans `pollMagicLink()`) donnerait le même résultat pour le cas rapporté, mais elle élargit l'endpoint : une session authentifiée pour une tout autre raison recevrait `{confirmed: true}` sur n'importe quel id. Retirer le `forget()` prématuré ne touche à aucune garantie — le poll exige toujours `matches()`, donc la session requérante et elle seule — et corrige la cause plutôt que son effet.

Le flux inter-appareils (téléphone A demande, téléphone B confirme) passe par la branche `$isRequestingSession === false` et n'est pas concerné : `matches()` y échoue côté confirmation, donc ni login ni `forget()` n'y avaient lieu de toute façon.

### Vérification

`tests/Integration/MagicLinkWindowIdentityTest` gagne le cas manquant — demander, confirmer dans la même session, puis interroger `/auth/poll/{id}` — vérifié rouge sans le correctif (`Failed asserting that false is true`) et vert avec. Les cinq assertions existantes de ce fichier, dont « un autre navigateur ne peut pas collecter la session en interrogeant le poll », restent vertes.

`vendor/bin/phpunit` : 16 235 tests verts. `vendor/bin/phpunit --group=database` (MariaDB) : 7 935 verts. `vendor/bin/phpstan analyse` : no errors.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, aucun fichier JS touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1

---
_Generated by [Claude Code](https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1)_