### PR TITLE
Le scan du backlog nommait `steps` dans un `env:` de job, ce qui rendait le fichier invalide

### DIFF
--- a/.github/workflows/issue-backlog-scan.yml
+++ b/.github/workflows/issue-backlog-scan.yml
@@ -190,6 +190,34 @@ jobs:
       # The prompt fetches the skill rather than opening it, because there
       # is no checkout. Reading it from the default branch is also what
       # pins WHICH version runs: the copy on `main`, reviewed and merged.
+      #
+      # `__SELECTED_ISSUES__` IS A PLACEHOLDER AND NOT AN OVERSIGHT. This
+      # is a JOB-LEVEL `env:`, and the `steps` context is not available in
+      # one — GitHub's context-availability table grants `jobs.<id>.env`
+      # only github, needs, strategy, matrix, vars, secrets and inputs.
+      # Writing `${{ steps.before.outputs.selected }}` here did not read
+      # as an empty string: it made the WHOLE FILE an invalid workflow.
+      #
+      # What that looks like is worth knowing, because nothing about it
+      # says "syntax error". GitHub reports an unusable workflow as a
+      # FAILED RUN ATTRIBUTED TO THE PUSH — even for a file that declares
+      # no `push:` trigger — with zero jobs, no log to open, and the run
+      # named by its file path instead of by `name:`. That is issue #256:
+      # 124 red runs across every branch, from the first push carrying
+      # the bad line (2026-09-06, on the branch of #182) to the day it
+      # was found. The path-instead-of-name is the tell, and it is why
+      # the same workflow's `schedule` runs were named `Issue backlog
+      # scan` and its `push` runs were not.
+      #
+      # It also stopped the job entirely: an invalid workflow does not
+      # run at all, so the nightly triage this file exists for made ZERO
+      # scheduled runs in the two days that followed, silently, while the
+      # only visible symptom was a red run nobody had asked for.
+      #
+      # The `before` step resolves the placeholder into
+      # `RESOLVED_SCAN_PROMPT` below. One text, one substitution, both
+      # attempts identical — which is the property this block was written
+      # for and the reason not to inline the selection into each step.
       SCAN_PROMPT: |
         You are triaging the untriaged backlog of ${{ github.repository }}.
 
@@ -202,7 +230,7 @@ jobs:
         issues to run it on.
 
         THE ISSUES ARE CHOSEN FOR YOU. Triage exactly these, and
-        nothing else: ${{ steps.before.outputs.selected }}
+        nothing else: __SELECTED_ISSUES__
 
         They were selected by this workflow, before you were started:
         open, opened more than one hour ago, carrying `triage:pending`
@@ -404,6 +432,25 @@ jobs:
 
           echo "Candidates awaiting triage: ${candidates} (this run should clear ${expected})."
           echo "Selected: ${selected:-none}"
+          # THE PROMPT, RESOLVED HERE BECAUSE HERE IS WHERE IT MAY BE.
+          # A step may read the `steps` context; the job-level `env:` that
+          # holds the prompt may not, and a run that tried made the whole
+          # file invalid rather than merely wrong (see SCAN_PROMPT above).
+          #
+          # The delimiter is not a fixed word: `GITHUB_ENV` ends a
+          # multi-line value at the first line equal to it, so a
+          # delimiter an issue title could contain would let that title
+          # end the variable and have the rest of the prompt read as
+          # further assignments. The selection is a list of integers and
+          # cannot, but the prompt around it is edited by people, so the
+          # delimiter is random per run.
+          delimiter="SCAN_PROMPT_$(openssl rand -hex 16)"
+          {
+            echo "RESOLVED_SCAN_PROMPT<<${delimiter}"
+            printf '%s\n' "${SCAN_PROMPT//__SELECTED_ISSUES__/${selected:-none}}"
+            echo "${delimiter}"
+          } >> "${GITHUB_ENV}"
+
           echo "cutoff=${CUTOFF}" >> "${GITHUB_OUTPUT}"
           echo "candidates=${candidates}" >> "${GITHUB_OUTPUT}"
           echo "expected=${expected}" >> "${GITHUB_OUTPUT}"
