### PR TITLE
L'export Desk du scénario de transition ne portait pas de chef d'unité

### DIFF
--- a/tests/Modules/Rental/Controller/RentalRequestControllerTest.php
+++ b/tests/Modules/Rental/Controller/RentalRequestControllerTest.php
@@ -76,6 +76,7 @@ class RentalRequestControllerTest extends TestCase
     private RentalPricingService $pricingService;
     private EditableContentService $editableContentService;
     private EncryptionService $encryption;
+    private SettingService $settingService;
     private int $scoutYearId;
 
     /** @var list<array{to: string, subject: string, html: string, text: string, headers: array<string, string>}> */
@@ -87,7 +88,12 @@ class RentalRequestControllerTest extends TestCase
         RentalTestHelper::createTables($this->pdo);
         $this->encryption = new EncryptionService(str_repeat('a', 32), str_repeat('b', 32));
 
-        $settingService = new SettingService(new SettingRepository($this->pdo));
+        // Kept on the instance because one test raises the human-check
+        // threshold for itself (see testABotSubmittingInstantlyIsRefused).
+        // It must be THIS object: SettingService caches per instance and
+        // clears its own cache on write, so a second one would update the
+        // database while the controller went on reading the old value.
+        $this->settingService = $settingService = new SettingService(new SettingRepository($this->pdo));
         // One second: the shortest delay that still makes the "submitted
         // instantly" barrier real, and the test suite pays it once per
         // submission.
