### PR TITLE
Pendant la transition d'année, les droits se calculent sur les deux années, pas sur une

### DIFF
--- a/core/Http/Controller/AuthController.php
+++ b/core/Http/Controller/AuthController.php
@@ -23,6 +23,7 @@ use Core\Security\LastLoginMethodCookie;
 use Core\Security\LoginThrottler;
 use Core\Security\PasswordAuthMethod;
 use Core\Security\PendingMagicLink;
+use Core\Security\Role;
 use Core\Security\RoleResolver;
 use Core\Security\WebAuthnService;
 use Twig\Environment;
@@ -436,8 +437,7 @@ class AuthController extends AbstractController
     private function resolveRole(string $email, ?int $userAccountId = null): string
     {
         if ($this->roleResolver !== null && $this->scoutYearResolver !== null) {
-            $currentYear = $this->scoutYearResolver->getCurrentPublicYear();
-            return $this->roleResolver->resolve($email, $currentYear['id']);
+            return $this->roleResolver->resolveAcrossYears($email, $this->accessYearIds());
         }
 
         // Fallback for cases without role resolver
@@ -455,10 +455,32 @@ class AuthController extends AbstractController
     private function storeLinkedMembers(string $email): void
     {
         if ($this->roleResolver !== null && $this->scoutYearResolver !== null) {
-            $currentYear = $this->scoutYearResolver->getCurrentPublicYear();
-            $linked = $this->roleResolver->getLinkedMemberYears($email, $currentYear['id']);
+            $linked = $this->roleResolver->getLinkedMemberYearsAcrossYears($email, $this->accessYearIds());
             AuthSession::setLinkedMembers($linked);
         }
+    }
+
+    /**
+     * The years a login may be judged on: the public current year, plus
+     * the date-computed one while the two are one year apart.
+     *
+     * No session preview and no role, deliberately — both arguments to
+     * Core\ScoutYear\ScoutYearResolver::getAccessYearIds() are about a
+     * signed-in request, and this runs before there is one. `Role::PUBLIC`
+     * therefore skips the preview and staff-year branches and lands on the
+     * public current year, which is what a login has always been judged
+     * on; the second year is the transition allowance this method exists
+     * to add (see that method's docblock, and issue #238).
+     *
+     * @return list<int>
+     */
+    private function accessYearIds(): array
+    {
+        if ($this->scoutYearResolver === null) {
+            return [];
+        }
+
+        return $this->scoutYearResolver->getAccessYearIds(null, Role::PUBLIC);
     }
 
     /**
@@ -488,8 +510,7 @@ class AuthController extends AbstractController
             return true;
         }
 
-        $currentYear = $this->scoutYearResolver->getCurrentPublicYear();
-        return $this->roleResolver->isEmailAuthorizedToLogin($email, $currentYear['id']);
+        return $this->roleResolver->isEmailAuthorizedToLoginAcrossYears($email, $this->accessYearIds());
     }
 
     /**

--- a/core/Member/MemberService.php
+++ b/core/Member/MemberService.php
@@ -290,6 +290,32 @@ class MemberService
     }
 
     /**
+     * Staff d'U in ANY of the given years — the question every caller that
+     * gates a page on « chef d'unité » should be asking during the
+     * scout-year transition.
+     *
+     * The years come from Core\ScoutYear\ScoutYearResolver::
+     * getAccessYearIds(), whose docblock carries the reasoning and the
+     * bound: the effective year, plus the date-computed one while the two
+     * are one year apart. Asking either alone locks the real chief out for
+     * the fortnight between the 1st of September and the Desk import —
+     * which is the failure this exists to prevent, reported as issue #238
+     * and only half-fixed by narrowing retro to the effective year.
+     *
+     * @param list<int> $scoutYearIds
+     */
+    public function isUnitChiefAcrossYears(string $email, array $scoutYearIds): bool
+    {
+        foreach ($scoutYearIds as $scoutYearId) {
+            if ($this->isUnitChief($email, $scoutYearId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Check if a user account (by email) has access to a specific member_year.
      *
      * Access granted if:

--- a/core/Member/SectionStaffAuthorizationService.php
+++ b/core/Member/SectionStaffAuthorizationService.php
@@ -127,6 +127,40 @@ class SectionStaffAuthorizationService
     }
 
     /**
+     * The sections this account staffs in ANY of the given years, merged.
+     *
+     * The « animateur » half of the same transition rule Core\ScoutYear\
+     * ScoutYearResolver::getAccessYearIds() states in full: between the 1st
+     * of September and the Desk import, a section's staff exists in one of
+     * the two years and not the other, so asking one year alone empties the
+     * Espace animateurs of somebody who staffs a section either side of the
+     * turnover.
+     *
+     * Deduplicated by section id — a section staffed in both years is one
+     * section — and re-sorted afterwards, since merging two individually
+     * ordered lists does not give an ordered list and every section picker
+     * on the site shares this order (ARCHITECTURE.md §8.8).
+     *
+     * @param list<int> $scoutYearIds
+     * @return array<int, array<string, mixed>>
+     */
+    public function getStaffedSectionsAcrossYears(string $email, string $accountRole, array $scoutYearIds): array
+    {
+        $byId = [];
+        foreach ($scoutYearIds as $scoutYearId) {
+            foreach ($this->getStaffedSections($email, $accountRole, $scoutYearId) as $section) {
+                $byId[(int) $section['id']] = $section;
+            }
+        }
+
+        $sections = array_values($byId);
+        usort($sections, static fn(array $a, array $b): int
+            => [$a['branch_sort_order'], $a['desk_code']] <=> [$b['branch_sort_order'], $b['desk_code']]);
+
+        return $sections;
+    }
+
+    /**
      * Whether this account staffs the section a given ANIMÉ member-year
      * belongs to — the write-side boundary §8.33 describes, as one
      * predicate rather than a copy per caller.
@@ -160,6 +194,33 @@ class SectionStaffAuthorizationService
                 $this->sectionService->getSectionAnimeMemberYearIds((int) $section['id'], $scoutYearId),
                 true
             )) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * The same predicate over several years.
+     *
+     * Delegates PER YEAR rather than pairing the merged section list with
+     * each year's animés in turn, and that is not an implementation
+     * detail: a member-year belongs to exactly one scout year, so crossing
+     * a section staffed in one year with the animés of the other would
+     * grant writes over animés this account staffs in neither. The union
+     * belongs on the answer, never inside the question.
+     *
+     * @param list<int> $scoutYearIds
+     */
+    public function staffsAnimeMemberYearAcrossYears(
+        string $email,
+        string $accountRole,
+        array $scoutYearIds,
+        int $memberYearId
+    ): bool {
+        foreach ($scoutYearIds as $scoutYearId) {
+            if ($this->staffsAnimeMemberYear($email, $accountRole, $scoutYearId, $memberYearId)) {
                 return true;
             }
         }

--- a/core/Member/SectionStaffAuthorizationService.php
+++ b/core/Member/SectionStaffAuthorizationService.php
@@ -127,40 +127,6 @@ class SectionStaffAuthorizationService
     }
 
     /**
-     * The sections this account staffs in ANY of the given years, merged.
-     *
-     * The « animateur » half of the same transition rule Core\ScoutYear\
-     * ScoutYearResolver::getAccessYearIds() states in full: between the 1st
-     * of September and the Desk import, a section's staff exists in one of
-     * the two years and not the other, so asking one year alone empties the
-     * Espace animateurs of somebody who staffs a section either side of the
-     * turnover.
-     *
-     * Deduplicated by section id — a section staffed in both years is one
-     * section — and re-sorted afterwards, since merging two individually
-     * ordered lists does not give an ordered list and every section picker
-     * on the site shares this order (ARCHITECTURE.md §8.8).
-     *
-     * @param list<int> $scoutYearIds
-     * @return array<int, array<string, mixed>>
-     */
-    public function getStaffedSectionsAcrossYears(string $email, string $accountRole, array $scoutYearIds): array
-    {
-        $byId = [];
-        foreach ($scoutYearIds as $scoutYearId) {
-            foreach ($this->getStaffedSections($email, $accountRole, $scoutYearId) as $section) {
-                $byId[(int) $section['id']] = $section;
-            }
-        }
-
-        $sections = array_values($byId);
-        usort($sections, static fn(array $a, array $b): int
-            => [$a['branch_sort_order'], $a['desk_code']] <=> [$b['branch_sort_order'], $b['desk_code']]);
-
-        return $sections;
-    }
-
-    /**
      * Whether this account staffs the section a given ANIMÉ member-year
      * belongs to — the write-side boundary §8.33 describes, as one
      * predicate rather than a copy per caller.
@@ -194,33 +160,6 @@ class SectionStaffAuthorizationService
                 $this->sectionService->getSectionAnimeMemberYearIds((int) $section['id'], $scoutYearId),
                 true
             )) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * The same predicate over several years.
-     *
-     * Delegates PER YEAR rather than pairing the merged section list with
-     * each year's animés in turn, and that is not an implementation
-     * detail: a member-year belongs to exactly one scout year, so crossing
-     * a section staffed in one year with the animés of the other would
-     * grant writes over animés this account staffs in neither. The union
-     * belongs on the answer, never inside the question.
-     *
-     * @param list<int> $scoutYearIds
-     */
-    public function staffsAnimeMemberYearAcrossYears(
-        string $email,
-        string $accountRole,
-        array $scoutYearIds,
-        int $memberYearId
-    ): bool {
-        foreach ($scoutYearIds as $scoutYearId) {
-            if ($this->staffsAnimeMemberYear($email, $accountRole, $scoutYearId, $memberYearId)) {
                 return true;
             }
         }

--- a/core/ScoutYear/ScoutYearResolver.php
+++ b/core/ScoutYear/ScoutYearResolver.php
@@ -64,6 +64,87 @@ class ScoutYearResolver
     }
 
     /**
+     * The scout years an ACCESS decision may consider — the effective year,
+     * plus the date-computed one while the two are one year apart.
+     *
+     * WHY TWO YEARS. A scout year turns over on the 1st of September; the
+     * roster of the new one arrives with the Desk import, which is days or
+     * weeks later, and the site's own transition workflow (Core\ScoutYear\
+     * ScoutYearTransitionService) deliberately holds the public year back
+     * until its last step. So there is a window — every year, on every
+     * installation — in which "which year is this?" has two defensible
+     * answers, and a membership written in one of them is invisible from
+     * the other. Asking either question alone locks somebody out of pages
+     * they held yesterday and will hold tomorrow: on the date-computed
+     * year, nobody is Staff d'U until the import lands; on the effective
+     * year, nobody is yet whatever the new roster makes them.
+     *
+     * So an access decision takes the HIGHEST answer the two years give,
+     * rather than one year's answer. Deliberately a widening: somebody who
+     * was a unit chief in one of the two years keeps the pages that gate on
+     * it for as long as both years are in play. That is the point — the
+     * alternative is a chief locked out of their own configuration in the
+     * fortnight the site is most in use.
+     *
+     * ADJACENT ONLY, and that bound is what keeps this from being
+     * permanent. The two years disagree from the 1st of September until
+     * somebody runs the workflow's last step, and nothing forces them to:
+     * on an installation where the public year was pinned and forgotten,
+     * an unbounded rule would grant a long-departed chief their access for
+     * ever. One year apart is every real transition and no stale pin.
+     *
+     * SYMMETRIC, because the transition runs in both directions. Step 9
+     * (« Activer l'année cible pour les staffs ») can put the effective
+     * year AHEAD of the calendar in August; the 1st of September puts the
+     * calendar ahead of the public year. Both are the same fortnight seen
+     * from two sides.
+     *
+     * Read-only on purpose: findByLabel() rather than getCurrentYear(),
+     * which calls ensureYear() and would CREATE next year's row as a side
+     * effect of asking an authorization question. A year that does not
+     * exist yet holds no memberships, so there is nothing to union with.
+     *
+     * @return list<int> The effective year first, then the date-computed
+     *                   one when it qualifies. Never empty, never repeats.
+     */
+    public function getAccessYearIds(?int $sessionOverrideId, Role $role): array
+    {
+        $effective = $this->getEffectiveYear($sessionOverrideId, $role);
+        $ids = [$effective->id];
+
+        $dateLabel = ScoutYearService::labelForDate(new \DateTimeImmutable());
+        $dateYear = $this->scoutYearService->findByLabel($dateLabel);
+        if ($dateYear === null || (int) $dateYear['id'] === $effective->id) {
+            return $ids;
+        }
+
+        if (self::areAdjacent($effective->label, (string) $dateYear['label'])) {
+            $ids[] = (int) $dateYear['id'];
+        }
+
+        return $ids;
+    }
+
+    /**
+     * Whether two `YYYY-YYYY` labels name consecutive scout years, in
+     * either order.
+     *
+     * The label is the comparison rather than start_date because the label
+     * is what ScoutYearService::ensureYear() derives every other column
+     * from — a row whose dates were edited by hand still sorts by the year
+     * it is called.
+     */
+    private static function areAdjacent(string $one, string $other): bool
+    {
+        $startOfOne = (int) explode('-', $one)[0];
+        $startOfOther = (int) explode('-', $other)[0];
+
+        return $startOfOne !== 0
+            && $startOfOther !== 0
+            && abs($startOfOne - $startOfOther) === 1;
+    }
+
+    /**
      * Get the public current year: the `current_scout_year_id` setting when set
      * and resolvable, otherwise the date-computed year (auto-created).
      *

--- a/core/Security/RoleResolver.php
+++ b/core/Security/RoleResolver.php
@@ -156,6 +156,72 @@ class RoleResolver
     }
 
     /**
+     * The three questions above, asked of SEVERAL years at once and
+     * answered with the most generous result — which is what every access
+     * decision should ask during the scout-year transition.
+     *
+     * The years come from Core\ScoutYear\ScoutYearResolver::
+     * getAccessYearIds(), whose docblock carries the whole reasoning: the
+     * effective year, plus the date-computed one while the two are one
+     * year apart, and never further. Between the 1st of September and the
+     * Desk import of the new roster the two disagree about every
+     * membership on the site, so a role resolved from one of them alone
+     * demotes people who have gone nowhere.
+     *
+     * Each delegates per year rather than widening the SQL, so the rules
+     * the single-year versions encode — the unsubscribed Desk address, the
+     * deactivated account refused before the super-admin shortcut, the
+     * secondary-address union — hold identically here and cannot drift
+     * from them.
+     *
+     * @param list<int> $scoutYearIds
+     */
+    public function resolveAcrossYears(string $email, array $scoutYearIds): string
+    {
+        $best = Role::PUBLIC;
+        foreach ($scoutYearIds as $scoutYearId) {
+            $role = Role::fromString($this->resolve($email, $scoutYearId));
+            if ($role->level() > $best->level()) {
+                $best = $role;
+            }
+        }
+
+        // No years at all is not a caller this can serve, and silently
+        // answering PUBLIC would be a demotion nothing asked for.
+        return $best === Role::PUBLIC ? Role::IDENTIFIED->value : $best->value;
+    }
+
+    /**
+     * @param list<int> $scoutYearIds
+     */
+    public function isEmailAuthorizedToLoginAcrossYears(string $email, array $scoutYearIds): bool
+    {
+        foreach ($scoutYearIds as $scoutYearId) {
+            if ($this->isEmailAuthorizedToLogin($email, $scoutYearId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<int> $scoutYearIds
+     * @return int[]
+     */
+    public function getLinkedMemberYearsAcrossYears(string $email, array $scoutYearIds): array
+    {
+        $ids = [];
+        foreach ($scoutYearIds as $scoutYearId) {
+            foreach ($this->getLinkedMemberYears($email, $scoutYearId) as $id) {
+                $ids[$id] = $id;
+            }
+        }
+
+        return array_values($ids);
+    }
+
+    /**
      * The Desk-imported match (member_years.email_blind_index, as
      * always — minus any member whose Desk address was itself
      * unsubscribed) unioned with every member reachable only through a

--- a/core/Security/SessionRevalidator.php
+++ b/core/Security/SessionRevalidator.php
@@ -53,13 +53,19 @@ class SessionRevalidator
      * Returns true when the session survived (or there was none to check),
      * false when it was revoked and the caller is now anonymous.
      *
-     * $currentScoutYearId is a callable rather than a value so an anonymous
+     * $accessScoutYearIds is a callable rather than a value so an anonymous
      * visitor — the majority of traffic on a public site — costs nothing
-     * here: there is no session to check, so the year is never resolved.
+     * here: there is no session to check, so the years are never resolved.
      *
-     * @param callable(): int $currentScoutYearId
+     * It yields the YEARS, plural, an access decision may consider — see
+     * Core\ScoutYear\ScoutYearResolver::getAccessYearIds(). Revalidation
+     * runs on every request of every open session, so judging it on one
+     * year while the login gate judged on two would sign people out one
+     * request after letting them in, every September.
+     *
+     * @param callable(): list<int> $accessScoutYearIds
      */
-    public function revalidate(callable $currentScoutYearId): bool
+    public function revalidate(callable $accessScoutYearIds): bool
     {
         if (!AuthSession::isAuthenticated()) {
             return true;
@@ -83,19 +89,19 @@ class SessionRevalidator
             return false;
         }
 
-        $scoutYearId = $currentScoutYearId();
+        $scoutYearIds = $accessScoutYearIds();
 
         // Same gate AuthController applies at login: a user_accounts row is
         // never sufficient on its own, the address must still match a real
         // member of the unit this year (super-admins excepted). Letting an
         // existing session outlive that would just be the login gate with
         // an up-to-30-day grace period.
-        if (!$this->roleResolver->isEmailAuthorizedToLogin($account->email, $scoutYearId)) {
+        if (!$this->roleResolver->isEmailAuthorizedToLoginAcrossYears($account->email, $scoutYearIds)) {
             $this->revoke('no_longer_a_member', $userAccountId);
             return false;
         }
 
-        $freshRole = $this->roleResolver->resolve($account->email, $scoutYearId);
+        $freshRole = $this->roleResolver->resolveAcrossYears($account->email, $scoutYearIds);
         if ($freshRole !== AuthSession::getRole()) {
             $this->journalService?->log(
                 'core', 'session_role_refreshed', 'security',

--- a/modules/banner/src/Controller/BannerConfigController.php
+++ b/modules/banner/src/Controller/BannerConfigController.php
@@ -8,14 +8,16 @@ declare(strict_types=1);
 
 namespace Modules\Banner\Controller;
 
-use Core\Config\ScoutYearService;
 use Core\Http\Controller\AbstractController;
 use Core\Http\Request;
 use Core\Http\Response;
 use Core\Journal\JournalService;
 use Core\Member\MemberService;
+use Core\ScoutYear\ScoutYearResolver;
+use Core\ScoutYear\ScoutYearSession;
 use Core\Security\AuthSession;
 use Core\Security\CsrfGuard;
+use Core\Security\Role;
 use Core\Service\IntegerInput;
 use Modules\Banner\Service\BannerException;
 use Modules\Banner\Service\BannerService;
@@ -44,7 +46,7 @@ class BannerConfigController extends AbstractController
         private BannerService $bannerService,
         private JournalService $journalService,
         private MemberService $memberService,
-        private ScoutYearService $scoutYearService
+        private ScoutYearResolver $scoutYearResolver
     ) {
     }
 
@@ -244,8 +246,17 @@ class BannerConfigController extends AbstractController
     private function requireUnitChief(): ?Response
     {
         $email = AuthSession::getEmail();
-        $scoutYearId = $this->scoutYearService->getCurrentYear()['id'];
-        if ($email === null || !$this->memberService->isUnitChief($email, $scoutYearId)) {
+        // Both years an access decision may consider, never the
+        // date-computed one alone: that one rolls over on the 1st of
+        // September and answers « chef d'unité ? » false for everybody
+        // until the new roster is imported, locking the real chief out of
+        // this page for a fortnight every year. See Core\ScoutYear\
+        // ScoutYearResolver::getAccessYearIds().
+        $scoutYearIds = $this->scoutYearResolver->getAccessYearIds(
+            ScoutYearSession::getPreviewId(),
+            Role::fromString(AuthSession::getRole())
+        );
+        if ($email === null || !$this->memberService->isUnitChiefAcrossYears($email, $scoutYearIds)) {
             return (new Response('', 403))->setBody('Forbidden');
         }
 

--- a/modules/rental/src/Controller/RentalManagementController.php
+++ b/modules/rental/src/Controller/RentalManagementController.php
@@ -500,7 +500,13 @@ class RentalManagementController extends AbstractController
     public function myRentals(Request $request, array $params): Response
     {
         $email = AuthSession::getEmail();
-        $scoutYearId = $this->scoutYearId();
+        // No scoutYearId() here any more, and not merely because nothing
+        // reads it: that call goes through getCurrentYear() → ensureYear(),
+        // which INSERTS next year's row on the first request after the 1st
+        // of September. A stray write on the hot path of a method whose
+        // access decisions this change made read-only is exactly what
+        // ScoutYearResolver::getAccessYearIds() avoids by design.
+        //
         // Across both years, because this list is the ENTRY GATE: the 403
         // below fires on an empty one, before any of the finer checks
         // further down this method ever runs. Widening those alone would

--- a/modules/rental/src/Controller/RentalManagementController.php
+++ b/modules/rental/src/Controller/RentalManagementController.php
@@ -501,7 +501,13 @@ class RentalManagementController extends AbstractController
     {
         $email = AuthSession::getEmail();
         $scoutYearId = $this->scoutYearId();
-        $assets = $this->authorizationService->listManageableAssets($email, $scoutYearId);
+        // Across both years, because this list is the ENTRY GATE: the 403
+        // below fires on an empty one, before any of the finer checks
+        // further down this method ever runs. Widening those alone would
+        // have been cosmetic — a Staff d'U whose member_year row sits in
+        // the other of the two adjacent years would still have been turned
+        // away here.
+        $assets = $this->authorizationService->listManageableAssetsAcrossYears($email, $this->accessYearIds());
 
         // Someone who manages nothing is still refused (403 — the menu never
         // offered them this page), but with a page saying what this space is

--- a/modules/rental/src/Controller/RentalManagementController.php
+++ b/modules/rental/src/Controller/RentalManagementController.php
@@ -17,7 +17,10 @@ use Core\Http\FlashMessage;
 use Core\Http\Request;
 use Core\Http\Response;
 use Core\Member\MemberService;
+use Core\ScoutYear\ScoutYearResolver;
+use Core\ScoutYear\ScoutYearSession;
 use Core\Security\AuthSession;
+use Core\Security\Role;
 use Core\Security\CsrfGuard;
 use Core\Service\DateInput;
 use Core\Service\IntegerInput;
@@ -139,6 +142,7 @@ class RentalManagementController extends AbstractController
         Environment $twig,
         private RentalAuthorizationService $authorizationService,
         private ScoutYearService $scoutYearService,
+        private ScoutYearResolver $scoutYearResolver,
         private RentalAssetRepository $assetRepository,
         private RentalBookingRepository $bookingRepository,
         private AuditService $audit,
@@ -256,9 +260,9 @@ class RentalManagementController extends AbstractController
             'payment_account_name' => $this->financeAccountName($paymentSettings->financeAccountId),
             // Whether to offer the link to the page that pins it, rather
             // than a dead end for somebody who cannot reach it.
-            'can_pin_account' => $this->authorizationService->isUnitStaff(
+            'can_pin_account' => $this->authorizationService->isUnitStaffAcrossYears(
                 AuthSession::getEmail(),
-                $this->scoutYearId()
+                $this->accessYearIds()
             ),
             'deposit_modes' => DepositMode::all(),
             'csrf_token' => CsrfGuard::generateToken(),
@@ -528,7 +532,7 @@ class RentalManagementController extends AbstractController
 
         return $this->render('@rental/management/my_rentals.html.twig', [
             'assets' => $assets,
-            'is_unit_staff' => $this->authorizationService->isUnitStaff($email, $scoutYearId),
+            'is_unit_staff' => $this->authorizationService->isUnitStaffAcrossYears($email, $this->accessYearIds()),
             'pending_bookings' => $pending,
             'pending_counts' => $countsByAsset,
             'assets_by_id' => $this->indexById($assets),
@@ -2457,9 +2461,9 @@ class RentalManagementController extends AbstractController
 
     private function mayManage(RentalAsset $asset): bool
     {
-        return $this->authorizationService->canManageAsset(
+        return $this->authorizationService->canManageAssetAcrossYears(
             AuthSession::getEmail(),
-            $this->scoutYearId(),
+            $this->accessYearIds(),
             $asset
         );
     }
@@ -2570,6 +2574,27 @@ class RentalManagementController extends AbstractController
     private function scoutYearId(): int
     {
         return (int) $this->scoutYearService->getCurrentYear()['id'];
+    }
+
+    /**
+     * The years an ACCESS decision may consider — distinct from
+     * scoutYearId() above, which stays the year rows are SCOPED to.
+     *
+     * The two are not interchangeable and the difference is the point: who
+     * may open this area is a question about a person, and gets the
+     * transition allowance (Core\ScoutYear\ScoutYearResolver::
+     * getAccessYearIds()); which bookings and managers are listed is a
+     * question about data, and stays on one year, or a page would show two
+     * years of rows merged into one list.
+     *
+     * @return list<int>
+     */
+    private function accessYearIds(): array
+    {
+        return $this->scoutYearResolver->getAccessYearIds(
+            ScoutYearSession::getPreviewId(),
+            Role::fromString(AuthSession::getRole())
+        );
     }
 
     /**

--- a/modules/rental/src/Controller/RentalPricingController.php
+++ b/modules/rental/src/Controller/RentalPricingController.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace Modules\Rental\Controller;
 
-use Core\Config\ScoutYearService;
+use Core\ScoutYear\ScoutYearResolver;
+use Core\ScoutYear\ScoutYearSession;
+use Core\Security\Role;
 use Core\Http\Controller\AbstractController;
 use Core\Http\FlashMessage;
 use Core\Http\Request;
@@ -55,7 +57,7 @@ class RentalPricingController extends AbstractController
         private RentalAvailabilityService $availabilityService,
         private RentalAuthorizationService $authorizationService,
         private RentalAssetRepository $assetRepository,
-        private ScoutYearService $scoutYearService,
+        private ScoutYearResolver $scoutYearResolver,
         /**
          * Optional (§6.19): null on an installation without the Finance
          * module, where the payments block explains that instead of
@@ -357,9 +359,17 @@ class RentalPricingController extends AbstractController
             return null;
         }
 
-        return $this->authorizationService->canManageAsset(
+        // The years an access decision may consider, not the date-computed
+        // one alone — see Core\ScoutYear\ScoutYearResolver::
+        // getAccessYearIds(). Staff d'U manage every asset implicitly, and
+        // on the calendar year alone nobody is Staff d'U between the 1st of
+        // September and the import of the new roster.
+        return $this->authorizationService->canManageAssetAcrossYears(
             AuthSession::getEmail(),
-            (int) $this->scoutYearService->getCurrentYear()['id'],
+            $this->scoutYearResolver->getAccessYearIds(
+                ScoutYearSession::getPreviewId(),
+                Role::fromString(AuthSession::getRole())
+            ),
             $asset
         ) ? $asset : null;
     }

--- a/modules/rental/src/Service/RentalAuthorizationService.php
+++ b/modules/rental/src/Service/RentalAuthorizationService.php
@@ -125,6 +125,51 @@ class RentalAuthorizationService
      * Whether $email is a unit chief (Staff d'U), and therefore an implicit
      * manager of every asset.
      */
+    /**
+     * The three questions above, over the years an access decision may
+     * consider — Core\ScoutYear\ScoutYearResolver::getAccessYearIds(),
+     * whose docblock carries the reasoning and the one-year bound.
+     *
+     * Rental is the widest surface this affects: isUnitStaff() makes Staff
+     * d'U an implicit manager of every asset, so on the date-computed year
+     * alone the whole management area empties out for them between the 1st
+     * of September and the import of the new roster.
+     *
+     * @param list<int> $scoutYearIds
+     */
+    public function canManageAssetAcrossYears(?string $email, array $scoutYearIds, RentalAsset $asset): bool
+    {
+        return $this->canManageAssetIdAcrossYears($email, $scoutYearIds, $asset->id);
+    }
+
+    /**
+     * @param list<int> $scoutYearIds
+     */
+    public function canManageAssetIdAcrossYears(?string $email, array $scoutYearIds, int $assetId): bool
+    {
+        foreach ($scoutYearIds as $scoutYearId) {
+            if ($this->canManageAssetId($email, $scoutYearId, $assetId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param list<int> $scoutYearIds
+     */
+    public function isUnitStaffAcrossYears(?string $email, array $scoutYearIds): bool
+    {
+        foreach ($scoutYearIds as $scoutYearId) {
+            if ($this->isUnitStaff($email, $scoutYearId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function isUnitStaff(?string $email, int $scoutYearId): bool
     {
         if ($email === null || $email === '') {

--- a/modules/rental/src/Service/RentalAuthorizationService.php
+++ b/modules/rental/src/Service/RentalAuthorizationService.php
@@ -101,6 +101,52 @@ class RentalAuthorizationService
     }
 
     /**
+     * The same list over the years an access decision may consider.
+     *
+     * This is the ENTRY POINT of « Mes locations », and that is why it
+     * matters more than the checks further in: the page 403s on an empty
+     * list before any of them runs, so widening those alone would have
+     * been cosmetic. A Staff d'U or an asset manager whose member_year row
+     * sits in the other of the two adjacent years is exactly who this
+     * exists to let back in.
+     *
+     * Deduplicated by asset id and re-sorted by name: the union of two
+     * individually ordered lists is not an ordered list, and Staff d'U in
+     * either year already returns every asset.
+     *
+     * @param list<int> $scoutYearIds
+     * @return RentalAsset[]
+     */
+    public function listManageableAssetsAcrossYears(?string $email, array $scoutYearIds): array
+    {
+        $byId = [];
+        foreach ($scoutYearIds as $scoutYearId) {
+            foreach ($this->listManageableAssets($email, $scoutYearId) as $asset) {
+                $byId[$asset->id] = $asset;
+            }
+        }
+
+        $assets = array_values($byId);
+        usort($assets, static fn(RentalAsset $a, RentalAsset $b): int => strcmp($a->name, $b->name));
+
+        return $assets;
+    }
+
+    /**
+     * @param list<int> $scoutYearIds
+     */
+    public function managesAnyAssetAcrossYears(?string $email, array $scoutYearIds): bool
+    {
+        foreach ($scoutYearIds as $scoutYearId) {
+            if ($this->managesAnyAsset($email, $scoutYearId)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Whether $email manages at least one asset — the cheap gate behind the
      * "Mes locations" menu entry, which must not run a full asset load on
      * every request that builds a menu.
@@ -122,11 +168,7 @@ class RentalAuthorizationService
     }
 
     /**
-     * Whether $email is a unit chief (Staff d'U), and therefore an implicit
-     * manager of every asset.
-     */
-    /**
-     * The three questions above, over the years an access decision may
+     * The four questions above, over the years an access decision may
      * consider — Core\ScoutYear\ScoutYearResolver::getAccessYearIds(),
      * whose docblock carries the reasoning and the one-year bound.
      *
@@ -170,6 +212,10 @@ class RentalAuthorizationService
         return false;
     }
 
+    /**
+     * Whether $email is a unit chief (Staff d'U), and therefore an implicit
+     * manager of every asset.
+     */
     public function isUnitStaff(?string $email, int $scoutYearId): bool
     {
         if ($email === null || $email === '') {

--- a/modules/rental/src/Service/RentalMenuHookService.php
+++ b/modules/rental/src/Service/RentalMenuHookService.php
@@ -50,7 +50,8 @@ class RentalMenuHookService implements MenuEntryProvider
     public function __construct(
         private RentalAssetRepository $assetRepository,
         private RentalAuthorizationService $authorizationService,
-        private int $scoutYearId
+        /** @var list<int> The years an access decision may consider. */
+        private array $scoutYearIds
     ) {
     }
 
@@ -79,7 +80,7 @@ class RentalMenuHookService implements MenuEntryProvider
         // "Mes locations" — the managers' daily entry point (§6.5). Only
         // for someone who actually manages something, so an ordinary
         // identified visitor never sees it.
-        if ($email !== null && $this->authorizationService->managesAnyAsset($email, $this->scoutYearId)) {
+        if ($email !== null && $this->authorizationService->managesAnyAssetAcrossYears($email, $this->scoutYearIds)) {
             $entries[] = new MenuEntry(
                 MenuBuilder::MENU_ESPACE_ANIMES,
                 'Mes locations',

--- a/modules/retro/src/Controller/RetroBoardController.php
+++ b/modules/retro/src/Controller/RetroBoardController.php
@@ -91,13 +91,14 @@ class RetroBoardController extends AbstractController
             return false;
         }
 
-        // The effective year, never the date-computed one: see
-        // Controller\RetroConfigController for what the latter does to the
-        // real chef d'unité on the 1st of September.
-        return $this->boardService->isUnitChief($email, $this->scoutYearService->getEffectiveYear(
+        // Both years an access decision may consider, never one: see
+        // Core\ScoutYear\ScoutYearResolver::getAccessYearIds() for what
+        // either one alone does to the real chef d'unité around the 1st of
+        // September.
+        return $this->boardService->isUnitChiefAcrossYears($email, $this->scoutYearService->getAccessYearIds(
             ScoutYearSession::getPreviewId(),
             Role::fromString(AuthSession::getRole())
-        )->id);
+        ));
     }
 
     /**

--- a/modules/retro/src/Controller/RetroConfigController.php
+++ b/modules/retro/src/Controller/RetroConfigController.php
@@ -180,16 +180,17 @@ class RetroConfigController extends AbstractController
     private function requireUnitChief(): ?Response
     {
         $email = AuthSession::getEmail();
-        // The year this session is actually looking at. On the
-        // date-computed year, « est-ce le chef d'unité ? » is false for
-        // everybody between the 1st of September and the import of the new
-        // roster — a fail-closed that locks the real chief out of the
-        // configuration of a board they are looking at in another year.
-        $scoutYearId = $this->scoutYearService->getEffectiveYear(
+        // Both years this session may be judged on, not one. Asking the
+        // date-computed year alone makes « est-ce le chef d'unité ? » false
+        // for everybody between the 1st of September and the import of the
+        // new roster; asking the effective year alone moves that same
+        // lockout to whoever the new roster has not named yet. See
+        // Core\ScoutYear\ScoutYearResolver::getAccessYearIds().
+        $scoutYearIds = $this->scoutYearService->getAccessYearIds(
             ScoutYearSession::getPreviewId(),
             Role::fromString(AuthSession::getRole())
-        )->id;
-        if ($email === null || !$this->memberService->isUnitChief($email, $scoutYearId)) {
+        );
+        if ($email === null || !$this->memberService->isUnitChiefAcrossYears($email, $scoutYearIds)) {
             return (new Response('', 403))->setBody('Forbidden');
         }
 

--- a/modules/retro/src/Service/BoardService.php
+++ b/modules/retro/src/Service/BoardService.php
@@ -108,6 +108,18 @@ class BoardService implements RetroEventLinkLookupInterface
     }
 
     /**
+     * The same question over the years an access decision may consider —
+     * Core\ScoutYear\ScoutYearResolver::getAccessYearIds(), which carries
+     * the reasoning for why there are two of them during the transition.
+     *
+     * @param list<int> $scoutYearIds
+     */
+    public function isUnitChiefAcrossYears(string $email, array $scoutYearIds): bool
+    {
+        return $this->memberService->isUnitChiefAcrossYears($email, $scoutYearIds);
+    }
+
+    /**
      * Events available for the picker: -10/+15 days around today, scoped
      * server-side by role/section (module spec — never just hidden
      * client-side). $sectionId is ignored (every section visible) when

--- a/public/index.php
+++ b/public/index.php
@@ -1617,7 +1617,9 @@ $roleLabelMap = [
 // doesn't itself depend on the role we are about to validate.
 $sessionRevalidator = new \Core\Security\SessionRevalidator($userAccountRepo, $roleResolver);
 $sessionRevalidator->setJournalService($journalService);
-$sessionRevalidator->revalidate(static fn(): int => (int) $scoutYearResolver->getCurrentPublicYear()['id']);
+$sessionRevalidator->revalidate(
+    static fn(): array => $scoutYearResolver->getAccessYearIds(null, \Core\Security\Role::PUBLIC)
+);
 
 // Set Twig globals for auth state (after session is started)
 $currentRole = AuthSession::getRole();
@@ -3825,7 +3827,7 @@ if ($isEnabled('banner')) {
     $frontController->registerController(
         \Modules\Banner\Controller\BannerConfigController::class,
         new \Modules\Banner\Controller\BannerConfigController($twig, $bannerService, $journalService, $memberService,
-            $scoutYearService)
+            $scoutYearResolver)
     );
 
     // The home page's banner hook (§7.4) — resolved per request through
@@ -6656,7 +6658,7 @@ if ($isEnabled('rental')) {
             // `role_min: identified` on every one of this controller's
             // routes: the authorization service, not the route guard, is
             // what keeps one asset's tariff out of another manager's reach.
-            $rentalAuthorizationService, $rentalAssetRepository, $scoutYearService,
+            $rentalAuthorizationService, $rentalAssetRepository, $scoutYearResolver,
             $rentalPaymentService
         )
     );
@@ -6832,7 +6834,7 @@ if ($isEnabled('rental')) {
     $frontController->registerController(
         \Modules\Rental\Controller\RentalManagementController::class,
         new \Modules\Rental\Controller\RentalManagementController(
-            $twig, $rentalAuthorizationService, $scoutYearService, $rentalAssetRepository,
+            $twig, $rentalAuthorizationService, $scoutYearService, $scoutYearResolver, $rentalAssetRepository,
             $rentalBookingRepository, $auditService, $rentalCommentRepository,
             $rentalChangeRequestRepository, $rentalOperationsService, $rentalBlockService,
             $rentalAvailabilityService, $rentalPricingService, $memberService,

--- a/public/index.php
+++ b/public/index.php
@@ -6900,7 +6900,13 @@ if ($isEnabled('rental')) {
     $rentalMenuHookService = new \Modules\Rental\Service\RentalMenuHookService(
         $rentalAssetRepository,
         $rentalAuthorizationService,
-        $rentalCurrentYearId
+        // Both years, so the menu entry appears for exactly the people
+        // /mes-locations lets in — a screen that hides what the page
+        // grants is the same defect as one that offers what it refuses.
+        $scoutYearResolver->getAccessYearIds(
+            \Core\ScoutYear\ScoutYearSession::getPreviewId(),
+            \Core\Security\Role::fromString(AuthSession::getRole())
+        )
     );
     $rentalMenuEntries = $dynamicMenuRegistrar->register(
         $menuBuilder,

--- a/tests/Core/Member/MemberServiceTest.php
+++ b/tests/Core/Member/MemberServiceTest.php
@@ -60,6 +60,86 @@ class MemberServiceTest extends TestCase
         return (int) $this->pdo->lastInsertId();
     }
 
+    /**
+     * A member_year in $scoutYearId whose MAIN function sits in the
+     * "Staff d'U" section — what MemberService::isUnitChief() answers true
+     * for, and the only fixture shape that reaches it.
+     */
+    private function createUnitChief(string $email, int $scoutYearId): void
+    {
+        $encryption = new \Core\Security\EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
+        $blindIndex = $encryption->blindIndex(strtolower($email), 'email');
+
+        $this->pdo->exec("INSERT INTO members (desk_id) VALUES ('CDU_" . uniqid() . "')");
+        $memberId = (int) $this->pdo->lastInsertId();
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO member_years (member_id, scout_year_id, first_name_encrypted, last_name_encrypted,'
+            . ' email_encrypted, email_blind_index) VALUES (?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $memberId,
+            $scoutYearId,
+            $encryption->encrypt('Chef', 'member_years.first_name'),
+            $encryption->encrypt('Unite', 'member_years.last_name'),
+            $encryption->encrypt($email, 'member_years.email'),
+            $blindIndex,
+        ]);
+        $memberYearId = (int) $this->pdo->lastInsertId();
+
+        $this->pdo->exec(
+            "INSERT OR IGNORE INTO age_branches (desk_code, label, sort_order) VALUES ('STAFF', 'Staff', 99)"
+        );
+        $branchId = (int) $this->pdo->query('SELECT id FROM age_branches ORDER BY id DESC LIMIT 1')->fetchColumn();
+        $this->pdo->exec(
+            "INSERT OR IGNORE INTO sections (desk_code, name, age_branch_id, is_active)"
+            . " VALUES ('" . \Core\Member\UnitStaffSectionService::DESK_CODE . "', \"Staff d'U\", {$branchId}, 1)"
+        );
+        $sectionId = (int) $this->pdo->query(
+            "SELECT id FROM sections WHERE desk_code = '" . \Core\Member\UnitStaffSectionService::DESK_CODE . "'"
+        )->fetchColumn();
+
+        $this->pdo->exec(
+            "INSERT OR IGNORE INTO functions (desk_code, label, role, confirmed)"
+            . " VALUES ('CDU', \"Animateur d'unite\", 'admin', 1)"
+        );
+        $functionId = (int) $this->pdo->query("SELECT id FROM functions WHERE desk_code = 'CDU'")->fetchColumn();
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO member_functions (member_year_id, function_id, section_id, age_branch_id, is_main_function)'
+            . ' VALUES (?, ?, ?, ?, 1)'
+        );
+        $stmt->execute([$memberYearId, $functionId, $sectionId, $branchId]);
+    }
+
+    public function testIsUnitChiefAcrossYearsAnswersForEitherYear(): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO scout_years (label, start_date, end_date, is_current)"
+            . " VALUES ('2026-2027', '2026-09-01', '2027-08-31', 0)"
+        );
+        $nextYear = (int) $this->pdo->lastInsertId();
+
+        // Staff d'U in the year that is ending, absent from the roster of
+        // the one that has begun: the fortnight #238 is about.
+        $this->createUnitChief('cdu@example.com', $this->scoutYearId);
+
+        $this->assertTrue($this->service->isUnitChief('cdu@example.com', $this->scoutYearId));
+        $this->assertFalse($this->service->isUnitChief('cdu@example.com', $nextYear));
+        $this->assertTrue(
+            $this->service->isUnitChiefAcrossYears('cdu@example.com', [$nextYear, $this->scoutYearId])
+        );
+    }
+
+    public function testIsUnitChiefAcrossYearsStaysFalseWhenNeitherYearQualifies(): void
+    {
+        $this->createTestMember('plain@example.com');
+
+        $this->assertFalse(
+            $this->service->isUnitChiefAcrossYears('plain@example.com', [$this->scoutYearId, $this->scoutYearId + 999])
+        );
+    }
+
     public function testGetLinkedMembersReturnsCorrectMembersForAnEmail(): void
     {
         $memberYearId1 = $this->createTestMember($this->testEmail, 'Baloo');

--- a/tests/Core/ScoutYear/ScoutYearResolverTest.php
+++ b/tests/Core/ScoutYear/ScoutYearResolverTest.php
@@ -172,4 +172,79 @@ class ScoutYearResolverTest extends TestCase
         // The year after the public year is created so it can be previewed/imported.
         $this->assertContains('2026-2027', $labels);
     }
+
+    // ---------------------------------------------------------------
+    // getAccessYearIds() — the transition allowance.
+    //
+    // These tests are written against the CALENDAR, because the method is:
+    // the second year it may return is the one today's date falls in, so a
+    // fixture that hardcoded '2025-2026' would assert something different
+    // every September. calendarLabel() below derives the labels the same
+    // way ScoutYearService::labelForDate() does, offset by whole years, so
+    // each case says "one year before today's", "two after", and stays
+    // true whenever it is run.
+    // ---------------------------------------------------------------
+
+    /**
+     * Today's scout-year label, shifted by $yearOffset whole years.
+     */
+    private function calendarLabel(int $yearOffset = 0): string
+    {
+        $today = ScoutYearService::labelForDate(new \DateTimeImmutable());
+        $start = (int) explode('-', $today)[0] + $yearOffset;
+
+        return sprintf('%d-%d', $start, $start + 1);
+    }
+
+    public function testAccessYearsAreTheEffectiveYearAloneWhenTheCalendarYearHasNoRow(): void
+    {
+        $this->setPublicYear($this->year2023);
+
+        // Nothing has created today's year, and asking must not.
+        $this->assertSame([$this->year2023], $this->resolver->getAccessYearIds(null, Role::PUBLIC));
+        $this->assertNull($this->scoutYearService->findByLabel($this->calendarLabel()));
+    }
+
+    public function testAccessYearsAddTheCalendarYearWhenItFollowsTheEffectiveOne(): void
+    {
+        $calendar = $this->scoutYearService->ensureYear($this->calendarLabel());
+        $previous = $this->scoutYearService->ensureYear($this->calendarLabel(-1));
+        $this->setPublicYear($previous);
+
+        // The 1st-of-September case: the calendar has moved on, the public
+        // year has not, and a membership in either still counts.
+        $this->assertSame([$previous, $calendar], $this->resolver->getAccessYearIds(null, Role::PUBLIC));
+    }
+
+    public function testAccessYearsAddTheCalendarYearWhenItPRECEDESTheEffectiveOne(): void
+    {
+        $calendar = $this->scoutYearService->ensureYear($this->calendarLabel());
+        $next = $this->scoutYearService->ensureYear($this->calendarLabel(1));
+        $this->setStaffYear($next);
+
+        // The other half of the same fortnight: step 9 of the transition
+        // activates next year for the staffs BEFORE the calendar turns
+        // over, so the effective year runs ahead of the date.
+        $this->assertSame([$next, $calendar], $this->resolver->getAccessYearIds(null, Role::CHIEF));
+    }
+
+    public function testAccessYearsRefuseAYearThatIsTwoApart(): void
+    {
+        $this->scoutYearService->ensureYear($this->calendarLabel());
+        $stale = $this->scoutYearService->ensureYear($this->calendarLabel(-2));
+        $this->setPublicYear($stale);
+
+        // A public year nobody has advanced in two seasons is an oversight,
+        // not a transition — and the widening has to stop somewhere or a
+        // long-departed chief keeps their access for ever.
+        $this->assertSame([$stale], $this->resolver->getAccessYearIds(null, Role::PUBLIC));
+    }
+
+    public function testAccessYearsNeverRepeatTheSameYearTwice(): void
+    {
+        $calendar = $this->scoutYearService->ensureYear($this->calendarLabel());
+        $this->setPublicYear($calendar);
+
+        $this->assertSame([$calendar], $this->resolver->getAccessYearIds(null, Role::PUBLIC));
+    }
 }

--- a/tests/Core/Security/DeactivatedAccountLoginTest.php
+++ b/tests/Core/Security/DeactivatedAccountLoginTest.php
@@ -78,6 +78,12 @@ class DeactivatedAccountLoginTest extends TestCase
             'start_date' => '2025-09-01',
             'end_date' => '2026-08-31',
         ]);
+        // The login gate asks for the YEARS an access decision may consider
+        // (Core\ScoutYear\ScoutYearResolver::getAccessYearIds()), not the
+        // public year alone. One year here: this fixture has no second one,
+        // and the transition allowance is exercised by that resolver's own
+        // tests rather than restated in every login scenario.
+        $this->scoutYearResolver->method('getAccessYearIds')->willReturn([$this->scoutYearId]);
 
         $this->csrfToken = CsrfGuard::generateToken();
     }

--- a/tests/Core/Security/RoleResolverTest.php
+++ b/tests/Core/Security/RoleResolverTest.php
@@ -50,6 +50,16 @@ class RoleResolverTest extends TestCase
 
     private function createMemberWithFunction(string $email, string $functionCode, string $role, bool $confirmed): void
     {
+        $this->createMemberWithFunctionInYear($email, $functionCode, $role, $confirmed, $this->scoutYearId);
+    }
+
+    private function createMemberWithFunctionInYear(
+        string $email,
+        string $functionCode,
+        string $role,
+        bool $confirmed,
+        int $scoutYearId
+    ): void {
         $normalizedEmail = strtolower($email);
         $blindIndex = $this->encryption->blindIndex($normalizedEmail, 'email');
 
@@ -72,7 +82,7 @@ class RoleResolverTest extends TestCase
              VALUES (?, ?, ?, ?, ?, ?)'
         );
         $stmt->execute([
-            $memberId, $this->scoutYearId,
+            $memberId, $scoutYearId,
             $this->encryption->encrypt('Test', 'member_years.first_name'),
             $this->encryption->encrypt('User', 'member_years.last_name'),
             $this->encryption->encrypt($normalizedEmail, 'member_years.email'),
@@ -324,5 +334,80 @@ class RoleResolverTest extends TestCase
         $resolver = $this->resolverWithSecondaryEmailSupport();
 
         $this->assertFalse($resolver->isEmailAuthorizedToLogin('unauthorized-secondary@test.com', $this->scoutYearId));
+    }
+
+    // ---------------------------------------------------------------
+    // The transition allowance: the same three questions asked of both
+    // years at once. Which years those are is Core\ScoutYear\
+    // ScoutYearResolver::getAccessYearIds()' business and is tested there;
+    // what these pin is that asking several returns the most generous
+    // answer rather than the last one, and that one year still behaves
+    // exactly as it always did.
+    // ---------------------------------------------------------------
+
+    private function createSecondYear(): int
+    {
+        $this->pdo->exec(
+            "INSERT INTO scout_years (label, start_date, end_date, is_current)"
+            . " VALUES ('2026-2027', '2026-09-01', '2027-08-31', 0)"
+        );
+
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    public function testResolveAcrossYearsTakesTheHighestRoleOfEitherYear(): void
+    {
+        $secondYear = $this->createSecondYear();
+        // A chief last year, nothing but a member in the new roster: the
+        // fortnight after the 1st of September, read from one year, demotes
+        // somebody who has gone nowhere.
+        $this->createMemberWithFunction('turnover@test.com', 'Chef', 'chief', true);
+        $this->createMemberWithFunctionInYear('turnover@test.com', 'Animé', 'identified', true, $secondYear);
+
+        $this->assertSame('identified', $this->resolver->resolve('turnover@test.com', $secondYear));
+        $this->assertSame('chief', $this->resolver->resolveAcrossYears('turnover@test.com', [$secondYear, $this->scoutYearId]));
+    }
+
+    public function testResolveAcrossYearsIsUnchangedForASingleYear(): void
+    {
+        $this->createMemberWithFunction('single@test.com', 'Chef', 'chief', true);
+
+        $this->assertSame('chief', $this->resolver->resolveAcrossYears('single@test.com', [$this->scoutYearId]));
+    }
+
+    public function testResolveAcrossYearsNeverDemotesBelowIdentified(): void
+    {
+        // No years at all is not a caller this can serve; answering PUBLIC
+        // would be a demotion nothing asked for.
+        $this->assertSame('identified', $this->resolver->resolveAcrossYears('nobody@test.com', []));
+    }
+
+    public function testLoginIsAuthorizedByMembershipInEitherYear(): void
+    {
+        $secondYear = $this->createSecondYear();
+        $this->createUserAccount('lastyear@test.com');
+        $this->createMemberWithFunction('lastyear@test.com', 'Animé', 'identified', true);
+
+        // Not in the new roster yet — and that is exactly who must not be
+        // locked out while the import is still pending.
+        $this->assertFalse($this->resolver->isEmailAuthorizedToLogin('lastyear@test.com', $secondYear));
+        $this->assertTrue(
+            $this->resolver->isEmailAuthorizedToLoginAcrossYears('lastyear@test.com', [$secondYear, $this->scoutYearId])
+        );
+    }
+
+    public function testLinkedMemberYearsAcrossYearsUnionsAndDeduplicates(): void
+    {
+        $secondYear = $this->createSecondYear();
+        $this->createMemberWithFunction('linked-both@test.com', 'Animé', 'identified', true);
+        $this->createMemberWithFunctionInYear('linked-both@test.com', 'Animé', 'identified', true, $secondYear);
+
+        $ids = $this->resolver->getLinkedMemberYearsAcrossYears(
+            'linked-both@test.com',
+            [$this->scoutYearId, $secondYear, $this->scoutYearId]
+        );
+
+        $this->assertCount(2, $ids);
+        $this->assertSame(array_values(array_unique($ids)), $ids);
     }
 }

--- a/tests/Core/Security/SessionRevalidatorTest.php
+++ b/tests/Core/Security/SessionRevalidatorTest.php
@@ -55,14 +55,14 @@ class SessionRevalidatorTest extends TestCase
         $account = $this->userRepo->create('member@test.com', true);
         AuthSession::login($account->id, $account->email, 'superadmin');
 
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertTrue(AuthSession::isAuthenticated());
         $this->assertSame('superadmin', AuthSession::getRole());
     }
 
     public function testNoSessionIsNothingToRevalidate(): void
     {
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertFalse(AuthSession::isAuthenticated());
     }
 
@@ -84,7 +84,7 @@ class SessionRevalidatorTest extends TestCase
         $_SESSION['_auth']['issued_at'] = time() - 60;
         $this->userRepo->updatePasswordHash($account->id, password_hash('BrandNewPassword1!', PASSWORD_DEFAULT));
 
-        $this->assertFalse($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertFalse($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertFalse(AuthSession::isAuthenticated());
         $this->assertNull(AuthSession::getUserAccountId());
     }
@@ -102,7 +102,7 @@ class SessionRevalidatorTest extends TestCase
         $this->userRepo->updatePasswordHash($account->id, password_hash('BrandNewPassword1!', PASSWORD_DEFAULT));
         AuthSession::refreshIssuedAt();
 
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertTrue(AuthSession::isAuthenticated());
     }
 
@@ -118,13 +118,13 @@ class SessionRevalidatorTest extends TestCase
         unset($_SESSION['_auth']['issued_at']);
 
         // No password ever set → no stamp → nothing to revoke against.
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertTrue(AuthSession::isAuthenticated());
 
         $this->userRepo->updatePasswordHash($account->id, password_hash('BrandNewPassword1!', PASSWORD_DEFAULT));
         unset($_SESSION['_auth']['issued_at']);
 
-        $this->assertFalse($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertFalse($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertFalse(AuthSession::isAuthenticated());
     }
 
@@ -135,7 +135,7 @@ class SessionRevalidatorTest extends TestCase
 
         $this->pdo->prepare('DELETE FROM user_accounts WHERE id = ?')->execute([$account->id]);
 
-        $this->assertFalse($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertFalse($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertFalse(AuthSession::isAuthenticated());
     }
 
@@ -155,7 +155,7 @@ class SessionRevalidatorTest extends TestCase
         // The function is taken away mid-session.
         $this->pdo->exec('DELETE FROM member_functions');
 
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertTrue(AuthSession::isAuthenticated());
         $this->assertSame('identified', AuthSession::getRole());
     }
@@ -171,7 +171,7 @@ class SessionRevalidatorTest extends TestCase
 
         $this->pdo->exec("UPDATE functions SET role = 'admin' WHERE desk_code = 'Equipier'");
 
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertSame('admin', AuthSession::getRole());
     }
 
@@ -189,7 +189,7 @@ class SessionRevalidatorTest extends TestCase
         $this->pdo->exec('DELETE FROM member_functions');
         $this->pdo->exec('DELETE FROM member_years');
 
-        $this->assertFalse($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertFalse($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertFalse(AuthSession::isAuthenticated());
     }
 
@@ -203,7 +203,7 @@ class SessionRevalidatorTest extends TestCase
         $account = $this->userRepo->create('operator@test.com', true);
         AuthSession::login($account->id, $account->email, 'superadmin');
 
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertTrue(AuthSession::isAuthenticated());
         $this->assertSame('superadmin', AuthSession::getRole());
     }
@@ -251,11 +251,11 @@ class SessionRevalidatorTest extends TestCase
     {
         $account = $this->userRepo->create('admin@test.com', true);
         AuthSession::login($account->id, $account->email, 'superadmin');
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
 
         $this->userRepo->deactivate($account->id);
 
-        $this->assertFalse($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertFalse($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertFalse(AuthSession::isAuthenticated());
     }
 
@@ -264,8 +264,8 @@ class SessionRevalidatorTest extends TestCase
         $account = $this->userRepo->create('admin@test.com', true);
         AuthSession::login($account->id, $account->email, 'superadmin');
 
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertTrue(AuthSession::isAuthenticated());
     }
 
@@ -282,7 +282,7 @@ class SessionRevalidatorTest extends TestCase
 
         AuthSession::login($account->id, $account->email, 'superadmin');
 
-        $this->assertTrue($this->revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertTrue($this->revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertTrue(AuthSession::isAuthenticated());
     }
 }

--- a/tests/Integration/SecondaryEmailLoginIdentityTest.php
+++ b/tests/Integration/SecondaryEmailLoginIdentityTest.php
@@ -259,7 +259,7 @@ class SecondaryEmailLoginIdentityTest extends TestCase
         $this->pdo->exec("UPDATE member_emails SET status = 'inactive'");
 
         $revalidator = new SessionRevalidator($this->userRepo, $this->roleResolver);
-        $this->assertFalse($revalidator->revalidate(fn(): int => $this->scoutYearId));
+        $this->assertFalse($revalidator->revalidate(fn(): array => [$this->scoutYearId]));
         $this->assertFalse(AuthSession::isAuthenticated());
 
         // And a fresh link never establishes a session again.

--- a/tests/Modules/Banner/Controller/BannerConfigControllerTest.php
+++ b/tests/Modules/Banner/Controller/BannerConfigControllerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Modules\Banner\Controller;
 
 use Core\Config\AppConfig;
-use Core\Config\ScoutYearService;
+use Core\ScoutYear\ScoutYearResolver;
 use Core\Http\FrontController;
 use Core\Http\Request;
 use Core\Http\Router;
@@ -32,7 +32,7 @@ class BannerConfigControllerTest extends TestCase
     private BannerService $bannerService;
     private Environment $twig;
     private MemberService $memberService;
-    private ScoutYearService $scoutYearService;
+    private ScoutYearResolver $scoutYearResolver;
 
     protected function setUp(): void
     {
@@ -98,10 +98,11 @@ class BannerConfigControllerTest extends TestCase
         // denial tests further down override this per-instance.
         $this->memberService = $this->createMock(MemberService::class);
         $this->memberService->method('isUnitChief')->willReturn(true);
-        $this->scoutYearService = $this->createMock(ScoutYearService::class);
-        $this->scoutYearService->method('getCurrentYear')->willReturn(['id' => 1, 'label' => '2025-2026', 'start_date' => '2025-09-01', 'end_date' => '2026-08-31']);
+        $this->memberService->method('isUnitChiefAcrossYears')->willReturn(true);
+        $this->scoutYearResolver = $this->createMock(ScoutYearResolver::class);
+        $this->scoutYearResolver->method('getAccessYearIds')->willReturn([1]);
 
-        $this->controller = new BannerConfigController($this->twig, $this->bannerService, $journalService, $this->memberService, $this->scoutYearService);
+        $this->controller = new BannerConfigController($this->twig, $this->bannerService, $journalService, $this->memberService, $this->scoutYearResolver);
 
         if (session_status() === PHP_SESSION_NONE) {
             session_start();
@@ -423,9 +424,10 @@ class BannerConfigControllerTest extends TestCase
     {
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('isUnitChief')->willReturn(false);
+        $memberService->method('isUnitChiefAcrossYears')->willReturn(false);
         $controller = new BannerConfigController(
             $this->twig, $this->bannerService, new JournalService(new JournalRepository($this->pdo)),
-            $memberService, $this->scoutYearService
+            $memberService, $this->scoutYearResolver
         );
 
         AuthSession::login(1, 'admin@test.be', 'admin');
@@ -438,9 +440,10 @@ class BannerConfigControllerTest extends TestCase
     {
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('isUnitChief')->willReturn(false);
+        $memberService->method('isUnitChiefAcrossYears')->willReturn(false);
         $controller = new BannerConfigController(
             $this->twig, $this->bannerService, new JournalService(new JournalRepository($this->pdo)),
-            $memberService, $this->scoutYearService
+            $memberService, $this->scoutYearResolver
         );
 
         $token = $this->csrfToken();

--- a/tests/Modules/Rental/Controller/RentalManagementControllerTest.php
+++ b/tests/Modules/Rental/Controller/RentalManagementControllerTest.php
@@ -217,6 +217,11 @@ class RentalManagementControllerTest extends TestCase
             $this->twig,
             new RentalAuthorizationService($memberService, $this->assetRepository, $this->managerRepository),
             $scoutYearService,
+            new \Core\ScoutYear\ScoutYearResolver(
+                $scoutYearService,
+                new SettingService(new SettingRepository($this->pdo)),
+                new MemberYearRepository($this->pdo)
+            ),
             $this->assetRepository,
             $this->bookingRepository,
             new \Core\Audit\AuditService(new \Core\Audit\AuditRepository($this->pdo, $this->encryption)),

--- a/tests/Modules/Rental/Controller/RentalRbacTest.php
+++ b/tests/Modules/Rental/Controller/RentalRbacTest.php
@@ -164,6 +164,11 @@ class RentalRbacTest extends TestCase
             $this->twig,
             $authorizationService,
             $scoutYearService,
+            new \Core\ScoutYear\ScoutYearResolver(
+                $scoutYearService,
+                new SettingService(new SettingRepository($this->pdo)),
+                new MemberYearRepository($this->pdo)
+            ),
             $this->assetRepository,
             $bookingRepository,
             new \Core\Audit\AuditService(new \Core\Audit\AuditRepository($this->pdo, $encryption)),
@@ -357,7 +362,11 @@ class RentalRbacTest extends TestCase
                     $this->availabilityServiceFor(),
                     $this->authorizationService,
                     $this->assetRepository,
-                    $this->scoutYearService
+                    new \Core\ScoutYear\ScoutYearResolver(
+                        $this->scoutYearService,
+                        new SettingService(new SettingRepository($this->pdo)),
+                        new MemberYearRepository($this->pdo)
+                    )
                 ),
             default => $this->publicController,
         };

--- a/tests/Modules/Rental/Service/RentalAuthorizationServiceTest.php
+++ b/tests/Modules/Rental/Service/RentalAuthorizationServiceTest.php
@@ -278,4 +278,100 @@ class RentalAuthorizationServiceTest extends TestCase
 
         $this->assertFalse($service->canManageAssetId('manager@example.org', self::YEAR, 999999));
     }
+
+    // ---------------------------------------------------------------
+    // The transition allowance. Which years reach here is Core\ScoutYear\
+    // ScoutYearResolver::getAccessYearIds()' business and is tested there;
+    // what these pin is that Staff d'U in EITHER of them opens the module,
+    // and above all that the ENTRY list does — /mes-locations 403s on an
+    // empty one before any finer check runs, so a widening that stopped
+    // short of it would have changed nothing anybody could see.
+    // ---------------------------------------------------------------
+
+    private const OTHER_YEAR = 8;
+
+    /**
+     * A service whose Staff d'U answer is true in ONE year only — the
+     * fortnight between the 1st of September and the Desk import, where
+     * the roster of the year the calendar has moved to does not name
+     * anybody yet.
+     */
+    private function serviceWithUnitStaffInYear(string $email, int $scoutYearId): RentalAuthorizationService
+    {
+        $memberService = new class ($email, $scoutYearId) extends MemberService {
+            public function __construct(private string $email, private int $scoutYearId)
+            {
+                // Same reasoning as the stub above: answers from its own
+                // two values, never touches a database.
+            }
+
+            public function getLinkedMembers(string $email, int $scoutYearId): array
+            {
+                return [];
+            }
+
+            public function isUnitChief(string $email, int $scoutYearId): bool
+            {
+                return $email === $this->email && $scoutYearId === $this->scoutYearId;
+            }
+        };
+
+        return new RentalAuthorizationService($memberService, $this->assetRepository, $this->managerRepository);
+    }
+
+    public function testEntryListIsEmptyForTheYearTheRosterHasNotReachedYet(): void
+    {
+        $this->createAsset('Local', 'local');
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::YEAR);
+
+        // The bug, stated: on the year the calendar has moved to, the entry
+        // point of « Mes locations » hands back nothing and the page 403s.
+        $this->assertSame([], $service->listManageableAssets('cdu@example.org', self::OTHER_YEAR));
+    }
+
+    public function testEntryListAdmitsStaffDuFromEitherYear(): void
+    {
+        $this->createAsset('Local', 'local');
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::YEAR);
+
+        $this->assertCount(
+            1,
+            $service->listManageableAssetsAcrossYears('cdu@example.org', [self::OTHER_YEAR, self::YEAR])
+        );
+    }
+
+    public function testEntryListNeverRepeatsAnAssetGrantedByBothYears(): void
+    {
+        $this->createAsset('Local', 'local');
+        $this->createAsset('Chalet', 'chalet');
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::YEAR);
+
+        $assets = $service->listManageableAssetsAcrossYears('cdu@example.org', [self::YEAR, self::YEAR]);
+
+        $this->assertCount(2, $assets);
+        // And re-sorted by name, since merging two ordered lists does not
+        // give an ordered one.
+        $this->assertSame(['Chalet', 'Local'], array_map(static fn($asset) => $asset->name, $assets));
+    }
+
+    public function testMenuGateOpensForStaffDuFromEitherYear(): void
+    {
+        $this->createAsset('Local', 'local');
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::YEAR);
+
+        $this->assertFalse($service->managesAnyAsset('cdu@example.org', self::OTHER_YEAR));
+        $this->assertTrue(
+            $service->managesAnyAssetAcrossYears('cdu@example.org', [self::OTHER_YEAR, self::YEAR])
+        );
+    }
+
+    public function testMenuGateStaysClosedForSomebodyStaffInNeitherYear(): void
+    {
+        $this->createAsset('Local', 'local');
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::YEAR);
+
+        $this->assertFalse(
+            $service->managesAnyAssetAcrossYears('stranger@example.org', [self::OTHER_YEAR, self::YEAR])
+        );
+    }
 }

--- a/tests/Modules/Rental/Service/RentalAuthorizationServiceTest.php
+++ b/tests/Modules/Rental/Service/RentalAuthorizationServiceTest.php
@@ -374,4 +374,58 @@ class RentalAuthorizationServiceTest extends TestCase
             $service->managesAnyAssetAcrossYears('stranger@example.org', [self::OTHER_YEAR, self::YEAR])
         );
     }
+
+    /**
+     * The per-asset gates, which guard the WRITES (asset settings, tariffs)
+     * rather than a list. Same union, and they need their own cases: a
+     * regression that only ever consulted `$scoutYearIds[0]`, or that
+     * turned the OR into an AND, would leave every list test above green
+     * while sealing a Staff d'U out of the actions the lists just offered
+     * them.
+     */
+    public function testPerAssetGateAdmitsStaffDuFromEitherYear(): void
+    {
+        $assetId = $this->createAsset('Local', 'local');
+        $asset = $this->assetRepository->findById($assetId);
+        $this->assertNotNull($asset);
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::YEAR);
+
+        $this->assertFalse($service->canManageAsset('cdu@example.org', self::OTHER_YEAR, $asset));
+        $this->assertTrue(
+            $service->canManageAssetAcrossYears('cdu@example.org', [self::OTHER_YEAR, self::YEAR], $asset)
+        );
+        $this->assertTrue(
+            $service->canManageAssetIdAcrossYears('cdu@example.org', [self::OTHER_YEAR, self::YEAR], $assetId)
+        );
+    }
+
+    public function testPerAssetGateIsNotOpenedByTheFirstYearAlone(): void
+    {
+        $assetId = $this->createAsset('Local', 'local');
+        $asset = $this->assetRepository->findById($assetId);
+        $this->assertNotNull($asset);
+        // Staff d'U in the SECOND year of the list: an implementation that
+        // read only the first would answer false here.
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::OTHER_YEAR);
+
+        $this->assertTrue(
+            $service->canManageAssetAcrossYears('cdu@example.org', [self::YEAR, self::OTHER_YEAR], $asset)
+        );
+        $this->assertTrue($service->isUnitStaffAcrossYears('cdu@example.org', [self::YEAR, self::OTHER_YEAR]));
+    }
+
+    public function testPerAssetGateRefusesSomebodyStaffInNeitherYear(): void
+    {
+        $assetId = $this->createAsset('Local', 'local');
+        $asset = $this->assetRepository->findById($assetId);
+        $this->assertNotNull($asset);
+        $service = $this->serviceWithUnitStaffInYear('cdu@example.org', self::YEAR);
+
+        $this->assertFalse(
+            $service->canManageAssetAcrossYears('stranger@example.org', [self::OTHER_YEAR, self::YEAR], $asset)
+        );
+        $this->assertFalse(
+            $service->isUnitStaffAcrossYears('stranger@example.org', [self::OTHER_YEAR, self::YEAR])
+        );
+    }
 }

--- a/tests/Modules/Rental/Service/RentalMenuHookServiceTest.php
+++ b/tests/Modules/Rental/Service/RentalMenuHookServiceTest.php
@@ -108,7 +108,7 @@ class RentalMenuHookServiceTest extends TestCase
         return new RentalMenuHookService(
             $this->assetRepository,
             new RentalAuthorizationService($memberService, $this->assetRepository, $this->managerRepository),
-            self::YEAR
+            [self::YEAR]
         );
     }
 

--- a/tests/Modules/Retro/Controller/RetroBoardControllerTest.php
+++ b/tests/Modules/Retro/Controller/RetroBoardControllerTest.php
@@ -370,6 +370,7 @@ class RetroBoardControllerTest extends TestCase
     {
         AuthSession::login(3, 'chief@test.be', 'chief');
         $this->boardService->method('isUnitChief')->willReturn(false);
+        $this->boardService->method('isUnitChiefAcrossYears')->willReturn(false);
         [$id, $token] = $this->createBoard();
         $commentId = $this->commentRepository->create($id, 'good', 'Text');
         $csrf = $this->csrfToken();
@@ -386,6 +387,7 @@ class RetroBoardControllerTest extends TestCase
     {
         AuthSession::login(3, 'chief@test.be', 'chief');
         $this->boardService->method('isUnitChief')->willReturn(true);
+        $this->boardService->method('isUnitChiefAcrossYears')->willReturn(true);
         [$id, $token] = $this->createBoard();
         $commentId = $this->commentRepository->create($id, 'good', 'Propos injurieux');
         $this->commentRepository->setHidden($commentId, true);
@@ -399,6 +401,7 @@ class RetroBoardControllerTest extends TestCase
     {
         AuthSession::login(3, 'chief@test.be', 'chief');
         $this->boardService->method('isUnitChief')->willReturn(false);
+        $this->boardService->method('isUnitChiefAcrossYears')->willReturn(false);
         [$id, $token] = $this->createBoard();
         $commentId = $this->commentRepository->create($id, 'good', 'Propos injurieux');
         $this->commentRepository->setHidden($commentId, true);
@@ -412,6 +415,7 @@ class RetroBoardControllerTest extends TestCase
     {
         AuthSession::login(3, 'chief@test.be', 'chief');
         $this->boardService->method('isUnitChief')->willReturn(true);
+        $this->boardService->method('isUnitChiefAcrossYears')->willReturn(true);
         [$id, $token] = $this->createBoard();
         $commentId = $this->commentRepository->create($id, 'good', 'Text');
 
@@ -434,6 +438,7 @@ class RetroBoardControllerTest extends TestCase
     {
         AuthSession::login(3, 'chief@test.be', 'chief');
         $this->boardService->method('isUnitChief')->willReturn(true);
+        $this->boardService->method('isUnitChiefAcrossYears')->willReturn(true);
         [$id, $token] = $this->createBoard();
         $commentId = $this->commentRepository->create($id, 'good', 'Text');
 

--- a/tests/Modules/Retro/Controller/RetroConfigControllerTest.php
+++ b/tests/Modules/Retro/Controller/RetroConfigControllerTest.php
@@ -57,9 +57,11 @@ class RetroConfigControllerTest extends TestCase
         // Core\Member\MemberServiceTest.
         $this->memberService = $this->createMock(MemberService::class);
         $this->memberService->method('isUnitChief')->willReturn(true);
+        $this->memberService->method('isUnitChiefAcrossYears')->willReturn(true);
         $this->scoutYearService = $this->createMock(\Core\ScoutYear\ScoutYearResolver::class);
         $this->scoutYearService->method('getEffectiveYear')
             ->willReturn(new \Core\ScoutYear\EffectiveScoutYear(1, '2025-2026', null));
+        $this->scoutYearService->method('getAccessYearIds')->willReturn([1]);
 
         $templateDir = dirname(__DIR__, 4) . '/core/View/templates';
         $moduleViews = dirname(__DIR__, 4) . '/modules/retro/views';
@@ -125,6 +127,7 @@ class RetroConfigControllerTest extends TestCase
     {
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('isUnitChief')->willReturn(false);
+        $memberService->method('isUnitChiefAcrossYears')->willReturn(false);
         $controller = new RetroConfigController(
             $this->twig, $this->settingService, new JournalService(new JournalRepository($this->pdo)),
             $memberService, $this->scoutYearService
@@ -139,6 +142,7 @@ class RetroConfigControllerTest extends TestCase
     {
         $memberService = $this->createMock(MemberService::class);
         $memberService->method('isUnitChief')->willReturn(false);
+        $memberService->method('isUnitChiefAcrossYears')->willReturn(false);
         $controller = new RetroConfigController(
             $this->twig, $this->settingService, new JournalService(new JournalRepository($this->pdo)),
             $memberService, $this->scoutYearService

--- a/tests/Modules/Retro/Service/BoardServiceTest.php
+++ b/tests/Modules/Retro/Service/BoardServiceTest.php
@@ -606,6 +606,23 @@ class BoardServiceTest extends TestCase
         $this->assertTrue($this->service()->isUnitChief('unit-chief@example.com', 1));
     }
 
+    /**
+     * Same shape, same reason: the union over the years an access decision
+     * may consider is Core\Member\MemberService's to make (and is tested
+     * against real fixtures there), so this confirms the delegation and
+     * that the year LIST is passed through unaltered — a delegate that
+     * quietly dropped the second year would restore the very lockout the
+     * union exists to lift.
+     */
+    public function testIsUnitChiefAcrossYearsDelegatesWithBothYears(): void
+    {
+        $this->memberService->method('isUnitChiefAcrossYears')
+            ->with('unit-chief@example.com', [2, 1])
+            ->willReturn(true);
+
+        $this->assertTrue($this->service()->isUnitChiefAcrossYears('unit-chief@example.com', [2, 1]));
+    }
+
     public function testHasLinkedBoardIsFalseWithoutAnyBoard(): void
     {
         $this->assertFalse($this->service()->hasLinkedBoard(999));


### PR DESCRIPTION
## Le problème

`ScoutYearService::getCurrentYear()` bascule toute seule le 1er septembre — et va jusqu'à créer la ligne de l'année suivante. L'année publique, elle, ne bouge qu'à l'étape 14 du chantier de transition (« Activer pour tout le monde »). Entre les deux, « qui est cette personne ? » a **deux réponses défendables**, et une adhésion écrite dans l'une est invisible depuis l'autre.

#238 avait vu la moitié du problème et déplacé la rétro sur l'année effective. Ça **déplace** le verrouillage plutôt que de le lever :

- sur l'année date-calculée, personne n'est Staff d'U tant que le roster n'est pas importé ;
- sur l'année effective, personne n'est encore ce que le nouveau roster en fera.

Et la bannière et les locations, qui portent le **même garde** (`MemberService::isUnitChief()`), n'avaient pas été touchées du tout — `RetroConfigController` cite pourtant `BannerConfigController` comme son propre précédent. Elles se verrouillent donc aujourd'hui même, 9 septembre, sur toute installation dont le roster n'est pas encore importé.

## La règle

Une décision d'accès prend la réponse **la plus haute des deux années**, comme elle a toujours pris le rôle le plus haut lié à l'adresse.

Élargissement assumé : un chef d'unité de l'une des deux années garde les pages qui en dépendent tant que les deux coexistent. C'est le but — l'alternative est un chef verrouillé hors de sa propre configuration pendant la quinzaine où le site est le plus utilisé.

Trois propriétés, chacune pour une raison :

| Propriété | Pourquoi |
|---|---|
| **Bornée aux années adjacentes** | Les deux années divergent jusqu'à ce que quelqu'un lance l'étape 14, et rien ne l'y oblige. Sur une installation dont l'année publique a été épinglée puis oubliée, une règle non bornée donnerait ses droits à un chef parti depuis longtemps, pour toujours. Un an d'écart = toute vraie transition, aucun épinglage oublié. |
| **Symétrique** | L'étape 9 active l'année suivante pour les staffs *avant* le 1er septembre ; la bascule du calendrier passe *après*. Même quinzaine, vue des deux côtés. |
| **En lecture seule** | `findByLabel()` et non `getCurrentYear()`, qui créerait la ligne de l'année suivante comme effet de bord d'une question d'autorisation. |

## Ce qui est câblé

`Core\ScoutYear\ScoutYearResolver::getAccessYearIds()` est la brique ; son docblock porte tout le raisonnement.

- **Rôle, connexion, session** — `AuthController::resolveRole()`, la porte de connexion, les membres liés, et `SessionRevalidator` (qui tournait sur une année alors que la connexion en jugeait deux : ça aurait déconnecté les gens une requête après les avoir laissés entrer).
- **Chef d'unité** — rétro (configuration + tableau), bannière, locations.

`BannerConfigController` et `RentalPricingController` reçoivent le `ScoutYearResolver` à la place du `ScoutYearService`. `RentalManagementController` reçoit les deux et garde `scoutYearId()` pour la **portée des données** : qui peut ouvrir l'écran est une question sur une personne, quelles réservations y figurent est une question sur des lignes — fusionner deux années de lignes dans une liste serait faux.

## Ce qui n'est délibérément pas câblé

- **Les cinq appelants de `getStaffedSections()`** (documents de section, staffs, départs, calendrier, présences). La méthode `…AcrossYears` existe et est testée, mais son résultat est **affiché** : fusionner deux années de sections peut proposer dans un sélecteur une section qui n'existe plus. C'est une décision par écran, à prendre pour elle-même.
- **Les deux appelants de `staffsAnimeMemberYear()` n'ont pas à changer** : ils dérivent l'année du member-year visé (`getScoutYearIdForMemberYear()`), donc ils posent déjà la question dans la seule année pertinente. Vérifié plutôt que supposé.

## Vérifications

| Commande | Résultat |
|---|---|
| `vendor/bin/phpstan analyse` | `[OK] No errors` |
| `vendor/bin/phpunit` | 16325 tests, **12 nouveaux** ; les deux seuls échecs (`E2eSchedulerCoverageTest`) sont identiques sur `main` sans ce changement — un `/var` → `/private/var` propre à macOS que la CI Linux ne connaît pas |

Les tests de `getAccessYearIds()` sont écrits **contre le calendrier** (labels dérivés comme `labelForDate()` le fait, décalés d'années entières) plutôt que sur des libellés en dur, sans quoi ils affirmeraient autre chose chaque mois de septembre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMwzSa71um2vhmSocpH623