### PR TITLE
`submit-once.js` déclarait en `var`, et la porte SonarCloud a refusé la release

### DIFF
--- a/public/assets/js/submit-once.js
+++ b/public/assets/js/submit-once.js
@@ -26,7 +26,7 @@
         // prevented keeps the confirmation in front of the action.
         if (event.defaultPrevented) return;
 
-        var form = /** @type {HTMLFormElement|null} */ (event.target);
+        const form = /** @type {HTMLFormElement|null} */ (event.target);
         if (form === null || typeof form.matches !== 'function' || !form.matches('form[data-submit-once]')) {
             return;
         }
@@ -35,7 +35,7 @@
         // (a form failing its own validation never gets here), so the
         // controls can go now.
         form.querySelectorAll('button[type="submit"], input[type="submit"]').forEach(function (control) {
-            var button = /** @type {HTMLButtonElement|HTMLInputElement} */ (control);
+            const button = /** @type {HTMLButtonElement|HTMLInputElement} */ (control);
             // `disabled` on a submit button is not submitted, and this
             // form's action does not read it — but a `name`d one would
             // be lost, so it is only ever disabled AFTER the browser has


### PR DESCRIPTION
## Description

`javascript:S3504` (« Unexpected var, use let or const instead »), deux fois — `public/assets/js/submit-once.js` lignes 29 et 38, en `MAINTAINABILITY` / `HIGH`.

L'exemption de la règle de release (AGENTS.md § SonarQube Cloud release gate) ne couvre que ce qui est `MAINTAINABILITY` **et** `LOW` **et** étiqueté `convention`, les trois à la fois. Ces deux signalements sont `HIGH` et étiquetés `bad-practice`/`es2015` : ils bloquent, et ils ont bloqué. `scripts/release.sh` s'est arrêté sur sa cinquième porte — les quatre premières (déploiement, CI, sécurité, fraîcheur) étaient vertes — **avant tout commit et tout tag**.

Le fichier est arrivé avec #257 (le garde-fou contre le double envoi, issue #251). C'est du code neuf, ce que SonarCloud regarde de plus près.

## Le correctif

Ni `form` ni `button` n'est réaffecté : `const` dans les deux cas. Aucun changement de comportement.

Les autres fichiers récents — `help-discovery.js` (16 `var`), `presences-lines.js` (41) — déclarent de la même façon sans être signalés : l'analyseur n'infère pas la même version d'ECMAScript partout, et une requête sur la règle confirme que ces deux occurrences sont les **seules** ouvertes du dépôt. Ce changement ne touche donc que ce que la porte nomme, plutôt que de réécrire des fichiers qu'elle ne signale pas — la réécriture générale, si elle est souhaitée, est une décision de style à prendre pour elle-même et pas au milieu d'une release.

## Vérifications locales

| Commande | Résultat |
|---|---|
| `npm run typecheck` | 0 nouveau signalement |
| `npx vitest run tests/js/submit-once.test.js` | 3 tests verts |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMwzSa71um2vhmSocpH623