### PR TITLE
Astuces de découverte IT-03 : la passe éditoriale et la charte

### DIFF
--- a/design.md
+++ b/design.md
@@ -615,6 +615,38 @@ formulaire pousse son pied hors de l'écran sur mobile, parce qu'un
 `<form>` sans `overflow` ne rétrécit jamais. Ici il n'y a rien à
 soumettre — la persistance est un `fetch`.
 
+**Quelle astuce, et quand — la clé `discovery`.** L'ordre dans lequel les
+sujets sont proposés est **éditorial** et se déclare dans le sujet
+lui-même, comme `role_min` et `paths` : écrire de l'aide ne touche jamais
+au code. Quatre valeurs, et le choix se fait à la rédaction :
+
+- **`discovery: 1`** — le sujet décrit une capacité qu'une personne peut
+  ignorer et qui lui fait gagner du temps. C'est la première carte qu'on
+  lui montrera. Exemples du corpus : `presences-feuille`, `publipostage`,
+  `camps-encoder`, `mes-paiements`, `envoyer-une-photo`,
+  `attestations-couverture`, `points-attention`.
+- **`discovery: 2`** — le défaut : utile, mais on le trouve en arrivant
+  sur la page. **Ne l'écrivez pas.** L'absence de clé vaut 2, et cent
+  vingt lignes `discovery: 2` seraient du bruit dans chaque fichier pour
+  aucune information ; le test refuse la valeur écrite en toutes lettres.
+- **`discovery: 3`** — vrai mais périphérique : un cas particulier, ou la
+  variante d'un sujet déjà étiqueté 1 — `presences-anime` à côté de
+  `presences-feuille`, `camps-modifier` à côté de `camps-encoder`.
+- **`discovery: off`** — hygiène de compte, obligation légale, opération
+  technique : ça ne se découvre pas, ça se consulte au moment voulu. Au
+  minimum `cookies`, `donnees-personnelles`, `se-connecter`,
+  `mon-compte`, `reinitialisation`, `installation-serveur`,
+  `sauvegardes`, `mises-a-jour`.
+
+**Une vingtaine de `1` au total, pas davantage.** Leur intérêt est d'être
+les premières cartes, ce que cinquante sujets prioritaires ne permettent
+plus. La contrainte du bas est l'autre moitié de la même règle :
+`tests/Core/Help/HelpDiscoveryInvariantsTest` exige **au moins trois
+sujets en priorité 1 à chaque plancher de rôle** — sans quoi un animé
+n'ouvrirait que sur des cartes de priorité 2 et le tri éditorial ne lui
+servirait à rien — et tient aussi le plafond. Six planchers, une
+vingtaine de sujets : quatre chacun.
+
 **Charte rédactionnelle** — enforced mechanically where possible by
 `tests/Core/Help/HelpInvariantsTest.php`, by review otherwise:
 

--- a/docs/chantiers/astuces-decouverte.md
+++ b/docs/chantiers/astuces-decouverte.md
@@ -214,3 +214,86 @@ avec IT-02, qui est ce qui le consomme.
   lecture.
 
 **Reporté.** Rien.