@@ -491,7 +538,7 @@ jobs:
 
           # Defined once under the job's `env:` above, because the retry
           # step must be given the identical string.
-          prompt: ${{ env.SCAN_PROMPT }}
+          prompt: ${{ env.RESOLVED_SCAN_PROMPT }}
 
           # See the job-level SCAN_ARGS and SCAN_SCHEMA above for what
           # each half of this is and why. Both attempts are given the
@@ -562,7 +609,7 @@ jobs:
           # attempt returned more usable entries — and de-duplicates it by
           # issue. So no reporter can get two comments on one report even
           # when both attempts succeed.
-          prompt: ${{ env.SCAN_PROMPT }}
+          prompt: ${{ env.RESOLVED_SCAN_PROMPT }}
 
           # THE ONE PLACE THE TRANSCRIPT IS KEPT. The action hides the
           # agent's output by default and that default is right for a run

--- a/.github/workflows/issue-backlog-scan.yml
+++ b/.github/workflows/issue-backlog-scan.yml
@@ -536,8 +536,12 @@ jobs:
           allowed_non_write_users: "*"
           github_token: ${{ github.token }}
 
-          # Defined once under the job's `env:` above, because the retry
-          # step must be given the identical string.
+          # Resolved once by the `before` step into `GITHUB_ENV`, because
+          # the retry step must be given the identical string — and
+          # because the job's `env:` cannot hold it: the text names the
+          # selected issues, and a job-level `env:` may not read `steps`.
+          # It held it once, and that made the whole file invalid (#256;
+          # see SCAN_PROMPT above).
           prompt: ${{ env.RESOLVED_SCAN_PROMPT }}
 
           # See the job-level SCAN_ARGS and SCAN_SCHEMA above for what
@@ -602,8 +606,10 @@ jobs:
           allowed_non_write_users: "*"
           github_token: ${{ github.token }}
 
-          # The identical prompt and arguments, from the same `env:`
-          # entries. Running it twice is safe by construction now rather
+          # The identical prompt and arguments: the same `env:` entries
+          # for the arguments, and for the prompt the one string the
+          # `before` step resolved into `GITHUB_ENV` (see the first
+          # attempt above). Running it twice is safe by construction rather
           # than by instruction: an attempt RETURNS verdicts, it does not
           # post them, and the apply step below takes ONE set — whichever
           # attempt returned more usable entries — and de-duplicates it by

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -422,6 +422,29 @@ they are in the list at the end of this document for that reason, and
 repeated in the file's own header because that is where somebody editing it
 will be looking.
 
