### PR TITLE
Les deux trouvailles SonarCloud du filtre de section, ni l'une ni l'autre exemptée

### DIFF
--- a/public/assets/js/registration-public-form.js
+++ b/public/assets/js/registration-public-form.js
@@ -84,16 +84,20 @@
     function updateDesiredSections(branchId) {
         if (!desiredSection) return;
 
-        var options = desiredSection.options;
+        // Copied into an array rather than iterated in place: `options`
+        // is a live HTMLOptionsCollection, and this loop writes to the
+        // very properties it reads.
+        var options = /** @type {HTMLOptionElement[]} */ (
+            Array.prototype.slice.call(desiredSection.options)
+        );
 
-        for (var i = 0; i < options.length; i++) {
-            var option = options[i];
-            var optionBranch = option.getAttribute('data-branch-id');
+        options.forEach(function (option) {
+            var optionBranch = option.dataset.branchId;
 
             // « Aucune préférence » carries no branch and is always on
             // offer: not choosing is a valid answer at every age.
             var offered = branchId === null
-                || optionBranch === null
+                || optionBranch === undefined
                 || Number(optionBranch) === branchId;
 
             option.hidden = !offered;
@@ -102,7 +106,7 @@
             if (!offered && option.selected) {
                 desiredSection.value = '';
             }
-        }
+        });
     }
 
     /**


### PR DESCRIPTION
## Description

Suite de #271, qui a fusionné pendant que ce correctif était en vol. Aucune issue nouvelle : ce sont les deux findings que SonarCloud a rendus **sur** #271, sur le code que cette PR y a ajouté.

| Règle | Ligne | Sévérité | Tags |
|---|---|---|---|
| `javascript:S4138` — `for-of` plutôt qu'une boucle `for` indexée | `registration-public-form.js:89` | MINOR | `clumsy` |
| `javascript:S7761` — `.dataset` plutôt que `getAttribute(…)` | `registration-public-form.js:91` | MAJOR | `api,dom,editable-source,html` |

Le portail de qualité de #271 est passé (les deux sont des `CODE_SMELL`), mais l'unique exemption d'AGENTS.md § SonarQube Cloud release gate demande les **trois** conditions à la fois — `MAINTAINABILITY`, `LOW`, et taguée `convention`. Ni l'une ni l'autre ne l'est. Elles bloqueraient donc la prochaine release, et « no finding of your own left unfiled » vaut aussi pour les siennes propres.

### Ce que ça change dans le code

La collection est copiée dans un tableau avant d'être parcourue, ce qui n'est pas qu'une concession au linter : `select.options` est une `HTMLOptionsCollection` **vive**, et cette boucle écrit dans les propriétés (`hidden`, `disabled`, `selected`) qu'elle lit. La copie était déjà la bonne forme ; la règle l'a rendue visible.

`option.dataset.branchId` rend `undefined` quand l'attribut est absent, là où `getAttribute` rendait `null` — le test « Aucune préférence » suit, et c'est le seul endroit où la distinction compte.

### Vérification

Les 24 specs de `tests/js/registration-public-form.test.js` restent vertes, dont les cinq qui échouent sans le filtre. `npm run test:coverage` (ce que lance `javascript-tests`) : 119 fichiers, 2 071 tests. `npm run typecheck` : 0 nouvelle trouvaille. `vendor/bin/phpstan analyse` : no errors.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] Automated tests are written/updated for this change — les specs de #271 couvrent ce code et restent vertes ; ce diff ne change aucun comportement
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: `npm run test:coverage` passe, specs existantes inchangées

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1

---
_Generated by [Claude Code](https://claude.ai/code/session_0121PxXgPDhEBzmpbb1Er1s1)_