+
+---
+
+## IT-03 — La passe éditoriale et la charte
+
+**Livré.**
+
+- **Le corpus entier étiqueté** — 135 sujets relus un par un : **24 en
+  priorité 1**, 40 en `3`, 13 en `off`, et 58 laissés au défaut, c'est-à-dire
+  sans clé du tout.
+- **La charte, aux deux endroits où un auteur la cherchera** :
+  `design.md` §7.11 (la règle des quatre valeurs, les exemples du corpus,
+  le plafond d'une vingtaine de `1` et le plancher de trois par rôle) et
+  la section Aide de `docs/module-development.md` (la puce `discovery`, à
+  côté de `paths`, `question` et des citations de libellés).
+- **`tests/Core/Help/HelpDiscoveryInvariantsTest`** — quatre invariants
+  sur le corpus livré : toute valeur `discovery` déclarée est valide ;
+  **aucun sujet n'écrit `discovery: 2`** en toutes lettres ; **chaque
+  plancher de rôle porte au moins trois sujets en priorité 1** ; et les
+  huit sujets que le chantier nomme (`cookies`, `donnees-personnelles`,
+  `se-connecter`, `mon-compte`, `reinitialisation`,
+  `installation-serveur`, `sauvegardes`, `mises-a-jour`) sont bien en
+  `off`.
+
+**Les 24 sujets de priorité 1, par plancher de rôle** — quatre chacun,
+ce qui est la rencontre entre les deux moitiés de la règle (voir la
+décision 1) :
+
+| Plancher | Sujets |
+|---|---|
+| `public` | `installer-application`, `un-email-plusieurs-animes`, `recherche-dans-l-aide`, `modifier-une-reponse` |
+| `identified` | `mes-paiements`, `envoyer-une-photo`, `notifications-preferences`, `trombinoscope` |
+| `intendant` | `etiquettes-paiement`, `importer-extraits`, `rappels`, `campagnes` |
+| `chief` | `presences-feuille`, `publipostage`, `camps-encoder`, `envoi-de-mails` |
+| `admin` | `points-attention`, `attestations-couverture`, `edition-du-site`, `justesse-des-tarifs` |
+| `superadmin` | `config-emails`, `frequentation`, `connecteur-ia`, `config-desk` |
+
+**Décisions autonomes.**
+
+1. **Vingt-quatre plutôt que vingt.** Le document vise « une vingtaine,
+   pas davantage » ET exige trois `1` par plancher de rôle. Le corpus
+   utilise six planchers, donc le plancher seul impose dix-huit. À vingt,
+   deux planchers vivraient au minimum exact, et le premier sujet retiré
+   ou passé en `off` casserait le test. Quatre par plancher donne
+   vingt-quatre, garde une marge d'un sujet partout, et reste « une
+   vingtaine ». Le test porte les deux bornes.
+2. **Un plafond, pas seulement un plancher.** Le document ne demande que
+   l'invariant du bas ; sans plafond, « vise une vingtaine » n'est appliqué
+   par rien et le corpus dérive vers cinquante prioritaires, ce qui est le
+   défaut sous un autre nom. Le plafond est délibérément lâche (trente) :
+   il refuse une dérive, pas un arbitrage sur un sujet.
+3. **`discovery: 2` écrit en toutes lettres est une erreur de test.** La
+   charte dit de ne pas l'écrire ; une règle que rien ne vérifie est une
+   règle que la moitié du corpus finira par enfreindre.
+4. **Cinq `off` de plus que le minimum du document** : `se-desinscrire`
+   (se retirer d'une liste de diffusion — hygiène de compte),
+   `comptes-superadmin` (idem, côté administration), `config-rgpd`
+   (obligation légale), `support-github` et `support-sondes-email`
+   (opérations techniques qu'on ouvre au moment où on en a besoin). Chacun
+   tombe exactement dans une des trois catégories que le document énumère.
+5. **Les variantes d'un sujet déjà en `1` passent en `3`, systématiquement** :
+   `presences-anime` et `presences-registre` derrière `presences-feuille`,
+   les huit sujets `camps-*` derrière `camps-encoder`,
+   `attestations-distribuer` et `attestations-verifier` derrière
+   `attestations-couverture`, `recus-compte` et `rapprochement` derrière
+   les outils de finance. C'est la règle du document appliquée à la
+   lettre, et c'est ce qui remplit la catégorie `3` — quarante sujets,
+   sans quoi elle serait restée vide.
+6. **`journal` reste en `3` plutôt qu'en `off`.** Consulter le journal du
+   site est une capacité d'administration qui vaut d'être connue, pas une
+   opération d'hygiène ; ce qui la met en `3` et non en `1`, c'est qu'on
+   n'y va que quand on cherche déjà quelque chose.
+
+**Divergences avec le dépôt réel.**
+
+- Le corpus compte **135 sujets** et non « ~120 » : 44 core et 91 livrés
+  par des modules.
+- Le document nomme sept exemples de priorité 1 ; six existent tels quels,
+  et tous ont été retenus.
+- Le document énumère huit `off` « au minimum » ; les huit existent et
+  sont bien en `off`, plus cinq autres.
+
+**Reporté.** Rien.

--- a/docs/chantiers/astuces-decouverte.md
+++ b/docs/chantiers/astuces-decouverte.md
@@ -229,14 +229,20 @@ avec IT-02, qui est ce qui le consomme.
   le plafond d'une vingtaine de `1` et le plancher de trois par rôle) et
   la section Aide de `docs/module-development.md` (la puce `discovery`, à
   côté de `paths`, `question` et des citations de libellés).
-- **`tests/Core/Help/HelpDiscoveryInvariantsTest`** — quatre invariants
+- **`tests/Core/Help/HelpDiscoveryInvariantsTest`** — six invariants
   sur le corpus livré : toute valeur `discovery` déclarée est valide ;
   **aucun sujet n'écrit `discovery: 2`** en toutes lettres ; **chaque
-  plancher de rôle porte au moins trois sujets en priorité 1** ; et les
+  plancher de rôle porte au moins trois sujets en priorité 1** ; les
   huit sujets que le chantier nomme (`cookies`, `donnees-personnelles`,
   `se-connecter`, `mon-compte`, `reinitialisation`,
   `installation-serveur`, `sauvegardes`, `mises-a-jour`) sont bien en
-  `off`.
+  `off` ; **la priorité 1 reste un petit ensemble** (trente au plus —
+  voir la décision 2) ; et **le corpus couvre exactement les six
+  planchers de rôle pour lesquels il est écrit**. Ce dernier existe pour
+  une cécité du précédent : le compte par plancher tire ses planchers du
+  corpus lui-même, donc un plancher qui disparaît entièrement — le
+  dernier sujet `intendant` supprimé, disons — cesse simplement d'être
+  vérifié, et la suite reste verte sur un rôle dont l'aide a disparu.
 
 **Les 24 sujets de priorité 1, par plancher de rôle** — quatre chacun,
 ce qui est la rencontre entre les deux moitiés de la règle (voir la
@@ -276,7 +282,7 @@ décision 1) :
    tombe exactement dans une des trois catégories que le document énumère.
 5. **Les variantes d'un sujet déjà en `1` passent en `3`, systématiquement** :
    `presences-anime` et `presences-registre` derrière `presences-feuille`,
-   les huit sujets `camps-*` derrière `camps-encoder`,
+   les neuf sujets `camps-*` derrière `camps-encoder`,
    `attestations-distribuer` et `attestations-verifier` derrière
    `attestations-couverture`, `recus-compte` et `rapprochement` derrière
    les outils de finance. C'est la règle du document appliquée à la

--- a/docs/help/actions-planifiees.md
+++ b/docs/help/actions-planifiees.md
@@ -4,6 +4,7 @@ title: Suivre les actions planifiées
 summary: Les tâches de fond du site : états, échecs et exécution.
 category: Configuration
 role_min: superadmin
+discovery: 3
 question: Pourquoi une tâche de fond du site ne s'exécute-t-elle pas ?
 question: Comment relancer une action planifiée en échec ?
 paths: /config/scheduled

--- a/docs/help/comptes-superadmin.md
+++ b/docs/help/comptes-superadmin.md
@@ -4,6 +4,7 @@ title: Gérer les comptes superadmin
 summary: Les comptes qui administrent le site en dehors du Desk : en ajouter un, retirer le droit, suspendre un accès, et les changements que le site refuse.
 category: Configuration
 role_min: superadmin
+discovery: off
 question: Comment donner les droits d'administration à quelqu'un ?
 question: Comment retirer l'accès d'un ancien administrateur ?
 paths: /config/superadmins

--- a/docs/help/config-desk.md
+++ b/docs/help/config-desk.md
@@ -4,6 +4,7 @@ title: Config Desk — fonctions, sections et branches
 summary: Donner leurs rôles aux fonctions Desk, et régler nom, e-mail, couleur et visibilité des sections.
 category: Configuration
 role_min: superadmin
+discovery: 1
 question: Comment dire quel rôle donne une fonction de Desk ?
 question: Comment renommer une section ou changer sa couleur ?
 question: Comment masquer une section aux visiteurs ?

--- a/docs/help/config-emails.md
+++ b/docs/help/config-emails.md
@@ -4,6 +4,7 @@ title: Réécrire les emails automatiques
 summary: La liste de tous les emails que le site envoie tout seul, et comment en changer le texte.
 category: Configuration
 role_min: superadmin
+discovery: 1
 question: Comment changer le texte d'un e-mail automatique du site ?
 question: Quels e-mails le site envoie-t-il tout seul ?
 paths: /config/emails, /config/emails/*

--- a/docs/help/config-rgpd.md
+++ b/docs/help/config-rgpd.md
@@ -4,6 +4,7 @@ title: Choisir le contenu de la page RGPD
 summary: Texte de référence, texte personnalisé ou texte généré par IA.
 category: Configuration
 role_min: superadmin
+discovery: off
 question: Comment rédiger la page de protection des données ?
 question: Comment faire générer la page RGPD par l'IA ?
 paths: /config/rgpd

--- a/docs/help/cookies.md
+++ b/docs/help/cookies.md
@@ -4,6 +4,7 @@ title: Choisir ses cookies
 summary: Le bandeau, les trois catégories et ce que change un refus.
 category: Premiers pas
 role_min: public
+discovery: off
 question: Comment changer mon choix sur les cookies ?
 question: Que se passe-t-il si je refuse les cookies ?
 question: Où revoir le bandeau des cookies ?

--- a/docs/help/decouvrir-le-site.md
+++ b/docs/help/decouvrir-le-site.md
@@ -4,6 +4,7 @@ title: Découvrir le site de l'unité
 summary: Ce que montrent l'accueil, la page Contact et la page Sections.
 category: Premiers pas
 role_min: public
+discovery: 3
 question: Que peut-on voir sur le site sans être connecté ?
 question: Où trouver les coordonnées de l'unité ?
 question: Où voir la liste des sections de l'unité ?

--- a/docs/help/donnees-personnelles.md
+++ b/docs/help/donnees-personnelles.md
@@ -4,6 +4,7 @@ title: Vos données personnelles
 summary: Ce que la page Protection des données explique, et vos droits.
 category: Premiers pas
 role_min: public
+discovery: off
 question: Quelles données le site conserve-t-il sur mon enfant ?
 question: Comment demander la suppression de mes données ?
 paths: /rgpd

--- a/docs/help/edition-du-site.md
+++ b/docs/help/edition-du-site.md
@@ -4,6 +4,7 @@ title: Modifier les textes et les photos du site
 summary: Le mode configuration, pour éditer le contenu directement dans les pages.
 category: Espace chefs d'U
 role_min: admin
+discovery: 1
 question: Comment changer le texte d'une page du site ?
 question: Comment remplacer une photo de la page d'accueil ?
 paths: /config/general

--- a/docs/help/envoyer-une-photo.md
+++ b/docs/help/envoyer-une-photo.md
@@ -4,6 +4,7 @@ title: Envoyer une photo au site
 summary: L'écran d'envoi partagé : choisir un fichier, prendre une photo, et ce que le site en fait.
 category: Espace membres
 role_min: identified
+discovery: 1
 question: Quelle taille de photo le site accepte-t-il ?
 question: Pourquoi ma photo est-elle refusée à l'envoi ?
 question: Comment prendre une photo directement depuis le site ?

--- a/docs/help/fiches-en-double.md
+++ b/docs/help/fiches-en-double.md
@@ -4,6 +4,7 @@ title: Les fiches en double
 summary: Réunir deux fiches qui désignent la même personne recréée dans Desk.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: La même personne apparaît deux fois, comment réunir ses fiches ?
 question: Pourquoi un animé a-t-il perdu son historique après un import ?
 paths: /admin/doublons

--- a/docs/help/import-historique.md
+++ b/docs/help/import-historique.md
@@ -4,6 +4,7 @@ title: L'historique des imports Desk
 summary: Retrouver un import passé, son fichier conservé et sa durée de conservation.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Comment retrouver un import Desk fait il y a six mois ?
 question: Combien de temps le site garde-t-il les fichiers importés ?
 paths: /admin/import/historique, /admin/import/*/rapport

--- a/docs/help/installation-serveur.md
+++ b/docs/help/installation-serveur.md
@@ -4,6 +4,7 @@ title: Installation & serveur
 summary: L'identité du site, la base de données, l'e-mail, les DNS et le cron.
 category: Configuration
 role_min: superadmin
+discovery: off
 question: Comment raccorder le site à sa base de données ?
 question: Pourquoi les e-mails du site n'arrivent-ils pas ?
 question: Comment vérifier que le cron du site tourne ?

--- a/docs/help/installer-application.md
+++ b/docs/help/installer-application.md
@@ -4,6 +4,7 @@ title: Installer le site comme application
 summary: Ajouter le site à l'écran d'accueil et le consulter hors connexion.
 category: Premiers pas
 role_min: public
+discovery: 1
 question: Comment installer le site comme application sur mon téléphone ?
 question: Comment consulter le site sans connexion internet ?
 paths: /

--- a/docs/help/journal.md
+++ b/docs/help/journal.md
@@ -4,6 +4,7 @@ title: Consulter le journal du site
 summary: Retrouver qui a fait quoi, et quand.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Qui a changé cela, et quand ?
 question: Où voir les erreurs techniques qu'a rencontrées le site ?
 paths: /admin/journal

--- a/docs/help/mises-a-jour.md
+++ b/docs/help/mises-a-jour.md
@@ -4,6 +4,7 @@ title: Mettre à jour le site
 summary: Vérifier, installer et automatiser les mises à jour.
 category: Configuration
 role_min: admin
+discovery: off
 question: Comment installer la dernière version du site ?
 question: Comment faire installer les mises à jour toutes seules ?
 paths: /config/maintenance

--- a/docs/help/mon-compte.md
+++ b/docs/help/mon-compte.md
@@ -4,6 +4,7 @@ title: Gérer « Mon compte »
 summary: Votre photo, votre nom, votre mot de passe, vos clés numériques, les astuces et les notifications de cet appareil.
 category: Espace membres
 role_min: identified
+discovery: off
 question: Comment changer ma photo de profil ?
 question: Comment définir un mot de passe pour me connecter ?
 question: Comment se connecter avec l'empreinte ou le visage ?

--- a/docs/help/notifications-preferences.md
+++ b/docs/help/notifications-preferences.md
@@ -4,6 +4,7 @@ title: Régler ses préférences de notification
 summary: Choisir les canaux par type, les heures calmes et la discrétion.
 category: Espace membres
 role_min: identified
+discovery: 1
 question: Comment recevoir moins de notifications ?
 question: Comment recevoir les notifications par e-mail aussi ?
 question: Comment ne plus être dérangé le soir et la nuit ?

--- a/docs/help/points-attention.md
+++ b/docs/help/points-attention.md
@@ -4,6 +4,7 @@ title: Les points d'attention
 summary: Ce qui ne va pas dans l'unité aujourd'hui, recalculé à chaque consultation.
 category: Espace chefs d'U
 role_min: admin
+discovery: 1
 question: Qu'est-ce qui ne va pas dans l'unité en ce moment ?
 question: Comment faire disparaître un point d'attention ?
 paths: /admin/points-attention

--- a/docs/help/recherche-dans-l-aide.md
+++ b/docs/help/recherche-dans-l-aide.md
@@ -4,6 +4,7 @@ title: Chercher dans l'aide
 summary: Le champ de recherche du panneau et de la page Aide, qui répond même hors connexion.
 category: Premiers pas
 role_min: public
+discovery: 1
 question: Comment retrouver la page qui permet de faire quelque chose ?
 question: Où chercher quand je ne sais pas comment faire ?
 question: Est-ce que l'aide fonctionne sans connexion internet ?

--- a/docs/help/reinitialisation.md
+++ b/docs/help/reinitialisation.md
@@ -4,6 +4,7 @@ title: Réinitialiser ou restaurer le site
 summary: La zone de danger : paramètres par défaut, restauration d'une sauvegarde, remise à zéro.
 category: Configuration
 role_min: admin
+discovery: off
 question: Comment restaurer le site à partir d'une sauvegarde ?
 question: Comment remettre le site complètement à zéro ?
 paths: /config/maintenance

--- a/docs/help/sauvegardes.md
+++ b/docs/help/sauvegardes.md
@@ -4,6 +4,7 @@ title: Sauvegarder le site
 summary: Les sauvegardes à la demande et automatiques, et leur téléchargement.
 category: Configuration
 role_min: admin
+discovery: off
 question: Comment sauvegarder le site avant une opération risquée ?
 question: Où télécharger la dernière sauvegarde du site ?
 paths: /config/maintenance

--- a/docs/help/se-connecter.md
+++ b/docs/help/se-connecter.md
@@ -4,6 +4,7 @@ title: Se connecter au site
 summary: Le lien magique, le mot de passe et la clé numérique, pas à pas.
 category: Premiers pas
 role_min: public
+discovery: off
 question: Comment se connecter sans mot de passe ?
 question: Je n'ai pas reçu mon lien de connexion, que faire ?
 question: J'ai oublié mon mot de passe, comment faire ?

--- a/docs/help/support-github.md
+++ b/docs/help/support-github.md
@@ -4,6 +4,7 @@ title: Citer un ticket dans un signalement GitHub
 summary: La référence d'un ticket de support, citée dans un signalement public, donne au triage automatique une copie anonymisée de l'archive.
 category: Configuration
 role_min: superadmin
+discovery: off
 question: Comment signaler un bug sur GitHub sans exposer mes journaux ?
 question: À quoi sert la référence du ticket de support sur GitHub ?
 question: Puis-je joindre le paquet de support à un signalement GitHub ?

--- a/docs/help/support-mesure.md
+++ b/docs/help/support-mesure.md
@@ -4,6 +4,7 @@ title: Mesurer une lenteur du site
 summary: Cinq minutes pendant lesquelles chaque page servie est chronométrée, pour le support.
 category: Configuration
 role_min: superadmin
+discovery: 3
 question: Le site est lent, comment le montrer au support ?
 question: Que mesure le bouton « Mesurer une lenteur » ?
 paths: /config/support

--- a/docs/help/support-sondes-email.md
+++ b/docs/help/support-sondes-email.md
@@ -4,6 +4,7 @@ title: Tester l'acheminement des e-mails
 summary: Vérifier que vos messages arrivent vraiment, et dans quel état.
 category: Configuration
 role_min: superadmin
+discovery: off
 question: Comment savoir si nos e-mails arrivent en spam ?
 question: Comment tester l'acheminement d'un e-mail vers une adresse ?
 paths: /config/support

--- a/docs/help/un-email-plusieurs-animes.md
+++ b/docs/help/un-email-plusieurs-animes.md
@@ -4,6 +4,7 @@ title: Une adresse e-mail pour plusieurs animés
 summary: Ce que voit un parent dont l'adresse est liée à plusieurs enfants.
 category: Premiers pas
 role_min: public
+discovery: 1
 question: Comment voir mes deux enfants avec une seule adresse ?
 question: Pourquoi je vois plusieurs enfants après ma connexion ?
 related: se-connecter, adresses-email, page-membre

--- a/docs/module-development.md
+++ b/docs/module-development.md
@@ -1087,20 +1087,19 @@ Corps en Markdown…
   topic is describing a screen instead of documenting a task**: rewrite it
   rather than pad the list. `tests/Core/Help/HelpInvariantsTest` enforces
   all of it.
-- `discovery` (optionnel) : où le sujet se place dans les astuces
-  « Le saviez-vous ? » (ARCHITECTURE.md §8.95). `1` pour une capacité
-  qu'une personne peut ignorer et qui lui fait gagner du temps — ce sera
-  une de ses premières cartes ; `3` pour un cas particulier ou la variante
-  d'un sujet déjà en `1` ; `off` pour ce qui ne se découvre pas — hygiène
-  de compte, obligation légale, opération technique, qui se consultent au
-  moment voulu. Le défaut est `2` et **ne s'écrit pas** : l'absence de clé
-  vaut 2, et le test refuse la valeur écrite en toutes lettres. Une valeur
-  inconnue est une erreur de chargement, exactement comme un `role_min`
-  inconnu, et pour la même raison : une rétrogradation silencieuse
-  transforme une faute de frappe en sujet qui n'apparaît jamais. La charte
-  qui décide de la valeur est design.md §7.11 ;
-  `tests/Core/Help/HelpDiscoveryInvariantsTest` tient le plancher (trois
-  `1` par plancher de rôle) et le plafond.
+- `discovery` (optional): where the topic sits in the « Le saviez-vous ? »
+  running order (ARCHITECTURE.md §8.95). `1` for a capability somebody can
+  plainly not know about and that saves them time — it will be one of
+  their first cards; `3` for a special case, or a variant of a topic
+  already tagged `1`; `off` for what is never discovered — account
+  hygiene, a legal obligation, a technical operation, each consulted at
+  the moment it is needed. The default is `2` and **is never written**: an
+  absent key already means it, and the test refuses the value spelled out.
+  An unknown value is a load error, exactly like an unknown `role_min` and
+  for the same reason — a silent downgrade turns a typo into a topic that
+  never appears. The charter that decides which value a topic carries is
+  design.md §7.11; `tests/Core/Help/HelpDiscoveryInvariantsTest` holds the
+  floor (three `1`s per role floor) and the ceiling.
 - **Quote a control exactly as the screen writes it.** A topic that says
   « à catégoriser » where the page shows « À catégoriser » is already
   drifting, and `tests/Core/Help/HelpLabelDriftTest` fails on a citation

--- a/docs/module-development.md
+++ b/docs/module-development.md
@@ -1087,6 +1087,20 @@ Corps en Markdown…
   topic is describing a screen instead of documenting a task**: rewrite it
   rather than pad the list. `tests/Core/Help/HelpInvariantsTest` enforces
   all of it.
+- `discovery` (optionnel) : où le sujet se place dans les astuces
+  « Le saviez-vous ? » (ARCHITECTURE.md §8.95). `1` pour une capacité
+  qu'une personne peut ignorer et qui lui fait gagner du temps — ce sera
+  une de ses premières cartes ; `3` pour un cas particulier ou la variante
+  d'un sujet déjà en `1` ; `off` pour ce qui ne se découvre pas — hygiène
+  de compte, obligation légale, opération technique, qui se consultent au
+  moment voulu. Le défaut est `2` et **ne s'écrit pas** : l'absence de clé
+  vaut 2, et le test refuse la valeur écrite en toutes lettres. Une valeur
+  inconnue est une erreur de chargement, exactement comme un `role_min`
+  inconnu, et pour la même raison : une rétrogradation silencieuse
+  transforme une faute de frappe en sujet qui n'apparaît jamais. La charte
+  qui décide de la valeur est design.md §7.11 ;
+  `tests/Core/Help/HelpDiscoveryInvariantsTest` tient le plancher (trois
+  `1` par plancher de rôle) et le plafond.
 - **Quote a control exactly as the screen writes it.** A topic that says
   « à catégoriser » where the page shows « À catégoriser » is already
   drifting, and `tests/Core/Help/HelpLabelDriftTest` fails on a citation

--- a/modules/attestations/help/attestations-couverture.md
+++ b/modules/attestations/help/attestations-couverture.md
@@ -4,6 +4,7 @@ title: Qui n'a pas encore reçu son attestation
 summary: Pour une catégorie et une année, qui la détient et de qui réclamer le complément.
 category: Espace chefs d'U
 role_min: admin
+discovery: 1
 question: Qui n'a pas encore reçu son attestation fiscale ?
 question: Que réclamer à la fédération pour compléter un lot ?
 paths: /admin/attestations/*

--- a/modules/attestations/help/attestations-distribuer.md
+++ b/modules/attestations/help/attestations-distribuer.md
@@ -4,6 +4,7 @@ title: Distribuer un lot d'attestations
 summary: Publier sur les pages des membres, prévenir les familles, lire les compteurs d'envoi.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Comment envoyer les attestations fiscales aux familles ?
 question: Comment savoir si une famille a bien reçu son attestation ?
 paths: /admin/attestations/*

--- a/modules/attestations/help/attestations-verifier.md
+++ b/modules/attestations/help/attestations-verifier.md
@@ -4,6 +4,7 @@ title: Vérifier un lot avant de le distribuer
 summary: Relire l'appariement, trancher les homonymes et décider ce qui part.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Comment vérifier un lot d'attestations avant de l'envoyer ?
 question: Deux membres portent le même nom, laquelle est la bonne ?
 paths: /admin/attestations/*

--- a/modules/camps/help/camps-anonymiser.md
+++ b/modules/camps/help/camps-anonymiser.md
@@ -4,6 +4,7 @@ title: Anonymiser un contact
 summary: Effacer les coordonnées d'une personne à sa demande, et ce que le site garde malgré tout.
 category: Espace animateurs
 role_min: admin
+discovery: 3
 question: Un propriétaire demande d'effacer ses coordonnées, que faire ?
 question: Que reste-t-il d'un contact après son anonymisation ?
 paths: /chefs/camps/contacts/*/anonymiser

--- a/modules/camps/help/camps-avis.md
+++ b/modules/camps/help/camps-avis.md
@@ -4,6 +4,7 @@ title: Laisser un avis sur un camp
 summary: Ce que le staff suivant a besoin de savoir avant d'aller sur ce terrain.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Comment prévenir le staff suivant que le terrain était mauvais ?
 question: Où lire ce que les staffs précédents ont pensé d'un terrain ?
 paths: /chefs/camps/sejours/*

--- a/modules/camps/help/camps-carte.md
+++ b/modules/camps/help/camps-carte.md
@@ -4,6 +4,7 @@ title: La carte des lieux de camp
 summary: Où sont les terrains, comment leurs coordonnées arrivent, et ce qui part vers OpenStreetMap.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Où voir nos lieux de camp sur une carte ?
 question: Pourquoi un terrain n'apparaît-il pas sur la carte ?
 paths: /chefs/camps/lieux/*

--- a/modules/camps/help/camps-courrier-ecran.md
+++ b/modules/camps/help/camps-courrier-ecran.md
@@ -4,6 +4,7 @@ title: L'écran du courrier des camps
 summary: Ce que la liste montre, confirmer une proposition, et ce que « Retirer » veut dire.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Où lire les e-mails reçus au sujet d'un camp ?
 question: Que veut dire retirer un message d'un séjour ?
 question: Comment faire disparaître un courrier qui ne concerne pas les camps ?

--- a/modules/camps/help/camps-courrier.md
+++ b/modules/camps/help/camps-courrier.md
@@ -4,6 +4,7 @@ title: Le courrier des camps
 summary: Ce que le site reprend de vos e-mails, ce qu'il ne touchera jamais, et l'écran où vous triez.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Pourquoi les e-mails du propriétaire arrivent-ils sur le séjour ?
 question: Comment dédier une adresse e-mail aux camps ?
 paths: /chefs/camps/courrier

--- a/modules/camps/help/camps-documents.md
+++ b/modules/camps/help/camps-documents.md
@@ -4,6 +4,7 @@ title: Les documents et les photos d'un séjour
 summary: Joindre un contrat, une facture ou des photos, et qui peut les rouvrir ensuite.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Où déposer le contrat de location du terrain de camp ?
 question: Qui peut rouvrir les documents d'un camp passé ?
 paths: /chefs/camps/sejours/*/documents, /chefs/camps/sejours/*/photos

--- a/modules/camps/help/camps-encoder.md
+++ b/modules/camps/help/camps-encoder.md
@@ -4,6 +4,7 @@ title: Encoder un camp
 summary: Créer un séjour et son lieu, et corriger l'un ou l'autre ensuite.
 category: Espace animateurs
 role_min: chief
+discovery: 1
 question: Comment enregistrer le camp de cet été ?
 question: Comment ajouter un nouveau terrain de camp ?
 paths: /chefs/camps/nouveau

--- a/modules/camps/help/camps-fusionner.md
+++ b/modules/camps/help/camps-fusionner.md
@@ -4,6 +4,7 @@ title: Fusionner deux lieux ou deux séjours
 summary: Quand un même terrain a fini par exister en double, et comment les recoller sans rien perdre.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Le même terrain existe deux fois, comment les recoller ?
 question: Comment supprimer un séjour créé en double ?
 paths: /chefs/camps/lieux/*, /chefs/camps/sejours/*, /chefs/camps/lieux/*/fusionner, /chefs/camps/sejours/*/fusionner

--- a/modules/camps/help/camps-modifier.md
+++ b/modules/camps/help/camps-modifier.md
@@ -4,6 +4,7 @@ title: Corriger un séjour ou un lieu
 summary: Ce qu'on peut changer après coup, et ce que la correction laisse derrière elle.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Comment corriger les dates d'un camp déjà encodé ?
 question: Comment changer l'adresse d'un lieu de camp ?
 paths: /chefs/camps/lieux/*/modifier, /chefs/camps/sejours/*/modifier

--- a/modules/camps/help/camps-propositions.md
+++ b/modules/camps/help/camps-propositions.md
@@ -4,6 +4,7 @@ title: Les informations lues dans un message
 summary: Ce que le site sait lire dans un e-mail reçu, et pourquoi il ne réécrit jamais ce que vous avez tapé.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Pourquoi le prix lu dans un e-mail ne s'écrit-il pas tout seul ?
 question: Comment appliquer les dates trouvées dans un message ?
 paths: /chefs/camps/sejours/*

--- a/modules/fees/help/justesse-des-tarifs.md
+++ b/modules/fees/help/justesse-des-tarifs.md
@@ -4,6 +4,7 @@ title: Corriger les tarifs de cotisation dans Desk
 summary: Les foyers dont la catégorie encodée ne correspond pas au nombre de personnes qui y vivent.
 category: Espace chefs d'U
 role_min: admin
+discovery: 1
 question: Quelles familles paient un tarif qui ne correspond pas ?
 question: Comment corriger une catégorie de cotisation mal encodée ?
 paths: /admin/fees/tarifs

--- a/modules/fees/help/verification-facture.md
+++ b/modules/fees/help/verification-facture.md
@@ -4,6 +4,7 @@ title: Lire le rapport de vérification d'une facture
 summary: Ce que la fédération a compté, ce que Desk contenait le jour de l'émission, et nominativement où les deux divergent.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: La facture de la fédération est-elle juste ?
 question: Pour qui la fédération nous facture-t-elle à tort ?
 paths: /admin/fees/factures/*

--- a/modules/finance/help/campagnes.md
+++ b/modules/finance/help/campagnes.md
@@ -4,6 +4,7 @@ title: Lancer une campagne de paiement
 summary: Facturer un montant à chaque membre d'une liste, et suivre les paiements reçus.
 category: Espace animateurs
 role_min: intendant
+discovery: 1
 question: Comment réclamer la cotisation à toutes les familles ?
 question: Comment savoir qui a payé et qui n'a pas payé ?
 paths: /finance/campaigns, /finance/campaigns/new, /finance/campaigns/*

--- a/modules/finance/help/courrier-finances.md
+++ b/modules/finance/help/courrier-finances.md
@@ -4,6 +4,7 @@ title: Un reçu reçu par e-mail
 summary: Comment le site décide où classer une pièce jointe, ce qu'il fait tout seul et ce qu'il vous laisse.
 category: Espace animateurs
 role_min: intendant
+discovery: 3
 question: Une facture est arrivée par e-mail, comment la classer ?
 question: Pourquoi une pièce jointe n'est-elle pas classée toute seule ?
 paths: /finance/receipts

--- a/modules/finance/help/etiquettes-paiement.md
+++ b/modules/finance/help/etiquettes-paiement.md
@@ -4,6 +4,7 @@ title: Distribuer des étiquettes de paiement
 summary: Imprimer une feuille d'étiquettes à découper, une par créance, avec son code QR de paiement.
 category: Espace animateurs
 role_min: intendant
+discovery: 1
 question: Comment imprimer des étiquettes de paiement à distribuer ?
 question: Comment donner un code QR de paiement sur papier ?
 paths: /finance/campaigns/*

--- a/modules/finance/help/importer-extraits.md
+++ b/modules/finance/help/importer-extraits.md
@@ -4,6 +4,7 @@ title: Importer un extrait bancaire
 summary: Charger le relevé CSV de la banque et garder les soldes justes.
 category: Espace animateurs
 role_min: intendant
+discovery: 1
 question: Comment charger le relevé bancaire du mois ?
 question: Pourquoi mon solde ne correspond-il pas à celui de la banque ?
 paths: /finance/import

--- a/modules/finance/help/mes-paiements.md
+++ b/modules/finance/help/mes-paiements.md
@@ -4,6 +4,7 @@ title: Payer ce que votre famille doit
 summary: Où trouver le montant, la communication et le code QR, et pourquoi un virement par enfant.
 category: Espace membres
 role_min: identified
+discovery: 1
 question: Combien dois-je payer pour l'inscription de mon enfant ?
 question: Quelle communication faut-il mettre sur le virement ?
 question: J'ai payé, pourquoi le montant s'affiche-t-il toujours ?

--- a/modules/finance/help/outils-finance.md
+++ b/modules/finance/help/outils-finance.md
@@ -4,6 +4,7 @@ title: Les outils de paiement
 summary: Fabriquer un code QR de virement, et vérifier une communication structurée.
 category: Espace animateurs
 role_min: intendant
+discovery: 3
 question: Comment fabriquer un code QR pour un virement ?
 question: Comment vérifier qu'une communication structurée est valable ?
 paths: /finance/tools

--- a/modules/finance/help/rappels.md
+++ b/modules/finance/help/rappels.md
@@ -4,6 +4,7 @@ title: Envoyer un rappel de paiement
 summary: Préparer le publipostage de rappel d'une campagne, et marquer les familles notifiées.
 category: Espace animateurs
 role_min: intendant
+discovery: 1
 question: Comment relancer les familles qui n'ont pas encore payé ?
 question: Comment éviter de relancer deux fois la même famille ?
 paths: /finance/campaigns/*

--- a/modules/finance/help/rapprochement.md
+++ b/modules/finance/help/rapprochement.md
@@ -4,6 +4,7 @@ title: Rapprocher un paiement qui tombe de travers
 summary: Les quatre situations que le site ne sait pas traiter seul, et le geste qui convient à chacune.
 category: Espace animateurs
 role_min: intendant
+discovery: 3
 question: Un parent a payé pour trois enfants en un virement, que faire ?
 question: Un virement est arrivé sans communication, comment le rattacher ?
 question: Comment rembourser une famille qui a payé en trop ?

--- a/modules/finance/help/recus-compte.md
+++ b/modules/finance/help/recus-compte.md
@@ -4,6 +4,7 @@ title: Le compte d'un reçu, et « Compte inconnu »
 summary: Déplacer un reçu vers un autre compte, et trier ceux que le courrier n'a pas su rattacher.
 category: Espace animateurs
 role_min: intendant
+discovery: 3
 question: Comment déplacer un reçu déposé sur le mauvais compte ?
 question: Que faire des reçus arrivés par e-mail sans compte ?
 question: Pourquoi mon reçu a-t-il perdu ses mouvements associés ?

--- a/modules/groups/help/pages-d-un-groupe.md
+++ b/modules/groups/help/pages-d-un-groupe.md
@@ -4,6 +4,7 @@ title: Membres, galerie et recherche d'un groupe
 summary: Les trois pages qui accompagnent la conversation d'un groupe.
 category: Espace membres
 role_min: identified
+discovery: 3
 question: Qui fait partie de ce groupe de discussion ?
 question: Comment retrouver une photo publiée dans un groupe ?
 paths: /groups/*/members, /groups/*/gallery, /groups/*/search

--- a/modules/groups/help/signalements-groupe.md
+++ b/modules/groups/help/signalements-groupe.md
@@ -4,6 +4,7 @@ title: Traiter les signalements d'un groupe
 summary: La page « Signalements » côté modérateur : masquer, ignorer, restaurer.
 category: Espace membres
 role_min: identified
+discovery: 3
 question: Que faire quand un message d'un groupe est signalé ?
 question: Comment masquer un message déplacé dans un groupe ?
 paths: /groups/*/reports

--- a/modules/inbound_mail/help/courrier-orienter.md
+++ b/modules/inbound_mail/help/courrier-orienter.md
@@ -4,6 +4,7 @@ title: Orienter un message
 summary: Confirmer une proposition, rattacher à la main, détacher, et ce qui disparaît quand.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Comment classer un e-mail reçu dans le bon dossier ?
 question: Comment rattacher à la main un e-mail qu'aucun module n'a reconnu ?
 question: Comment défaire un rattachement fait par erreur ?

--- a/modules/inbound_mail/help/courrier-portee.md
+++ b/modules/inbound_mail/help/courrier-portee.md
@@ -4,6 +4,7 @@ title: Ce que chaque module fait d'une boîte
 summary: Boîte partagée ou dédiée, qui analyse, qui peut lire, et combien de temps le courrier est conservé.
 category: Configuration
 role_min: superadmin
+discovery: 3
 question: Comment réserver une boîte e-mail à un seul usage ?
 question: Qui a le droit de lire le courrier entrant ?
 paths: /config/courrier-entrant/boites/*/portee

--- a/modules/inbound_mail/help/courrier-reponse.md
+++ b/modules/inbound_mail/help/courrier-reponse.md
@@ -4,6 +4,7 @@ title: L'adresse de réponse signée
 summary: Pourquoi les e-mails du site portent une adresse de réponse à rallonge, et quand la désactiver.
 category: Configuration
 role_min: superadmin
+discovery: 3
 question: Pourquoi l'adresse de réponse du site contient-elle un « + » et une référence ?
 question: Comment faire reconnaître une réponse sans référence dans l'objet ?
 question: Les réponses à nos e-mails reviennent en erreur, que faire ?

--- a/modules/leadership/help/encadrement-obligations.md
+++ b/modules/leadership/help/encadrement-obligations.md
@@ -4,6 +4,7 @@ title: Obligations et intendants
 summary: Les 20 ans qui approchent, les candidats signalés par Desk et les inscriptions des intendants.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Quels animateurs vont bientôt avoir 20 ans ?
 question: Quels animateurs doivent encore s'inscrire à une formation ?
 paths: /admin/leadership/obligations, /admin/leadership/stewards

--- a/modules/llm_connector/help/connecteur-ia.md
+++ b/modules/llm_connector/help/connecteur-ia.md
@@ -4,6 +4,7 @@ title: Activer l'intelligence artificielle
 summary: Choisir un fournisseur d'IA, sa clé, et ce que le site en fait.
 category: Configuration
 role_min: superadmin
+discovery: 1
 question: Comment brancher une intelligence artificielle sur le site ?
 question: Combien coûte l'IA branchée sur le site ?
 question: Que fait le site avec l'IA une fois branchée ?

--- a/modules/mass_mail/help/envoi-de-mails.md
+++ b/modules/mass_mail/help/envoi-de-mails.md
@@ -4,6 +4,7 @@ title: Envoyer un e-mail groupé
 summary: Du brouillon au test, puis l'envoi et son suivi, destinataire par destinataire.
 category: Espace animateurs
 role_min: chief
+discovery: 1
 question: Comment écrire à tous les parents de ma section ?
 question: Comment prévenir tous les parents d'une section ?
 question: Comment vérifier qu'un e-mail groupé est bien parti ?

--- a/modules/mass_mail/help/publipostage.md
+++ b/modules/mass_mail/help/publipostage.md
@@ -4,6 +4,7 @@ title: Faire un publipostage depuis Excel
 summary: Un e-mail personnalisé par ligne d'un fichier Excel, variables comprises.
 category: Espace animateurs
 role_min: chief
+discovery: 1
 question: Comment envoyer un mail personnalisé depuis un fichier Excel ?
 question: Comment mettre le prénom de chacun dans un e-mail groupé ?
 paths: /mass-mail

--- a/modules/mass_mail/help/se-desinscrire.md
+++ b/modules/mass_mail/help/se-desinscrire.md
@@ -4,6 +4,7 @@ title: Ne plus recevoir les e-mails de l'unité
 summary: Le lien de désinscription, ce qu'il arrête et ce qu'il n'arrête pas.
 category: Premiers pas
 role_min: public
+discovery: off
 question: Comment ne plus recevoir les e-mails de l'unité ?
 question: Je me suis désinscrit, pourquoi je reçois encore des mails ?
 paths: /mass-mail/unsubscribe/*

--- a/modules/news/help/modifier-une-reponse.md
+++ b/modules/news/help/modifier-une-reponse.md
@@ -4,6 +4,7 @@ title: Modifier votre réponse à un formulaire
 summary: Corriger une inscription déjà envoyée, tant que le formulaire est ouvert.
 category: Premiers pas
 role_min: public
+discovery: 1
 question: Comment corriger une inscription déjà envoyée ?
 question: Puis-je encore changer ma réponse à un formulaire ?
 paths: /news/*/form/responses/*/edit

--- a/modules/news/help/scanner-un-billet.md
+++ b/modules/news/help/scanner-un-billet.md
@@ -4,6 +4,7 @@ title: Contrôler les entrées à la porte
 summary: Scanner un billet, retrouver quelqu'un par son nom, suivre le compte des arrivées.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Comment vérifier les billets à l'entrée de notre souper ?
 question: Quelqu'un a perdu son billet, comment le retrouver ?
 question: Que faire si le réseau ne passe pas dans la salle ?

--- a/modules/news/help/suivi-apres-un-evenement.md
+++ b/modules/news/help/suivi-apres-un-evenement.md
@@ -4,6 +4,7 @@ title: Recouper les entrées et les paiements après un évènement
 summary: Croiser l'état du billet et l'état du paiement le lendemain d'une soirée, et relancer sans se tromper de personne.
 category: Espace animateurs
 role_min: intendant
+discovery: 3
 question: Qui est entré à notre souper sans avoir payé ?
 question: Pourquoi le compte des entrées ne correspond-il pas aux places vendues ?
 paths: /news/*/form/responses

--- a/modules/presences/help/presences-anime.md
+++ b/modules/presences/help/presences-anime.md
@@ -4,6 +4,7 @@ title: Préparer un appel à une famille
 summary: La page d'un animé : son taux, sa pente sur l'année, ce qui a été noté, et la correction date par date.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Comment voir si un animé vient moins souvent qu'avant ?
 question: Où retrouver ce qui a été noté sur un animé cette année ?
 question: Comment corriger la présence d'un animé à une date précise ?

--- a/modules/presences/help/presences-feuille.md
+++ b/modules/presences/help/presences-feuille.md
@@ -4,6 +4,7 @@ title: Remplir une feuille de présence
 summary: Pointer les animés d'une réunion, et écrire ce qu'il faut retenir.
 category: Espace animateurs
 role_min: chief
+discovery: 1
 question: Comment pointer les animés au début d'une réunion ?
 question: Comment retrouver ceux que je n'ai pas encore pointés ?
 question: Est-ce que les parents voient ce que j'écris sur un animé ?

--- a/modules/presences/help/presences-registre.md
+++ b/modules/presences/help/presences-registre.md
@@ -4,6 +4,7 @@ title: Suivre les présences de sa section
 summary: La page qui rassemble les évènements de la section, les taux et les feuilles.
 category: Espace animateurs
 role_min: chief
+discovery: 3
 question: Comment savoir qui vient aux réunions de ma section ?
 question: Comment repérer un animé qui ne vient plus ?
 question: Pourquoi je ne vois que ma section dans les présences ?

--- a/modules/registration/help/passage-repartition-automatique.md
+++ b/modules/registration/help/passage-repartition-automatique.md
@@ -4,6 +4,7 @@ title: Répartir automatiquement les passages
 summary: Placer d'un seul geste tous ceux que personne n'a encore placés, et repartir de zéro.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Comment placer d'un coup tous ceux qui restent à placer ?
 question: Comment recommencer la répartition depuis le début ?
 paths: /passage

--- a/modules/registration/help/suivre-une-demande.md
+++ b/modules/registration/help/suivre-une-demande.md
@@ -4,6 +4,7 @@ title: Suivre une demande d'inscription
 summary: La page de suivi, ses statuts, et les adresses e-mail de suivi.
 category: Premiers pas
 role_min: public
+discovery: 3
 question: Où en est ma demande d'inscription ?
 question: Que veut dire « En attente d'examen » sur ma demande ?
 paths: /inscriptions/suivi/demande/*, /inscriptions/suivi/*/*, /inscriptions/suivi/emails/confirm/*

--- a/modules/rental/help/locations-conformite.md
+++ b/modules/rental/help/locations-conformite.md
@@ -4,6 +4,7 @@ title: Le registre de conformité d'un bien
 summary: Les papiers du bien, leur échéance, et le rappel avant qu'elle ne tombe.
 category: Espace membres
 role_min: identified
+discovery: 3
 question: Où noter les contrôles obligatoires d'un bâtiment ?
 question: Quand le contrôle des extincteurs est-il à refaire ?
 paths: /mes-locations/*/conformite

--- a/modules/rental/help/locations-courrier.md
+++ b/modules/rental/help/locations-courrier.md
@@ -4,6 +4,7 @@ title: Le courrier d'une réservation
 summary: Les e-mails rattachés à une réservation, les propositions à confirmer, détacher et déplacer.
 category: Espace membres
 role_min: identified
+discovery: 3
 question: Où voir les e-mails d'un locataire sur sa réservation ?
 question: Que faire d'une proposition de rattachement sur une réservation ?
 question: Que devient un message quand je le détache d'une réservation ?

--- a/modules/rental/help/locations-reglages.md
+++ b/modules/rental/help/locations-reglages.md
@@ -4,6 +4,7 @@ title: Les réglages d'un bien
 summary: Ce qu'un visiteur peut demander, ce que ça coûte, et ce qui est attendu à l'avance.
 category: Espace membres
 role_min: identified
+discovery: 3
 question: Comment fixer le prix de location d'un local ?
 question: Comment imposer une durée minimum de réservation ?
 question: Comment demander une caution sur une location ?

--- a/modules/rental/help/locations-suivi.md
+++ b/modules/rental/help/locations-suivi.md
@@ -4,6 +4,7 @@ title: Suivre votre demande de location
 summary: La page que votre lien vous ouvre : l'état de votre dossier, son prix, et comment demander un changement.
 category: Premiers pas
 role_min: public
+discovery: 3
 question: Où voir l'état de ma réservation de local ?
 question: Comment demander un changement de dates pour ma location ?
 question: J'ai perdu mon lien de suivi de location, que faire ?

--- a/modules/retro/help/config-retro.md
+++ b/modules/retro/help/config-retro.md
@@ -4,6 +4,7 @@ title: Configurer les rétrospectives
 summary: Qui peut créer et clôturer, les valeurs par défaut, la modération IA.
 category: Espace chefs d'U
 role_min: admin
+discovery: 3
 question: Qui a le droit de créer une rétrospective ?
 question: Comment modérer automatiquement les messages d'une rétro ?
 paths: /config/retro

--- a/modules/retro/help/retro-participer.md
+++ b/modules/retro/help/retro-participer.md
@@ -4,6 +4,7 @@ title: Participer à une rétrospective
 summary: Déposer un mot, voter, en tout anonymat.
 category: Premiers pas
 role_min: public
+discovery: 3
 question: Comment participer à une rétrospective de staff ?
 question: Est-ce que mon message de rétrospective est anonyme ?
 paths: /r/*

--- a/modules/trombinoscope/help/trombinoscope.md
+++ b/modules/trombinoscope/help/trombinoscope.md
@@ -4,6 +4,7 @@ title: Le trombinoscope
 summary: Les animateurs de chaque section, en photos, avec leur responsable.
 category: Espace membres
 role_min: identified
+discovery: 1
 question: Qui sont les animateurs de la section de mon enfant ?
 question: Comment savoir qui est responsable d'une section ?
 question: Comment joindre l'animateur de mon enfant par téléphone ?

--- a/modules/usage_stats/help/frequentation.md
+++ b/modules/usage_stats/help/frequentation.md
@@ -4,6 +4,7 @@ title: Lire la fréquentation du site
 summary: Savoir si le site sert, et quels modules personne n'ouvre.
 category: Configuration
 role_min: superadmin
+discovery: 1
 question: Combien de familles se connectent réellement au site ?
 question: Comment savoir quel module personne n'utilise ?
 question: Le site enregistre-t-il qui a consulté quelle page ?

--- a/tests/Core/Help/HelpDiscoveryInvariantsTest.php
+++ b/tests/Core/Help/HelpDiscoveryInvariantsTest.php
@@ -12,7 +12,6 @@ namespace Tests\Core\Help;
 use Core\Help\DiscoveryPriority;
 use Core\Help\HelpRegistry;
 use Core\Help\HelpTopic;
-use Core\Security\Role;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -232,14 +231,44 @@ final class HelpDiscoveryInvariantsTest extends TestCase
     }
 
     /**
-     * A sanity check on the roles themselves: every floor the corpus uses
-     * is a real Role, so a typo cannot quietly create a seventh floor
-     * that the count above then finds empty.
+     * The set of role floors the corpus actually uses, held against the
+     * six it is written for.
+     *
+     * The per-floor count above derives its floors FROM the corpus, which
+     * makes it blind in one direction: a floor that disappears entirely —
+     * the last `intendant` topic deleted, say — is simply no longer
+     * checked, and the suite stays green over a role whose help has gone.
+     * A floor appearing is caught there (it would carry no priority-1
+     * topic); a floor vanishing is caught only here.
+     *
+     * Read off the raw `role_min:` lines rather than through the parser,
+     * like the discovery-value check above: the parser refuses an unknown
+     * role before a HelpTopic is ever built, so anything asked of the
+     * parsed object is answered by PHP's own type system rather than by
+     * the corpus.
      */
-    public function testEveryRoleFloorTheCorpusUsesIsARealRole(): void
+    public function testTheCorpusCoversExactlyTheSixRoleFloorsItIsWrittenFor(): void
     {
-        foreach (self::shippedTopics() as $topic) {
-            $this->assertInstanceOf(Role::class, $topic->roleMin);
+        $expected = ['admin', 'chief', 'identified', 'intendant', 'public', 'superadmin'];
+
+        $found = [];
+        foreach (self::shippedFiles() as $file) {
+            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
+                if (str_starts_with($line, 'role_min:')) {
+                    $found[trim(substr($line, strlen('role_min:')))] = true;
+                }
+            }
         }
+
+        $found = array_keys($found);
+        sort($found);
+
+        $this->assertSame(
+            $expected,
+            $found,
+            "A role floor appearing or disappearing changes what the per-floor rule above has to cover:\n"
+            . "a new one needs three priority-1 topics of its own, and one that vanished means a whole\n"
+            . "role's help has gone. Either is a deliberate change; update this list with it."
+        );
     }
 }

--- a/tests/Core/Help/HelpDiscoveryInvariantsTest.php
+++ b/tests/Core/Help/HelpDiscoveryInvariantsTest.php
@@ -154,16 +154,57 @@ final class HelpDiscoveryInvariantsTest extends TestCase
     {
         $declared = [];
         foreach (self::shippedFiles() as $file) {
-            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
-                $trimmed = trim($line);
-                $colon = strpos($trimmed, ':');
-                if ($colon !== false && trim(substr($trimmed, 0, $colon)) === 'discovery') {
-                    $declared[] = [basename($file), trim(substr($trimmed, $colon + 1))];
-                }
+            foreach (self::frontMatterValues($file, 'discovery') as $value) {
+                $declared[] = [basename($file), $value];
             }
         }
 
         return $declared;
+    }
+
+    /**
+     * Every value one file's FRONT MATTER declares for one key, read the
+     * way Core\Help\HelpFrontMatterParser::parse() reads it: the block
+     * between the opening `---` and the closing one, each line trimmed and
+     * split on its first colon.
+     *
+     * **The bound at the closing `---` is the whole point**, and leaving it
+     * out was the same mistake twice. The parser breaks there; a scan that
+     * does not walks the Markdown body too, and a body is prose — it may
+     * quote front matter, and docs/module-development.md's own example
+     * already carries a column-zero `role_min: public`. Unbounded, the two
+     * checks above fail in opposite directions: the discovery-value one
+     * would refuse a corpus over a value written in a sentence, and the
+     * role-floor one would keep a floor alive on the strength of a line in
+     * a body long after the last real declaration was deleted — silently
+     * defeating the one gap it exists to close.
+     *
+     * A file whose front matter never closes has none the parser would
+     * use, so it yields nothing; `shippedTopics()` already refuses such a
+     * corpus outright through an empty `loadErrors()`.
+     *
+     * @return string[]
+     */
+    private static function frontMatterValues(string $file, string $key): array
+    {
+        $lines = explode("\n", (string) file_get_contents($file));
+        $values = [];
+
+        // Line 0 is the opening delimiter — the parser requires it before
+        // reading anything, so the block starts at line 1.
+        foreach (array_slice($lines, 1) as $line) {
+            $trimmed = trim($line);
+            if ($trimmed === '---') {
+                return $values;
+            }
+
+            $colon = strpos($trimmed, ':');
+            if ($colon !== false && trim(substr($trimmed, 0, $colon)) === $key) {
+                $values[] = trim(substr($trimmed, $colon + 1));
+            }
+        }
+
+        return [];
     }
 
     /**
@@ -277,10 +318,8 @@ final class HelpDiscoveryInvariantsTest extends TestCase
 
         $found = [];
         foreach (self::shippedFiles() as $file) {
-            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
-                if (str_starts_with($line, 'role_min:')) {
-                    $found[trim(substr($line, strlen('role_min:')))] = true;
-                }
+            foreach (self::frontMatterValues($file, 'role_min') as $value) {
+                $found[$value] = true;
             }
         }
 

--- a/tests/Core/Help/HelpDiscoveryInvariantsTest.php
+++ b/tests/Core/Help/HelpDiscoveryInvariantsTest.php
@@ -105,14 +105,9 @@ final class HelpDiscoveryInvariantsTest extends TestCase
     public function testEveryDeclaredDiscoveryValueIsOneTheCharterAllows(): void
     {
         $offenders = [];
-        foreach (self::shippedFiles() as $file) {
-            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
-                if (str_starts_with($line, 'discovery:')) {
-                    $value = trim(substr($line, strlen('discovery:')));
-                    if (DiscoveryPriority::tryFrom($value) === null) {
-                        $offenders[] = basename($file) . ' declares discovery: ' . $value;
-                    }
-                }
+        foreach (self::declaredDiscoveryValues() as [$file, $value]) {
+            if (DiscoveryPriority::tryFrom($value) === null) {
+                $offenders[] = $file . ' declares discovery: ' . $value;
             }
         }
 
@@ -127,11 +122,9 @@ final class HelpDiscoveryInvariantsTest extends TestCase
     public function testNoTopicSpellsOutTheDefault(): void
     {
         $offenders = [];
-        foreach (self::shippedFiles() as $file) {
-            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
-                if (trim($line) === 'discovery: 2') {
-                    $offenders[] = basename($file);
-                }
+        foreach (self::declaredDiscoveryValues() as [$file, $value]) {
+            if ($value === DiscoveryPriority::Normal->value) {
+                $offenders[] = $file;
             }
         }
 
@@ -140,6 +133,37 @@ final class HelpDiscoveryInvariantsTest extends TestCase
             $offenders,
             "The default is written by leaving the key out (design.md §7.11):\n  " . implode("\n  ", $offenders)
         );
+    }
+
+    /**
+     * Every `discovery` value the corpus declares, read the way
+     * Core\Help\HelpFrontMatterParser reads it: the line trimmed, split
+     * on its FIRST colon, key and value trimmed in turn.
+     *
+     * One reader for both tests above, and that is the point rather than
+     * tidiness. They were two near-copies, and each had drifted its own
+     * way: one matched `discovery:` only at column zero, the other
+     * compared the whole line against the single-space spelling, so
+     * `discovery:2` and `discovery:  2` parsed as the default and escaped
+     * the test forbidding it. A check that reads the file differently
+     * from the parser is a check about a file nobody ships.
+     *
+     * @return array<int, array{0: string, 1: string}> file name, declared value
+     */
+    private static function declaredDiscoveryValues(): array
+    {
+        $declared = [];
+        foreach (self::shippedFiles() as $file) {
+            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
+                $trimmed = trim($line);
+                $colon = strpos($trimmed, ':');
+                if ($colon !== false && trim(substr($trimmed, 0, $colon)) === 'discovery') {
+                    $declared[] = [basename($file), trim(substr($trimmed, $colon + 1))];
+                }
+            }
+        }
+
+        return $declared;
     }
 
     /**

--- a/tests/Core/Help/HelpDiscoveryInvariantsTest.php
+++ b/tests/Core/Help/HelpDiscoveryInvariantsTest.php
@@ -1,0 +1,245 @@
+<?php
+
+/*
+ * ScoutMagic — Copyright (C) 2026 Xavier Dubois and contributors
+ * Licensed under AGPL-3.0-or-later. See LICENSE and NOTICE.
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Help;
+
+use Core\Help\DiscoveryPriority;
+use Core\Help\HelpRegistry;
+use Core\Help\HelpTopic;
+use Core\Security\Role;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The editorial half of « Le saviez-vous ? » (ARCHITECTURE.md §8.95),
+ * over the SHIPPED corpus — same scan-the-real-sources shape as
+ * Tests\Core\Help\HelpInvariantsTest, whose structural invariants this
+ * file deliberately does not repeat.
+ *
+ * What is checked here is the running order itself, and it is checked
+ * because nothing else can see it go wrong. A corpus where every topic
+ * sits at the default renders a perfectly good dialog; it just opens on
+ * whatever the seed happened to pick, which is the one thing the
+ * `discovery:` key exists to prevent.
+ */
+final class HelpDiscoveryInvariantsTest extends TestCase
+{
+    /**
+     * Every role floor must lead with something.
+     *
+     * Without this, a role whose topics are all at the default opens on a
+     * card drawn at random from everything it may read — and an animé,
+     * whose corpus is the smallest, is exactly who that happens to first.
+     * Three is the floor a charter can be held to; the aim written in
+     * design.md §7.11 is about twenty priority-1 topics in total, which
+     * over the six floors this corpus uses is four apiece.
+     */
+    private const MIN_HIGH_PER_ROLE = 3;
+
+    /**
+     * And a ceiling, because the aim has an upper half too. A priority-1
+     * topic is worth what it is only by being among the first cards
+     * somebody sees; fifty of them are just the default under another
+     * name. Deliberately loose — this refuses a drift, not a judgement
+     * call about one topic.
+     */
+    private const MAX_HIGH_TOTAL = 30;
+
+    /** @return string repo root */
+    private static function root(): string
+    {
+        return dirname(__DIR__, 3);
+    }
+
+    /**
+     * The whole shipped corpus through the real registry and parser —
+     * core topics plus every module's, enabled or not.
+     *
+     * @return HelpTopic[]
+     */
+    private static function shippedTopics(): array
+    {
+        $registry = new HelpRegistry(self::root() . '/docs/help');
+
+        foreach (glob(self::root() . '/modules/*/module.json') ?: [] as $manifestPath) {
+            $moduleDir = dirname($manifestPath);
+            $data = json_decode((string) file_get_contents($manifestPath), true);
+            $helpDirName = is_array($data) && isset($data['help']['dir']) && is_string($data['help']['dir'])
+                ? $data['help']['dir']
+                : 'help';
+            $helpDir = $moduleDir . '/' . $helpDirName;
+            if (is_dir($helpDir)) {
+                $registry->registerModuleTopics(basename($moduleDir), $helpDir);
+            }
+        }
+
+        self::assertSame([], $registry->loadErrors(), 'The shipped corpus must load without a single error.');
+
+        return array_values($registry->all());
+    }
+
+    /**
+     * @return string[] one absolute path per shipped topic file
+     */
+    private static function shippedFiles(): array
+    {
+        $files = glob(self::root() . '/docs/help/*.md') ?: [];
+        foreach (glob(self::root() . '/modules/*/help/*.md') ?: [] as $moduleFile) {
+            $files[] = $moduleFile;
+        }
+        sort($files);
+
+        return $files;
+    }
+
+    /**
+     * The parser already refuses an unknown value at load, so this reads
+     * the raw lines instead: it is the only way to tell a topic that
+     * declared `2` from one that declared nothing, and the charter has a
+     * rule about exactly that.
+     */
+    public function testEveryDeclaredDiscoveryValueIsOneTheCharterAllows(): void
+    {
+        $offenders = [];
+        foreach (self::shippedFiles() as $file) {
+            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
+                if (str_starts_with($line, 'discovery:')) {
+                    $value = trim(substr($line, strlen('discovery:')));
+                    if (DiscoveryPriority::tryFrom($value) === null) {
+                        $offenders[] = basename($file) . ' declares discovery: ' . $value;
+                    }
+                }
+            }
+        }
+
+        $this->assertSame([], $offenders, "Only 1, 2, 3 and off exist (Core\\Help\\DiscoveryPriority).");
+    }
+
+    /**
+     * `2` is the default and the charter says not to write it: an absent
+     * key already means it, and a hundred and twenty `discovery: 2` lines
+     * would be noise in every file for no information at all.
+     */
+    public function testNoTopicSpellsOutTheDefault(): void
+    {
+        $offenders = [];
+        foreach (self::shippedFiles() as $file) {
+            foreach (explode("\n", (string) file_get_contents($file)) as $line) {
+                if (trim($line) === 'discovery: 2') {
+                    $offenders[] = basename($file);
+                }
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "The default is written by leaving the key out (design.md §7.11):\n  " . implode("\n  ", $offenders)
+        );
+    }
+
+    /**
+     * The invariant this file exists for.
+     */
+    public function testEveryRoleFloorHasAtLeastThreeTopicsAtPriorityOne(): void
+    {
+        $highPerRole = [];
+        $floors = [];
+        foreach (self::shippedTopics() as $topic) {
+            $floors[$topic->roleMin->value] = true;
+            if ($topic->discovery === DiscoveryPriority::High) {
+                $highPerRole[$topic->roleMin->value] = ($highPerRole[$topic->roleMin->value] ?? 0) + 1;
+            }
+        }
+
+        $this->assertNotEmpty($floors, 'No topic at all — did the corpus move?');
+
+        $short = [];
+        foreach (array_keys($floors) as $floor) {
+            $count = $highPerRole[$floor] ?? 0;
+            if ($count < self::MIN_HIGH_PER_ROLE) {
+                $short[] = sprintf('%s: %d (needs %d)', $floor, $count, self::MIN_HIGH_PER_ROLE);
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $short,
+            "A role floor with no priority-1 topic opens its dialog on a card drawn at random, which is what\n"
+            . "the editorial order exists to prevent. Tag one more `discovery: 1` at each of these floors:\n  "
+            . implode("\n  ", $short)
+        );
+    }
+
+    public function testPriorityOneStaysASmallSet(): void
+    {
+        $high = array_filter(
+            self::shippedTopics(),
+            static fn (HelpTopic $t): bool => $t->discovery === DiscoveryPriority::High
+        );
+
+        $this->assertLessThanOrEqual(
+            self::MAX_HIGH_TOTAL,
+            count($high),
+            'A priority-1 topic is worth what it is by being among the first cards somebody sees. '
+            . 'Past a few dozen, it is the default under another name — retag some to 2 or 3 '
+            . 'rather than raising this ceiling.'
+        );
+    }
+
+    /**
+     * The four ids §8.95 names as the kind of subject that must never be
+     * discovered — account hygiene, a legal obligation, a technical
+     * operation — plus the four the roadmap of this feature listed
+     * alongside them. Each is consulted at the moment it is needed; a
+     * card spent on one is a card wasted.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function topicsThatMustNeverBeOffered(): array
+    {
+        return array_map(
+            static fn (string $id): array => [$id],
+            array_combine(
+                $ids = [
+                    'cookies', 'donnees-personnelles', 'se-connecter', 'mon-compte',
+                    'reinitialisation', 'installation-serveur', 'sauvegardes', 'mises-a-jour',
+                ],
+                $ids
+            )
+        );
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('topicsThatMustNeverBeOffered')]
+    public function testHygieneAndOperationsTopicsAreNeverOffered(string $id): void
+    {
+        $topics = [];
+        foreach (self::shippedTopics() as $topic) {
+            $topics[$topic->id] = $topic;
+        }
+
+        $this->assertArrayHasKey($id, $topics, "The corpus no longer ships '{$id}' — this list needs revisiting.");
+        $this->assertSame(
+            DiscoveryPriority::Off,
+            $topics[$id]->discovery,
+            "'{$id}' is consulted at the moment it is needed, never discovered (design.md §7.11)."
+        );
+    }
+
+    /**
+     * A sanity check on the roles themselves: every floor the corpus uses
+     * is a real Role, so a typo cannot quietly create a seventh floor
+     * that the count above then finds empty.
+     */
+    public function testEveryRoleFloorTheCorpusUsesIsARealRole(): void
+    {
+        foreach (self::shippedTopics() as $topic) {
+            $this->assertInstanceOf(Role::class, $topic->roleMin);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Dernière des trois itérations du chantier « Astuces de découverte ». IT-01 a livré la clé `discovery`, IT-02 le dialogue — mais **les 135 sujets du corpus étaient tous restés au défaut**, donc la fenêtre s'ouvrait sur ce que la graine tirait. Ça s'affiche parfaitement, et c'est exactement pour ça que ça demande un test plutôt qu'une convention.

**La passe éditoriale.** Les 135 sujets relus un par un : **24 en priorité 1**, 40 en `3`, 13 en `off`, et 58 laissés au défaut — c'est-à-dire sans clé du tout, la charte disant de ne pas l'écrire.

Les `1`, par plancher de rôle :

| Plancher | Sujets |
|---|---|
| `public` | `installer-application`, `un-email-plusieurs-animes`, `recherche-dans-l-aide`, `modifier-une-reponse` |
| `identified` | `mes-paiements`, `envoyer-une-photo`, `notifications-preferences`, `trombinoscope` |
| `intendant` | `etiquettes-paiement`, `importer-extraits`, `rappels`, `campagnes` |
| `chief` | `presences-feuille`, `publipostage`, `camps-encoder`, `envoi-de-mails` |
| `admin` | `points-attention`, `attestations-couverture`, `edition-du-site`, `justesse-des-tarifs` |
| `superadmin` | `config-emails`, `frequentation`, `connecteur-ia`, `config-desk` |

**Quatre par plancher, et ce nombre est la rencontre des deux moitiés de la règle.** Le document vise « une vingtaine » ET exige trois `1` par plancher ; le corpus utilise six planchers, donc le plancher seul impose dix-huit. À vingt, deux planchers vivraient au minimum exact et le premier sujet retiré ou passé en `off` casserait le test. Quatre chacun garde une marge d'un sujet partout.

**`tests/Core/Help/HelpDiscoveryInvariantsTest`** tient six choses sur le corpus livré :

1. toute valeur `discovery` déclarée est valide ;
2. **aucun sujet n'écrit `discovery: 2`** — une règle que rien ne vérifie est une règle que la moitié du corpus finira par enfreindre ;
3. **chaque plancher de rôle porte au moins trois sujets en priorité 1**, sans quoi un animé — dont le corpus est le plus petit — n'ouvre que sur une carte tirée au hasard ;
4. les huit sujets que §8.95 nomme comme non découvrables (`cookies`, `donnees-personnelles`, `se-connecter`, `mon-compte`, `reinitialisation`, `installation-serveur`, `sauvegardes`, `mises-a-jour`) sont bien en `off` ;
5. **la priorité 1 reste un petit ensemble** — trente au plus, voir ci-dessous ;
6. **le corpus couvre exactement les six planchers de rôle pour lequel il est écrit.** Celui-ci ferme une cécité du point 3 : le comptage par plancher tire ses planchers du corpus lui-même, donc un plancher qui *apparaît* y est attrapé (il ne porterait aucun sujet en priorité 1) mais un plancher qui *disparaît* — le dernier sujet `intendant` supprimé — cesse simplement d'être vérifié, et la suite resterait verte sur un rôle dont l'aide a disparu.

**Un plafond, que le document ne demandait pas.** Sans borne haute, « vise une vingtaine » n'est appliqué par rien et le corpus dérive vers cinquante prioritaires — le défaut sous un autre nom. Il est délibérément lâche : il refuse une dérive, pas un arbitrage sur un sujet.

**La charte va où un auteur la cherchera** : `design.md` §7.11 pour la règle et ses exemples, et la section Aide de `docs/module-development.md` à côté de `paths` et `question`.

Le journal du chantier — les trois itérations, décisions autonomes et divergences comprises — est complet dans `docs/chantiers/astuces-decouverte.md`.

**Divergences relevées** : le corpus compte 135 sujets (44 core, 91 modules) et non « ~120 » ; cinq `off` de plus que le minimum du document (`se-desinscrire`, `comptes-superadmin`, `config-rgpd`, `support-github`, `support-sondes-email`), chacun tombant dans une des trois catégories qu'il énumère.

## Un défaut préexistant trouvé en route, et pas corrigé ici : #274

Le palier **complet** de l'E2E (`scripts/e2e.sh` sans `--grep-invert @full`, celui qui inclut `zz-module-boot-matrix.spec.js`) est rouge : 22 scénarios de la matrice échouent tous sur `/config/retro` → 403 au lieu de 200.

Ce n'est pas cette PR. Le même palier complet lancé sur `origin/main` (`de1062c`) échoue sur **exactement les mêmes 22 scénarios**, au fichier près. La cause est que `RetroConfigController` résout l'année *effective* là où `BannerConfigController` résout l'année calculée par la date, et que `scout-year-transition.spec.js` — qui passe avant la matrice, laquelle est préfixée `zz-` pour ça — avance l'année du staff. Analyse complète, options costées et tests à écrire dans **#274**.

Le job `End-to-end (browser)` de la CI fait tourner le palier de confiance (`npm run e2e`), qui ne contient pas la matrice : il est vert ici et sur `main`.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 16 297 tests)
- [x] PHPStan passes (`vendor/bin/phpstan analyse`)
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — *sans objet, aucun fichier `public/assets/js/` touché*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ioS5VnCjdW9a8vCJpddda

---
_Generated by [Claude Code](https://claude.ai/code/session_017ioS5VnCjdW9a8vCJpddda)_