### PR TITLE
La section souhaitée ne propose plus que les sections de la branche correspondant à l'année de naissance

### DIFF
--- a/modules/registration/src/Service/SlotService.php
+++ b/modules/registration/src/Service/SlotService.php
@@ -194,7 +194,21 @@ class SlotService
      * only the same available/limited/heavy tier the "Disponibilité des
      * places" section already shows, never the numbers behind it.
      *
-     * @return array<int, array{birth_year: int, branch_label: string, year_in_branch: int, tier: ?string}>
+     * `age_branch_id` is here for the « Section souhaitée » list, which
+     * has to keep only the sections of the branch the birth date lands
+     * in. It is the SAME identity
+     * Controller\PublicRegistrationController::resolveDesiredSectionId()
+     * validates the submitted section against, and that is the point of
+     * shipping the id rather than matching on `branch_label`: two readings
+     * of one relation that could disagree would let the form offer a
+     * section the server then drops. It identifies a branch and nothing
+     * else — the same value the page already prints on every
+     * `<option data-branch-id>` — so it exposes nothing a visitor cannot
+     * already read in the markup.
+     *
+     * @return array<int, array{
+     *   birth_year: int, age_branch_id: int, branch_label: string, year_in_branch: int, tier: ?string
+     * }>
      */
     public function birthYearSlotsForPublic(
         int $targetScoutYearId,
@@ -228,6 +242,7 @@ class SlotService
                 $birthYear = SlotMath::birthYearForSlot($bracket, $yearInBranch, $referenceYear);
                 $rows[] = [
                     'birth_year' => $birthYear,
+                    'age_branch_id' => $bracket->ageBranchId,
                     'branch_label' => $bracket->branchLabel,
                     'year_in_branch' => $yearInBranch,
                     'tier' => $tierByBirthYear[$birthYear] ?? null,

--- a/public/assets/js/registration-public-form.js
+++ b/public/assets/js/registration-public-form.js
@@ -49,6 +49,62 @@
     var friendWishBranchLabels = data.friendWishBranchLabels || [];
     var friendWishesZone = document.getElementById('friend-wishes-zone');
 
+    // « Section souhaitée ». Every <option> the template writes carries
+    // the branch it belongs to (`data-branch-id`), so the list can be
+    // narrowed to the branch the birth date lands in without asking the
+    // server anything — the same reasoning as the hint above.
+    var desiredSection = /** @type {HTMLSelectElement|null} */ (
+        document.getElementById('desired_section_id')
+    );
+
+    /**
+     * Keep only the sections of the branch the child would join, and put
+     * the whole list back when no branch is known.
+     *
+     * WHY THIS IS NOT COSMETIC. `Controller\PublicRegistrationController::
+     * resolveDesiredSectionId()` refuses a section outside the branch the
+     * birth date falls into and stores « Aucune préférence » instead —
+     * the right guard against a forged POST, and silent. So a family who
+     * picked a section from the full list, in good faith, had their
+     * choice dropped with nothing said. Narrowing the list here is what
+     * makes that branch unreachable for anybody filling the form
+     * honestly (issue #264).
+     *
+     * `hidden` AND `disabled`, not one of them: `hidden` is what removes
+     * an option from the dropdown, and Safari — the browser this was
+     * reported on — has shipped versions that ignore it on an <option>.
+     * A disabled option cannot be picked in any of them.
+     *
+     * A selection that has just become invalid is reset rather than left
+     * standing: an <option> that is hidden and still selected shows the
+     * family a section the server is about to refuse.
+     *
+     * @param {number|null} branchId
+     */
+    function updateDesiredSections(branchId) {
+        if (!desiredSection) return;
+
+        var options = desiredSection.options;
+
+        for (var i = 0; i < options.length; i++) {
+            var option = options[i];
+            var optionBranch = option.getAttribute('data-branch-id');
+
+            // « Aucune préférence » carries no branch and is always on
+            // offer: not choosing is a valid answer at every age.
+            var offered = branchId === null
+                || optionBranch === null
+                || Number(optionBranch) === branchId;
+
+            option.hidden = !offered;
+            option.disabled = !offered;
+
+            if (!offered && option.selected) {
+                desiredSection.value = '';
+            }
+        }
+    }
+
     /**
      * Show the « avec qui » fields for a branch that has a choice to
      * offer, hide them otherwise.
@@ -72,6 +128,7 @@
         if (!year || String(year).length !== 4) {
             hint.textContent = '';
             updateFriendWishes(null);
+            updateDesiredSections(null);
             return;
         }
 
@@ -82,6 +139,10 @@
             hint.textContent = "Hors des tranches d'âge de l'unité pour l'année "
                 + targetYearLabel + '.';
             updateFriendWishes(null);
+            // The whole list comes back rather than emptying: a birth year
+            // outside every branch is usually a typo being corrected, and
+            // a dropdown that has gone blank reads as a broken page.
+            updateDesiredSections(null);
             return;
         }
 
@@ -93,6 +154,9 @@
         // textContent, not innerHTML: a branch label is configured text.
         hint.textContent = text;
         updateFriendWishes(match.branch_label);
+        updateDesiredSections(
+            typeof match.age_branch_id === 'number' ? match.age_branch_id : null
+        );
     }
 
     birthDateInput.addEventListener('change', updateHint);

--- a/tests/Modules/Registration/Service/SlotServiceTest.php
+++ b/tests/Modules/Registration/Service/SlotServiceTest.php
@@ -133,6 +133,43 @@ class SlotServiceTest extends TestCase
     }
 
     /**
+     * The public page narrows « Section souhaitée » to the branch the
+     * typed birth date lands in, and it does that in the browser, from
+     * these rows — so a row that names the branch without identifying it
+     * leaves the list unfilterable.
+     *
+     * The ID, not the label: it is the identity
+     * Controller\PublicRegistrationController::resolveDesiredSectionId()
+     * validates the submitted section against, and matching on anything
+     * else would be a second reading of one relation. When those two
+     * disagree the form offers a section the server then drops, silently
+     * — which is issue #264.
+     */
+    public function testBirthYearSlotsForPublicIdentifyTheBranchAndDoNotOnlyNameIt(): void
+    {
+        $currentYearId = RegistrationTestHelper::insertScoutYear($this->pdo, '2026-2027', '2026-09-01', '2027-08-31');
+        $targetYearId = RegistrationTestHelper::insertScoutYear($this->pdo, '2027-2028', '2027-09-01', '2028-08-31');
+
+        $rows = $this->service->birthYearSlotsForPublic($targetYearId, '2027-2028', $currentYearId, false);
+
+        $bracket = $this->bracketRepository->findForBranch($this->baladinsId);
+        $birthYear = SlotMath::birthYearForSlot($bracket, 1, 2027);
+
+        $row = current(array_filter($rows, fn($r) => $r['birth_year'] === $birthYear));
+        $this->assertNotFalse($row);
+        $this->assertSame(
+            $this->baladinsId,
+            $row['age_branch_id'],
+            'A public slot row no longer carries the branch id, so the browser cannot tell which sections '
+            . 'belong to the branch a birth date lands in and offers all of them.',
+        );
+
+        foreach ($rows as $each) {
+            $this->assertArrayHasKey('age_branch_id', $each);
+        }
+    }
+
+    /**
      * The rule this whole change exists for, at the service level: a
      * branch with NO recorded capacity is unlimited, so it is never
      * announced full — whatever the projected headcount or the accepted

--- a/tests/js/registration-public-form.test.js
+++ b/tests/js/registration-public-form.test.js
@@ -13,16 +13,36 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const SLOTS = [
-    { birth_year: 2018, branch_label: 'Louveteaux', year_in_branch: 1, tier: 'available' },
-    { birth_year: 2014, branch_label: 'Éclaireurs', year_in_branch: 2, tier: 'limited' },
-    { birth_year: 2013, branch_label: 'Éclaireurs', year_in_branch: 3, tier: 'heavy' },
-    { birth_year: 2012, branch_label: 'Pionniers', year_in_branch: 1, tier: null },
+    { birth_year: 2018, age_branch_id: 2, branch_label: 'Louveteaux', year_in_branch: 1, tier: 'available' },
+    { birth_year: 2014, age_branch_id: 3, branch_label: 'Éclaireurs', year_in_branch: 2, tier: 'limited' },
+    { birth_year: 2013, age_branch_id: 3, branch_label: 'Éclaireurs', year_in_branch: 3, tier: 'heavy' },
+    { birth_year: 2012, age_branch_id: 4, branch_label: 'Pionniers', year_in_branch: 1, tier: null },
 ];
+
+// The « Section souhaitée » list as modules/registration/views/public.html.twig
+// writes it: « Aucune préférence » with no branch, then one option per
+// section carrying the branch it belongs to.
+const SECTIONS = [
+    { id: 11, branch: 2, label: 'Louveteaux — Meute A' },
+    { id: 12, branch: 2, label: 'Louveteaux — Meute B' },
+    { id: 21, branch: 3, label: 'Éclaireurs — Troupe' },
+    { id: 31, branch: 4, label: 'Pionniers — Poste' },
+];
+
+function sectionOptions() {
+    return SECTIONS
+        .map((s) => `<option value="${s.id}" data-branch-id="${s.branch}">${s.label}</option>`)
+        .join('');
+}
 
 function page(data) {
     return `
         <input type="date" id="birth_date" value="">
         <div class="form-text" id="birth-date-branch-hint"></div>
+        <select id="desired_section_id" name="desired_section_id">
+            <option value="">Aucune préférence</option>
+            ${sectionOptions()}
+        </select>
         <script type="application/json" id="registration-slots-data">${JSON.stringify(data)}<\/script>`;
 }
 
@@ -46,6 +66,12 @@ describe('registration-public-form.js', () => {
 
     const field = () => document.getElementById('birth_date');
     const hint = () => document.getElementById('birth-date-branch-hint').textContent;
+    const sections = () => document.getElementById('desired_section_id');
+
+    /** The labels a parent can actually pick, in order. */
+    const offered = () => Array.from(sections().options)
+        .filter((option) => !option.hidden && !option.disabled)
+        .map((option) => option.textContent.trim());
 
     function type(value) {
         field().value = value;
@@ -148,6 +174,12 @@ describe('registration-public-form.js', () => {
             expect(hint()).toBe('Branche prévue : Louveteaux — 1ᵉ année. Disponible.');
         });
 
+        it('leaves the section list alone until a branch is known', async () => {
+            await boot();
+
+            expect(offered()).toHaveLength(SECTIONS.length + 1);
+        });
+
         it('writes the branch label as TEXT, not markup', async () => {
             document.body.innerHTML = page({
                 ...DEFAULT_DATA,
@@ -159,6 +191,112 @@ describe('registration-public-form.js', () => {
             type('2018-05-04');
 
             expect(document.getElementById('birth-date-branch-hint').querySelector('b')).toBeNull();
+        });
+    });
+
+    // The list of sections a parent may ask for, narrowed to the branch
+    // the birth date lands in. The server already refuses a section from
+    // another branch — and replaces it with « Aucune préférence » without
+    // a word, which is what made the full list a real defect rather than
+    // an untidy one (issue #264).
+    describe('the « Section souhaitée » list', () => {
+        it('keeps only the sections of the branch the birth date lands in', async () => {
+            await boot();
+            type('2018-05-04');
+
+            expect(offered()).toEqual([
+                'Aucune préférence',
+                'Louveteaux — Meute A',
+                'Louveteaux — Meute B',
+            ]);
+        });
+
+        it('follows a corrected birth date from one branch to another', async () => {
+            await boot();
+            type('2018-05-04');
+            type('2012-05-04');
+
+            expect(offered()).toEqual(['Aucune préférence', 'Pionniers — Poste']);
+        });
+
+        it('always offers « Aucune préférence » — not choosing is valid at every age', async () => {
+            await boot();
+            type('2014-05-04');
+
+            expect(offered()).toContain('Aucune préférence');
+        });
+
+        it('hides AND disables what it removes, because Safari has ignored one of the two', async () => {
+            await boot();
+            type('2018-05-04');
+
+            const pionniers = Array.from(sections().options)
+                .find((option) => option.value === '31');
+
+            expect(pionniers.hidden).toBe(true);
+            expect(pionniers.disabled).toBe(true);
+        });
+
+        it('drops a selection the corrected date has just invalidated', async () => {
+            await boot();
+            type('2018-05-04');
+            sections().value = '12';
+
+            type('2012-05-04');
+
+            expect(sections().value).toBe('');
+        });
+
+        it('keeps a selection the corrected date leaves valid', async () => {
+            await boot();
+            type('2018-05-04');
+            sections().value = '12';
+
+            // Another Louveteaux birth year: same branch, same offer.
+            type('2018-11-30');
+
+            expect(sections().value).toBe('12');
+        });
+
+        it('puts the whole list back when the birth date is cleared', async () => {
+            await boot();
+            type('2018-05-04');
+            expect(offered()).toHaveLength(3);
+
+            type('');
+
+            expect(offered()).toHaveLength(SECTIONS.length + 1);
+        });
+
+        it('puts the whole list back for a year outside every branch, rather than emptying it', async () => {
+            await boot();
+            type('1998-06-01');
+
+            expect(offered()).toHaveLength(SECTIONS.length + 1);
+        });
+
+        it('does nothing at all on a page that has no such list', async () => {
+            document.body.innerHTML = `
+                <input type="date" id="birth_date" value="">
+                <div id="birth-date-branch-hint"></div>
+                <script type="application/json" id="registration-slots-data">${JSON.stringify(DEFAULT_DATA)}<\/script>`;
+            await boot();
+
+            expect(() => type('2018-05-04')).not.toThrow();
+            expect(hint()).toBe('Branche prévue : Louveteaux — 1ᵉ année. Disponible.');
+        });
+
+        it('offers every section when the row carries no branch id', async () => {
+            document.body.innerHTML = page({
+                ...DEFAULT_DATA,
+                birthYearSlots: [{
+                    birth_year: 2018, branch_label: 'Louveteaux', year_in_branch: 1, tier: null,
+                }],
+            });
+            await boot();
+            type('2018-05-04');
+
+            expect(offered()).toHaveLength(SECTIONS.length + 1);
         });
     });
 });


### PR DESCRIPTION
## Description

Bloc 4 de « fixe le backlog ».

Corrige #264

### Le défaut, et sa moitié invisible

Chaque `<option>` de « Section souhaitée » porte déjà `data-branch-id`, mais aucun script ne le lisait : la liste restait complète quoi que le parent tape comme date de naissance, alors que la note juste au-dessus annonçait déjà la bonne branche.

Ce n'est pas qu'une question d'affichage, et c'est ce qui rend le ticket sérieux. `PublicRegistrationController::resolveDesiredSectionId()` refuse une section hors de la branche où tombe la date de naissance et enregistre « Aucune préférence » à la place. C'est la bonne protection contre un POST forgé — et elle est silencieuse. Une famille de bonne foi qui choisissait dans la liste complète voyait donc son choix disparaître sans aucun message.

### Le correctif

`Service\SlotService::birthYearSlotsForPublic()` livre `age_branch_id` à côté de `branch_label`. C'est délibérément **l'identité que le serveur valide**, pas le libellé : faire correspondre sur le libellé serait une deuxième lecture d'une même relation, et le jour où les deux divergent le formulaire propose une section que le serveur refusera. La valeur n'expose rien de neuf — la page l'imprime déjà sur chaque `<option data-branch-id>`.

`public/assets/js/registration-public-form.js` narrows la liste à cette branche, sur le même événement que la note qu'il écrit déjà.

Trois détails valent d'être notés :

- **`hidden` ET `disabled`.** `hidden` est ce qui retire l'option du menu, et Safari — le navigateur du rapport — a livré des versions qui l'ignorent sur une `<option>`. Une option désactivée n'est sélectionnable dans aucune.
- **Une sélection invalidée est remise à « Aucune préférence ».** Une option cachée mais toujours sélectionnée montrerait à la famille une section que le serveur s'apprête à refuser — exactement le défaut, un tour plus tard.
- **Une date vide, incomplète ou hors de toutes les tranches d'âge rend la liste entière**, plutôt que de la vider. Une année hors branches est le plus souvent une faute de frappe en cours de correction, et un menu devenu vide se lit comme une page cassée.

« Aucune préférence » est toujours proposée : ne pas choisir est une réponse valable à tout âge.

`resolveDesiredSectionId()` n'est pas touché — c'est la protection contre un POST forgé, et elle doit rester. Ce changement la rend simplement inatteignable pour qui remplit le formulaire honnêtement.

### Vérification

`tests/js/registration-public-form.test.js` gagne dix specs sur la nouvelle liste (le fichier n'en couvrait que la note). Vérifiées rouges sans le correctif : 5 échecs sur les 5 qui affirment un rétrécissement, les autres décrivant le cas « rien à rétrécir ». `tests/Modules/Registration/Service/SlotServiceTest` épingle la présence de `age_branch_id` dans chaque ligne publique.

`npm run test:coverage` (ce que lance le job `javascript-tests`) : 118 fichiers, 2 058 tests verts. `npm run typecheck` : 0 nouvelle trouvaille. `vendor/bin/phpunit` : 16 238 verts. `--group=database` (MariaDB) : 7 935 verts. `vendor/bin/phpstan analyse` : no errors.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: dix specs Vitest ajoutées dans `tests/js/`, et `npm run test:coverage` passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1

---
_Generated by [Claude Code](https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1)_