+**And a fifth, which cost this workflow two days of not running at all.**
+A context named where it is not available does not resolve to an empty
+string: it makes the whole file an **invalid workflow**. This one
+interpolated `${{ steps.before.outputs.selected }}` into a job-level
+`env:`, and `jobs.<job_id>.env` is built before the first step runs, so
+the `steps` context is not among the ones it may read. What GitHub does
+with an unusable workflow is the part nobody expects: it creates a
+**failed run attributed to the push** — for a file that declares no
+`push:` trigger — with zero jobs, no log to open, and the run named by
+its file path instead of by its `name:`. 124 of those accumulated across
+every branch between 2026-09-06 and 2026-09-08 (issue #256), and the tell
+was in the name: every `push` run was called
+`.github/workflows/issue-backlog-scan.yml` and every `schedule` run was
+called `Issue backlog scan`. The louder half was invisible: an invalid
+workflow does not run for its own triggers either, so the nightly triage
+made **zero** scheduled runs while the bad line was on `main`, and the
+only symptom was a red run for an event nobody had asked for. The prompt
+now carries a `__SELECTED_ISSUES__` placeholder that the `before` step
+resolves into `GITHUB_ENV`, which keeps the one-copy property the
+job-level `env:` was there for;
+`tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest`
+refuses the `steps` context outside a step in every workflow here.
+
 `.github/workflows/claude-review.yml` is the AI reviewer; see below. It
 carries two jobs: `Claude review`, which reads the diff, and `Claude review
 status`, which posts the comment saying what that check's green means. They
@@ -1264,6 +1287,17 @@ nothing**:
   the top of the hour where every `0 *` cron fires at once. Nothing
   reports the drop; the run simply never happens. This is why
   `issue-backlog-scan.yml` asks for minute 17.
+- **A context used where it is not available makes the file invalid, and
+  GitHub reports that as a failed run on `push`.** Not as a syntax error,
+  not on the trigger the workflow declares: a zero-job run with no log,
+  attributed to a `push` event the file never asked for, and named by its
+  file path instead of by its `name:`. Meanwhile the workflow does not run
+  for its own triggers either — silently. `issue-backlog-scan.yml` put
+  `${{ steps.… }}` in a job-level `env:` and spent two days producing red
+  runs nobody had asked for and no nightly triage at all (issue #256). The
+  path-instead-of-name in the Actions list is the tell, and
+  `tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest`
+  is the check.
 - A **`schedule:` trigger only ever runs from the default branch**, so a
   change to `issue-backlog-scan.yml` on a pull request branch proves the
   YAML parses and nothing more. Its `workflow_dispatch:` is not a

--- a/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
+++ b/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
@@ -47,6 +47,24 @@ use PHPUnit\Framework\TestCase;
 final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
 {
     /**
+     * One GitHub expression, `${{ … }}`, naming the `steps` context
+     * somewhere inside it.
+     *
+     * `}(?!})` RATHER THAN `[^}]`, and that is not pedantry: an
+     * expression may contain a single `}` of its own, and the shortest
+     * realistic way to write one is the very alternative that was
+     * considered and rejected when fixing #256 —
+     *
+     *     SELECTED: ${{ format('{0}', steps.before.outputs.selected) }}
+     *
+     * A `[^}]*` reach stops dead at the `}` of `{0}` and can never get to
+     * `steps.`, so that line reads as clean while being the same invalid
+     * workflow. The expression ends at `}}`, so that is where the reach
+     * has to stop — and nowhere earlier.
+     */
+    private const STEPS_IN_AN_EXPRESSION = '/\$\{\{(?:[^}]|\}(?!\}))*?\bsteps\./';
+
+    /**
      * Every workflow this repository ships.
      *
      * @return array<string, array{0: string}>
@@ -163,7 +181,7 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
             }
 
             $this->assertDoesNotMatchRegularExpression(
-                '/\$\{\{[^}]*\bsteps\./',
+                self::STEPS_IN_AN_EXPRESSION,
                 $line,
                 $name . ' line ' . ($number + 1) . ' names the `steps` context before any step exists: '
                 . trim($line) . "\n\n"
@@ -191,6 +209,61 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
             $stepBlocks,
             $name . ' has `steps:` blocks the loop above never reached, so part of the file was read as '
             . 'job configuration when it is a step, or the other way round.',
+        );
+    }
+
+    /**
+     * Lines the detector above must and must not fire on.
+     *
+     * @return array<string, array{0: bool, 1: string}>
+     */
+    public static function expressions(): array
+    {
+        return [
+            'the defect itself' =>
+                [true, "      SCAN_PROMPT: \${{ steps.before.outputs.selected }}"],
+            'the same defect written through format()' =>
+                [true, "      SELECTED: \${{ format('{0}', steps.before.outputs.selected) }}"],
+            'two expressions, the second one guilty' =>
+                [true, "      X: \${{ github.repository }}-\${{ steps.before.outputs.selected }}"],
+            'a context that is available here' =>
+                [false, "      REPO: \${{ github.repository }}"],
+            'a brace of its own and no steps' =>
+                [false, "      GREETING: \${{ format('{0}', github.repository) }}"],
+            'the word outside any expression' =>
+                [false, '      # the steps context is not available here'],
+        ];
+    }
+
+    /**
+     * THE DETECTOR IS ITSELF A PLACE THE DEFECT CAN HIDE, and it hid
+     * there once: the first spelling of this pattern reached with
+     * `[^}]*`, which stops at any `}` — so an expression carrying a brace
+     * of its own, like `format('{0}', steps.…)`, passed as clean while
+     * being exactly the invalid workflow of #256. A regex nobody exercises
+     * is an assertion nobody has read.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('expressions')]
+    public function testTheDetectorFiresOnEverySpellingOfTheDefectAndOnNothingElse(
+        bool $shouldFire,
+        string $line,
+    ): void {
+        if ($shouldFire) {
+            $this->assertMatchesRegularExpression(
+                self::STEPS_IN_AN_EXPRESSION,
+                $line,
+                'This line names the `steps` context in an expression and the detector does not see it, '
+                . 'so the workflow scan above passes over it.',
+            );
+
+            return;
+        }
+
+        $this->assertDoesNotMatchRegularExpression(
+            self::STEPS_IN_AN_EXPRESSION,
+            $line,
+            'The detector fires on a line that names no `steps` context, which would make every workflow '
+            . 'here unfixable rather than merely wrong.',
         );
     }
 

--- a/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
+++ b/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Architecture;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A workflow that names a context it may not use is not a workflow with
+ * a wrong value in it. It is an INVALID FILE, and GitHub says so in a way
+ * that looks like nothing.
+ *
+ * `.github/workflows/issue-backlog-scan.yml` interpolated
+ * `${{ steps.before.outputs.selected }}` into a JOB-LEVEL `env:`. The
+ * context-availability table grants `jobs.<job_id>.env` only github,
+ * needs, strategy, matrix, vars, secrets and inputs — `steps` is not
+ * among them, and cannot be: the job's environment is built before its
+ * first step runs.
+ *
+ * WHAT THAT COST, AND WHY NOTHING POINTED AT IT. GitHub reports an
+ * unusable workflow as a FAILED RUN ATTRIBUTED TO THE PUSH — even for a
+ * file that declares no `push:` trigger at all — with zero jobs, no log
+ * to open, and the run named by its file path instead of by its `name:`.
+ * That produced 124 red runs across every branch of this repository in
+ * two days, on a workflow whose own header says it runs nightly and on
+ * demand, and issue #256 could establish everything about it EXCEPT the
+ * mechanism: no `push:` had ever been committed to the file, the file
+ * parsed, and the same file succeeded on `schedule`. The tell was the
+ * name — every `push` run was called
+ * `.github/workflows/issue-backlog-scan.yml` and every `schedule` run was
+ * called `Issue backlog scan`.
+ *
+ * And the red runs were the *visible* half. An invalid workflow does not
+ * run at all, so the nightly backlog triage made zero scheduled runs for
+ * the two days the bad line was on `main` — silently, which is the half
+ * that mattered.
+ *
+ * So this test reads every workflow and refuses the `steps` context
+ * anywhere outside a step. It is deliberately narrower than the whole
+ * availability table: this is the violation that has actually happened
+ * here, it is the one an editor makes while moving a string into a
+ * job-level `env:` to stop two copies drifting, and a test that fails for
+ * one clear reason is worth more than one that tries to be a YAML
+ * validator.
+ */
+final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
+{
+    /**
+     * Every workflow this repository ships.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function workflows(): array
+    {
+        $directory = dirname(__DIR__, 2) . '/.github/workflows';
+        $files = glob($directory . '/*.yml');
+
+        self::assertIsArray($files, 'The workflow directory could not be listed.');
+        self::assertNotEmpty($files, 'No workflow files were found, so this test would pass over anything.');
+
+        $cases = [];
+        foreach ($files as $file) {
+            $cases[basename($file)] = [$file];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * THE `steps` CONTEXT BELONGS TO A STEP, and everything a job
+     * declares before `steps:` — its `env:`, its `if:`, its
+     * `concurrency:`, its `outputs:` keys — is read before any step has
+     * run.
+     *
+     * `outputs:` is the one place a job legitimately names
+     * `steps.<id>.outputs.<name>`, so it is allowed by name below rather
+     * than by accident.
+     */
+    #[\PHPUnit\Framework\Attributes\DataProvider('workflows')]
+    public function testNoWorkflowNamesTheStepsContextOutsideAStep(string $file): void
+    {
+        $contents = file_get_contents($file);
+
+        self::assertIsString($contents, $file . ' is unreadable');
+
+        $lines = explode("\n", $contents);
+        $name = basename($file);
+
+        // Everything from the top of the file to the first `steps:` of
+        // each job is read before a step exists. `outputs:` is the one
+        // block inside that region where `steps` is legal, and it is
+        // tracked rather than assumed: a key at its own indentation ends
+        // it.
+        $inOutputs = false;
+        $sawSteps = false;
+
+        foreach ($lines as $number => $line) {
+            if (preg_match('/^ {4}steps:\s*$/', $line) === 1) {
+                $sawSteps = true;
+                continue;
+            }
+
+            if ($sawSteps) {
+                // Past the first `steps:` of a job, every later block of
+                // this file belongs to a step or to the next job's
+                // header — and a job header naming `steps` is caught on
+                // the next file-wide pass this loop cannot make. The
+                // violation this test exists for is above `steps:`,
+                // which is where a job-level `env:` is written.
+                continue;
+            }
+
+            if (preg_match('/^ {4}outputs:\s*$/', $line) === 1) {
+                $inOutputs = true;
+                continue;
+            }
+
+            if ($inOutputs && preg_match('/^ {0,4}\S/', $line) === 1) {
+                $inOutputs = false;
+            }
+
+            if ($inOutputs) {
+                continue;
+            }
+
+            // A comment naming the context is prose, and this file's own
+            // comments name it at length — including the line that
+            // explains why the placeholder below is a placeholder. Only
+            // an EXPRESSION counts, so only `${{ … steps.… }}` is read.
+            if (preg_match('/^\s*#/', $line) === 1) {
+                continue;
+            }
+
+            $this->assertDoesNotMatchRegularExpression(
+                '/\$\{\{[^}]*\bsteps\./',
+                $line,
+                $name . ' line ' . ($number + 1) . ' names the `steps` context before any step exists: '
+                . trim($line) . "\n\n"
+                . 'That is not a value GitHub resolves to an empty string — it makes the whole file an '
+                . 'invalid workflow, which GitHub reports as a zero-job failed run on every push and which '
+                . 'stops the workflow running for its own triggers. See issue #256: 124 red runs, and two '
+                . 'days with no nightly triage at all. Resolve it inside a step (`GITHUB_ENV`) and leave a '
+                . 'placeholder here.',
+            );
+        }
+
+        $this->assertTrue(
+            $sawSteps,
+            $name . ' has no `steps:` block at the indentation this test reads, so it checked the whole '
+            . 'file as job configuration or none of it. Either way the reading above is not the one it '
+            . 'claims to make.',
+        );
+    }
+
+    /**
+     * The one this test was written for, named outright.
+     *
+     * The general assertion above passes the moment somebody deletes the
+     * placeholder along with the prompt; this one says what the file is
+     * supposed to do instead, so the substitution cannot quietly become
+     * two inline copies of a string whose whole point is that there is
+     * one of it.
+     */
+    public function testTheBacklogScanResolvesItsPromptInsideAStep(): void
+    {
+        $path = dirname(__DIR__, 2) . '/.github/workflows/issue-backlog-scan.yml';
+        $contents = file_get_contents($path);
+
+        self::assertIsString($contents, $path . ' is unreadable');
+
+        $this->assertStringContainsString(
+            '__SELECTED_ISSUES__',
+            $contents,
+            'The backlog scan no longer carries the placeholder its prompt is built around. If the issue '
+            . 'numbers went back into the job-level `env:`, the file is invalid again (#256); if they were '
+            . 'inlined into each attempt instead, the two attempts now have two prompts that can drift — '
+            . 'and the one that drifts is the retry, which only runs when something has already gone wrong.',
+        );
+
+        $this->assertStringContainsString(
+            'RESOLVED_SCAN_PROMPT<<',
+            $contents,
+            'Nothing resolves the placeholder into the environment any more, so the agent is handed the '
+            . 'literal `__SELECTED_ISSUES__` and told to triage it.',
+        );
+
+        $this->assertSame(
+            2,
+            substr_count($contents, 'prompt: ${{ env.RESOLVED_SCAN_PROMPT }}'),
+            'The two attempts no longer read the same resolved prompt. They must be given identical '
+            . 'instructions: the job measures what it cleared against what it selected, and two prompts '
+            . 'are two populations.',
+        );
+    }
+}

--- a/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
+++ b/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
@@ -119,8 +119,21 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
         $inJobs = false;
         $inSteps = false;
         $inOutputs = false;
-        $jobHeaders = 0;
-        $stepBlocks = 0;
+
+        // THE ANTI-VACUITY MEASURE, and it has to come from somewhere
+        // other than this loop's own triggers. Every GitHub job carries
+        // either `steps:` or a `uses:` calling a reusable workflow —
+        // that is a property of the FILE, not of the reading, so a
+        // reading that has drifted disagrees with it: a job header this
+        // loop invents has neither, and a `steps:` it fails to see
+        // leaves a real job with neither.
+        //
+        // Counting `steps:` lines and comparing that to the number of
+        // `steps:` lines is what this used to do, and it could not fail
+        // for the reason its message gave.
+        /** @var array<string, bool> $jobHasABody */
+        $jobHasABody = [];
+        $currentJob = null;
 
         foreach ($lines as $number => $line) {
             if (preg_match('/^jobs:\s*$/', $line) === 1) {
@@ -140,8 +153,9 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
             // A job header — two spaces, a name, a colon, nothing after
             // it. This is where the next job's configuration begins, so
             // it is where the previous job's `steps:` stops counting.
-            if ($inJobs && preg_match('/^ {2}[A-Za-z0-9_-]+:\s*$/', $line) === 1) {
-                $jobHeaders++;
+            if ($inJobs && preg_match('/^ {2}([A-Za-z0-9_-]+):\s*$/', $line, $job) === 1) {
+                $currentJob = $job[1];
+                $jobHasABody[$currentJob] = false;
                 $inSteps = false;
                 $inOutputs = false;
                 continue;
@@ -149,8 +163,18 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
 
             if (preg_match('/^ {4}steps:\s*$/', $line) === 1) {
                 $inSteps = true;
-                $stepBlocks++;
+                if ($currentJob !== null) {
+                    $jobHasABody[$currentJob] = true;
+                }
                 continue;
+            }
+
+            // The other shape a job takes: calling a reusable workflow
+            // instead of listing steps. At four spaces it can only be a
+            // job key — a step's own `uses:` is six spaces in, behind a
+            // `- `, and is not reached here anyway.
+            if (!$inSteps && preg_match('/^ {4}uses:\s/', $line) === 1 && $currentJob !== null) {
+                $jobHasABody[$currentJob] = true;
             }
 
             if ($inSteps) {
@@ -193,23 +217,24 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
             );
         }
 
-        // ANTI-VACUITY, and both halves are needed. A file whose jobs
-        // this loop never recognised reads as one long block of
-        // something, and whichever way that block falls the assertion
-        // above stops meaning what it says.
-        $this->assertGreaterThan(
-            0,
-            $jobHeaders,
+        // ANTI-VACUITY. A file whose jobs this loop never recognised
+        // reads as one long block of something, and whichever way that
+        // block falls the assertion above stops meaning what it says.
+        $this->assertNotEmpty(
+            $jobHasABody,
             $name . ' has no job header at the indentation this test reads, so the loop above never told '
             . 'one job from the next — and the reading it claims to make is not the one it made.',
         );
 
-        $this->assertSame(
-            substr_count($contents, "\n    steps:\n"),
-            $stepBlocks,
-            $name . ' has `steps:` blocks the loop above never reached, so part of the file was read as '
-            . 'job configuration when it is a step, or the other way round.',
-        );
+        foreach ($jobHasABody as $job => $hasABody) {
+            $this->assertTrue(
+                $hasABody,
+                $name . ': the loop above read `' . $job . '` as a job and then found neither `steps:` nor '
+                . 'a `uses:` in it. Every GitHub job has one or the other, so the reading has drifted from '
+                . 'the file — either that is not a job, or its steps were read as job configuration. Both '
+                . 'silently narrow what the assertion above examines.',
+            );
+        }
     }
 
     /**

--- a/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
+++ b/tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest.php
@@ -87,27 +87,57 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
         $lines = explode("\n", $contents);
         $name = basename($file);
 
-        // Everything from the top of the file to the first `steps:` of
-        // each job is read before a step exists. `outputs:` is the one
-        // block inside that region where `steps` is legal, and it is
-        // tracked rather than assumed: a key at its own indentation ends
-        // it.
+        // The region this test reads is, in each job, everything from the
+        // job's header down to its `steps:`. PER JOB, and the difference
+        // is the whole test: a flag that latches at the first `steps:` of
+        // a file skips every later job in it, and `checks.yml` has eight.
+        // A `${{ steps.… }}` reintroduced into the second job's `env:` —
+        // the exact defect this file exists for — would then pass green.
+        // So a job header resets the reading.
+        //
+        // `outputs:` is the one block in that region where the `steps`
+        // context is legal, and it is tracked rather than assumed: a key
+        // at its own indentation or shallower ends it.
+        $inJobs = false;
+        $inSteps = false;
         $inOutputs = false;
-        $sawSteps = false;
+        $jobHeaders = 0;
+        $stepBlocks = 0;
 
         foreach ($lines as $number => $line) {
-            if (preg_match('/^ {4}steps:\s*$/', $line) === 1) {
-                $sawSteps = true;
+            if (preg_match('/^jobs:\s*$/', $line) === 1) {
+                $inJobs = true;
                 continue;
             }
 
-            if ($sawSteps) {
-                // Past the first `steps:` of a job, every later block of
-                // this file belongs to a step or to the next job's
-                // header — and a job header naming `steps` is caught on
-                // the next file-wide pass this loop cannot make. The
-                // violation this test exists for is above `steps:`,
-                // which is where a job-level `env:` is written.
+            // Back out at any top-level key: `jobs:` is last in these
+            // files today, and a reader that assumes so is a reader that
+            // breaks silently when it stops being true.
+            if ($inJobs && preg_match('/^\S/', $line) === 1) {
+                $inJobs = false;
+                $inSteps = false;
+                $inOutputs = false;
+            }
+
+            // A job header — two spaces, a name, a colon, nothing after
+            // it. This is where the next job's configuration begins, so
+            // it is where the previous job's `steps:` stops counting.
+            if ($inJobs && preg_match('/^ {2}[A-Za-z0-9_-]+:\s*$/', $line) === 1) {
+                $jobHeaders++;
+                $inSteps = false;
+                $inOutputs = false;
+                continue;
+            }
+
+            if (preg_match('/^ {4}steps:\s*$/', $line) === 1) {
+                $inSteps = true;
+                $stepBlocks++;
+                continue;
+            }
+
+            if ($inSteps) {
+                // Inside a step, where the `steps` context is exactly
+                // what a step is allowed to read.
                 continue;
             }
 
@@ -145,11 +175,22 @@ final class WorkflowContextsAreAvailableWhereTheyAreUsedTest extends TestCase
             );
         }
 
-        $this->assertTrue(
-            $sawSteps,
-            $name . ' has no `steps:` block at the indentation this test reads, so it checked the whole '
-            . 'file as job configuration or none of it. Either way the reading above is not the one it '
-            . 'claims to make.',
+        // ANTI-VACUITY, and both halves are needed. A file whose jobs
+        // this loop never recognised reads as one long block of
+        // something, and whichever way that block falls the assertion
+        // above stops meaning what it says.
+        $this->assertGreaterThan(
+            0,
+            $jobHeaders,
+            $name . ' has no job header at the indentation this test reads, so the loop above never told '
+            . 'one job from the next — and the reading it claims to make is not the one it made.',
+        );
+
+        $this->assertSame(
+            substr_count($contents, "\n    steps:\n"),
+            $stepBlocks,
+            $name . ' has `steps:` blocks the loop above never reached, so part of the file was read as '
+            . 'job configuration when it is a step, or the other way round.',
         );
     }
 


### PR DESCRIPTION
## Description

Bloc 2 de « fixe le backlog ».

Corrige #256

### Le mécanisme, que le ticket laissait explicitement ouvert

`jobs.scan.env.SCAN_PROMPT` interpolait `${{ steps.before.outputs.selected }}`. Le contexte `steps` n'est **pas disponible** dans un `env:` de job — la table d'availability n'y accorde que `github`, `needs`, `strategy`, `matrix`, `vars`, `secrets` et `inputs`, et ne peut pas faire autrement : l'environnement du job est construit avant que le premier step ne tourne.

Ce n'est pas une valeur qui vaut la chaîne vide. **Le fichier devient un workflow invalide**, et GitHub signale ça d'une façon qui ne ressemble à rien de ce que le ticket cherchait : un **run en échec attribué au push** — pour un fichier qui ne déclare aucun déclencheur `push` — avec zéro job, aucun log à ouvrir, et **le run nommé par son chemin de fichier plutôt que par son `name:`**.

C'est ce dernier détail qui tranche, et il est vérifiable sans jeton :

```
$ curl -s ".../actions/workflows/issue-backlog-scan.yml/runs?per_page=100" \
  | jq -r '.workflow_runs[] | "\(.event) \(.name)"' | sort -u
push         .github/workflows/issue-backlog-scan.yml
schedule     Issue backlog scan
workflow_dispatch Issue backlog scan
```

Les cinq éliminations du ticket restent toutes valables — aucun `push:` n'a jamais été commité, le fichier « parse », rien ne l'appelle en workflow réutilisable, et c'est le seul workflow dans ce cas. Ce dernier point est d'ailleurs la confirmation : c'est aussi le seul dont un `env:` de job touche `steps`.

La chronologie recolle exactement. Le premier run rouge (run 4, 2026-09-06T07:23:43Z) est sur `claude/backlog-futur-github-issues-6y3e0c`, la branche de #182 — celle qui a introduit la ligne. Le run `schedule` réussi (run 9, 07:56Z) est sur le `main` d'avant la fusion. Le run 10, trois secondes après la fusion de #182 sur `main`, est rouge, et tous depuis.

### La correction du rapport : le tri nocturne ne tourne pas

Le ticket écrit que « les runs `schedule` réussissent, ce ne sont donc pas les runs nocturnes qui sont perdus ». Ce n'est plus vrai depuis la fusion de #182 : un workflow invalide ne tourne pas non plus pour ses propres déclencheurs. Sur l'historique complet du workflow (128 runs), il y a **un seul** run `schedule`, le 2026-09-06T07:56Z. **Zéro** depuis. Deux nuits sans tri, en silence — et c'était la moitié coûteuse du défaut, pendant que la moitié visible était un rouge que personne ne pouvait expliquer.

C'est aussi pourquoi aucune des options 2 à 4 du ticket n'est retenue : il n'y a rien à chercher dans les réglages GitHub, rien à masquer avec un `paths-ignore`, et rien à purger en renommant le fichier.

### Le correctif

Le prompt porte un placeholder `__SELECTED_ISSUES__`, que le step `before` — qui est l'endroit où le contexte `steps` est légal — résout dans `GITHUB_ENV` sous `RESOLVED_SCAN_PROMPT`. Les deux tentatives le lisent.

La propriété pour laquelle ce `env:` de job existait est conservée : **un seul texte pour les deux tentatives**. Le fichier argumente lui-même que deux copies inline dériveraient, et que celle qui dérive est la relance — celle que personne ne relit, puisqu'elle ne tourne que quand quelque chose a déjà mal tourné. Le délimiteur du heredoc `GITHUB_ENV` est aléatoire par run : une ligne du prompt égale à un délimiteur fixe terminerait la variable et ferait lire le reste comme des affectations.

### Le contrôle

Le ticket proposait une assertion lisant l'API des runs et vérifiant que l'ensemble des `event` observés est inclus dans `{schedule, workflow_dispatch}`. `tests/Architecture/WorkflowContextsAreAvailableWhereTheyAreUsedTest` lit le défaut plutôt que sa trace : il refuse le contexte `steps` hors d'un step dans **tous** les workflows du dépôt. Hors ligne, sans jeton, déterministe, et rouge sur le fichier d'avant — vérifié :

```
issue-backlog-scan.yml line 205 names the `steps` context before any step exists:
nothing else: ${{ steps.before.outputs.selected }}
```

Un second test nomme ce fichier-ci : le placeholder existe, quelque chose le résout, et les deux tentatives lisent le même prompt résolu — sinon la correction se retransforme silencieusement en deux copies.

`docs/quality-pipeline.md` gagne ce comportement dans les deux endroits où les autres vivent : la section du scan, et la liste des échecs silencieux en fin de document.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: n/a, aucun fichier JS touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1

---
_Generated by [Claude Code](https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1)_