@@ -470,6 +476,21 @@ class RentalRequestControllerTest extends TestCase
     public function testABotSubmittingInstantlyIsRefused(): void
     {
         $this->createAsset();
+
+        // A threshold no rounding can reach, and no wait at all.
+        //
+        // HumanCheckService measures `time() - $timestamp` in WHOLE
+        // seconds, so against the suite's ordinary one-second threshold a
+        // render at X.999 and a submission at X+1.001 elapse "one second"
+        // without anybody having waited — and this test then admits the
+        // bot it exists to refuse. Not hypothetical: it failed on CI
+        // exactly that way, on a pull request that touched no PHP at all.
+        //
+        // Ten seconds cannot be crossed by a boundary, and costs nothing
+        // here because this is the one test that deliberately does NOT
+        // wait. The other submissions keep the one-second threshold the
+        // suite pays for on every one of them.
+        $this->settingService->setInternal('human_check_min_delay_seconds', '10');
 
         // Submitted the same instant the challenge was rendered, under the
         // minimum delay.

--- a/tests/e2e/specs/scout-year-transition.spec.js
+++ b/tests/e2e/specs/scout-year-transition.spec.js
@@ -62,6 +62,7 @@
 // September. Every label is read from the page and then asserted
 // *relationally* (the public year becomes the year step 7 previewed, and so
 // on), which is what the workflow actually promises.
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -81,6 +82,68 @@ const DESK_FIXTURE = path.join(
     // format Core\Import actually parses.
     '../../fixtures/desk_export_sample.csv',
 );
+
+/**
+ * The Desk export this scenario uploads: the shared sample, plus ONE row —
+ * the super-admin, as chef d'unité of the target year.
+ *
+ * WHY THE EXTRA ROW EXISTS. A Desk import replaces a roster:
+ * DeskImportService calls deactivateAllForYear() before writing, so after
+ * step 8 the only members of the target year are the ones this file names.
+ * The shared sample names six children and no unit chief, so the account
+ * every later scenario signs in as stopped being Staff d'U the moment this
+ * spec moved the public year forward — and pages gated on « chef d'unité »
+ * (/config/retro, /config/banner) began answering 403 in
+ * zz-module-boot-matrix, which runs after this one.
+ *
+ * A real unit's export always carries its own chief; the six-row sample
+ * simply is not a real unit. Adding the row here rather than to
+ * tests/fixtures/desk_export_sample.csv keeps that file byte-identical for
+ * tests/Core/Import/, which asserts on its exact contents.
+ *
+ * `FONCTION` is the column DeskCsvParser reads as the function code, and
+ * `E2E-CDU` is the admin-role function scripts/e2e-support.php already
+ * seeds (e2e_seed_unit_chief_function_for_admin). Section is left EMPTY on
+ * purpose: UnitStaffSectionService::syncMembership() is what puts every
+ * admin-role function with no section into « Staff d'U », which is exactly
+ * how a real chief lands there.
+ */
+function deskExportCarryingTheUnitChief() {
+    const raw = fs.readFileSync(DESK_FIXTURE, 'utf8');
+    const lines = raw.split(/\r?\n/).filter((line) => line.trim() !== '');
+    const header = lines[0].split(';');
+
+    const row = new Array(header.length).fill('');
+    const set = (column, value) => {
+        const index = header.indexOf(column);
+        if (index === -1) {
+            throw new Error(`Desk export has no "${column}" column — the fixture format changed.`);
+        }
+        row[index] = value;
+    };
+
+    set('Nom', 'Cheffe');
+    set('Prenom', 'Unite');
+    set('Genre', 'F');
+    set('Date de naissance', '01/01/1990');
+    set('Email Tiers', process.env.E2E_ADMIN_EMAIL ?? 'admin@example.invalid');
+    set('Rue', 'Rue du Staff');
+    set('No', '1');
+    set('Code Postal', '1000');
+    set('Ville', 'Bruxelles');
+    set('Pays', 'Belgique');
+    set("Type d'adresse", 'Domicile');
+    set('Courrier fédération', 'true');
+    set("Courrier d'unité", 'true');
+    set('Groupe unités', 'SV025');
+    set("Fonction au sein de l'unité", 'SV025U');
+    set('FONCTION', 'E2E-CDU');
+    set('Tiers', 'T900');
+    set('Date début', '01/09/2025');
+    set('Fonction principale', 'true');
+
+    return [...lines, row.join(';')].join('\n') + '\n';
+}
 
 /**
  * The card carrying a given year heading ("Année publique", "Année du
@@ -388,7 +451,11 @@ test('the whole site transitions to the next scout year through the documented w
 
     const importForm = page.locator('form[action="/admin/import"]');
     await importForm.getByLabel('Année scoute cible').selectOption({ label: targetYear });
-    await importForm.getByLabel('Fichier CSV à importer').setInputFiles(DESK_FIXTURE);
+    await importForm.getByLabel('Fichier CSV à importer').setInputFiles({
+        name: 'desk_export.csv',
+        mimeType: 'text/csv',
+        buffer: Buffer.from(deskExportCarryingTheUnitChief(), 'utf8'),
+    });
     // exact: Chromium exposes <input type="file"> as a button too, and its
     // accessible name ("Fichier CSV à importer") contains "importer".
     await importForm.getByRole('button', { name: 'Importer', exact: true }).click();


### PR DESCRIPTION
## Le symptôme

`zz-module-boot-matrix` échouait sur **23 de ses 24 cas** — `/config/retro` répondant 403 au lieu de 200 — et l'échec ne se voyait que dans la passe de release, ce fichier étant tagué `@full` (la passe de confiance de la CI le saute). Il a coûté une tentative de release complète : tag `v1.0.42` posé, workflow rouge, aucun brouillon créé.

Le seul cas qui passait était celui où `retro` était justement le module désactivé — ce qui disait déjà que le problème n'était pas le câblage inter-modules.

## La cause

`DeskImportService::deactivateAllForYear()` désactive tout le roster avant d'importer. Après l'étape 8 de `scout-year-transition.spec.js`, les seuls membres de l'année cible sont donc les six enfants de `tests/fixtures/desk_export_sample.csv` — **et aucun chef d'unité**.

Cette spec avance ensuite l'année publique. Son propre en-tête le dit : elle mute l'état global à dessein et prévient que « a future scenario that depends on the public year […] must not assume it still is what the harness provisioned ». `zz-` tourne après elle (son préfixe existe précisément pour ça), avec un compte admin qui n'est plus Staff d'U dans l'année effective. `RetroConfigController` et `BannerConfigController` gardent tous deux leur page derrière `MemberService::isUnitChief()` — d'où le 403.

Un vrai export Desk porte toujours son propre chef d'unité. L'échantillon à six lignes n'est simplement pas une vraie unité.

## Le correctif

La spec construit son export en mémoire : l'échantillon partagé **plus une ligne**, l'admin en chef d'unité de l'année cible.

| Détail | Pourquoi |
|---|---|
| `FONCTION` = `E2E-CDU` | La colonne que `DeskCsvParser` lit comme code de fonction, et la fonction de rôle `admin` que `e2e_seed_unit_chief_function_for_admin()` sème déjà dans `functions`. Une ligne de CSV n'a sinon aucun moyen de nommer un rôle. |
| **Section laissée vide** | C'est le cœur du mécanisme : `UnitStaffSectionService::syncMembership()` place en « Staff d'U » toute fonction de rôle `admin` sans section. C'est le chemin d'un vrai chef, pas un raccourci de fixture. |
| CSV partagé non modifié | `tests/fixtures/desk_export_sample.csv` reste **octet pour octet identique** : `tests/Core/Import/` assère sur son contenu exact, et une seconde copie du format dériverait de ce que `Core\Import` sait réellement lire. |

**Deux voies écartées, et pourquoi.** Pré-semer la fonction dans l'année cible au provisionnement ne survivrait pas au `deactivateAllForYear()`. Remettre l'année publique en place par l'interface est impossible : le contrôle est désactivé une fois la transition terminée (`can_activate_public` exige une année staff).

**Aucun code de production n'est touché.**

## Vérification

| Commande | Résultat |
|---|---|
| `npm run typecheck` | 0 nouveau signalement |
| `./scripts/e2e.sh scout-year-transition zz-module-boot-matrix` | **24 tests, tous verts** (23 rouges avant) |

Les deux specs sont lancées **dans cet ordre** à dessein : lancer la matrice seule ne prouve rien, l'échec dépendant de la transition qui la précède et déplace l'année publique.

## Ce que cette PR ne fait pas

Elle ne corrige pas le verrouillage du 1er septembre pour la bannière et les locations, qui utilisent encore l'année date-calculée. C'est le sujet de #277, laissée ouverte : la revue y a trouvé une régression de sécurité (la borne « années adjacentes » ne s'appliquait pas à l'année effective, qu'un aperçu admin peut fixer arbitrairement) et une incohérence rental à cinq contrôles. Elle se reprendra à froid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LMwzSa71um2vhmSocpH623