### PR TITLE
Écrire les nombres auxquels rien ne pouvait être comparé (chantier « Exigences opérationnelles », IT-01)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,6 +2,8 @@
 
 This document is the architectural reference for the project. Every contribution — human or agent-generated — must conform to it. When in doubt between a "simpler" solution and one that respects this document, this document takes priority.
 
+It says how the system is built; [`docs/exigences-non-fonctionnelles.md`](docs/exigences-non-fonctionnelles.md) says what it must hold to — the sizing target every design here assumes, the rendering budget a page is judged against, the recovery objectives the backup mechanisms (§8.15, §8.18) exist to meet, the operational alert thresholds, and the technical baseline. A design decision that cannot meet one of those numbers changes the number, in the same pull request, or it is the wrong design.
+
 ## 1. Overview
 
 ### Purpose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,10 @@ Thank you for considering contributing to this project.
 4. [docs/quality-pipeline.md](docs/quality-pipeline.md) maps the whole pipeline —
    tests, CI, code review, the release gates, and the GitHub settings none of it
    works without. Read it once; come back to it when a check surprises you.
+5. [docs/exigences-non-fonctionnelles.md](docs/exigences-non-fonctionnelles.md)
+   holds the numbers: sizing target, rendering budget, recovery objectives,
+   operational alert thresholds, technical baseline. It is what turns "is that
+   fast enough?" and "is that too full?" into questions a review can settle.
 
 ## Key rules
 

--- a/docs/chantiers/exigences-operationnelles.md
+++ b/docs/chantiers/exigences-operationnelles.md
@@ -113,6 +113,14 @@ Documentation seule, aucun code, conformément au document de chantier.
    Changer le défaut est du code, donc hors du périmètre d'IT-01. **C'est
    IT-03 qui portera ce changement**, dans la PR qui allume l'alerte —
    c'est la seule qui puisse le faire sans livrer une alerte fausse.
+   Ouvert comme issue #286, ce qu'exige `AGENTS.md`.
+
+   **L'écart est écrit sur la page d'exigences elle-même**, et pas
+   seulement ici. Relevé en revue : la page se lit toute seule et se cite
+   telle quelle, donc une phrase au présent disant que le RPO « fixe » le
+   défaut à hebdomadaire y ferait conclure que le défaut livré correspond
+   déjà. Les deux endroits qui l'affirmaient disent maintenant l'état réel
+   et nomment l'issue.
 
 2. **`ARCHITECTURE.md` ne comportait aucun renvoi vers un document
    d'exigences non fonctionnelles** parce qu'il n'en existait aucun : le

--- a/docs/chantiers/exigences-operationnelles.md
+++ b/docs/chantiers/exigences-operationnelles.md
@@ -1,0 +1,124 @@
+# Chantier — Exigences opérationnelles : disque, alertes, sauvegardes
+
+Journal d'implémentation du document de chantier « Exigences
+opérationnelles » (itérations IT-01 à IT-09). Une section par itération :
+ce qui a été livré, les décisions prises en autonomie, les divergences
+constatées entre le document de chantier et le dépôt réel, et ce qui a été
+reporté. Même format que `docs/chantiers/aide-contextuelle.md`.
+
+Le document de chantier lui-même est une pièce jointe et ne se trouve pas
+dans le dépôt : ce journal est la seule trace qui y survit.
+
+---
+
+## IT-01 — Écrire les exigences non fonctionnelles
+
+**Livré.** `docs/exigences-non-fonctionnelles.md` — cible de
+dimensionnement, budget de rendu, objectifs de reprise, seuils d'alerte,
+socle technique (PHP/MySQL, navigateurs, accessibilité). Référencé depuis
+`CONTRIBUTING.md` (§ Before you start, point 5) et depuis l'en-tête
+d'`ARCHITECTURE.md`, qui dit explicitement la répartition : l'un dit
+comment le système est bâti, l'autre à quoi il doit tenir.
+
+Documentation seule, aucun code, conformément au document de chantier.
+
+**Décisions autonomes.**
+
+1. **Le document est en anglais, son nom de fichier en français.** Le nom
+   est celui que le document de chantier fixe ; le contenu suit ses deux
+   voisins immédiats, `ARCHITECTURE.md` et `docs/quality-pipeline.md`,
+   d'où il est référencé et avec lesquels il sera lu. `AGENTS.md`
+   § Language ne tranche que le code et l'interface ; la documentation du
+   dépôt est mixte (`README.md` et `docs/rental-guide.md` en français,
+   destinés aux utilisateurs ; `ARCHITECTURE.md`, `AGENTS.md`,
+   `docs/module-development.md`, `docs/quality-pipeline.md` en anglais,
+   destinés aux contributeurs). Celui-ci est de la seconde famille.
+
+2. **Deux seuils de plus que les quatre proposés**, pour les alertes que
+   IT-09 devra publier : âge de la dernière sauvegarde distante réussie
+   (10 jours / 3 jours) et occupation du quota distant (90 % / 80 %). Les
+   écrire maintenant évite qu'IT-09 invente ses propres nombres hors de la
+   page qui centralise les nombres. Aucun code ne les lit encore.
+
+   Le seuil distant porte **les mêmes nombres que le seuil local**, et
+   c'est le plus important des deux : dans le scénario dont parle
+   réellement le RPO — le serveur n'existe plus — la vétusté de la copie
+   hors site *est* la perte de données réalisée. Un premier jet écrivait
+   21 jours, soit trois fois le RPO qu'il est censé garder ; corrigé en
+   revue.
+
+3. **Deux contraintes d'hôte chiffrées dans le budget de rendu** —
+   `max_execution_time` à 30 s (jamais plus de 120 s) et 128 Mio de
+   mémoire. Le document de chantier les invoque en prose dans IT-09 ; sans
+   nombre opposable, « ça ne tient pas dans une requête » reste une
+   opinion.
+
+4. **Les valeurs de dimensionnement sont déduites, pas inventées** : 500
+   membres par année et 5 années viennent du docblock de
+   `Core\Member\Service\MemberSearchService` (« quelques centaines de
+   membres », « cinq années scoutes, c'est cinq fois le travail AES ») ;
+   178 membres est ce que contiennent réellement les exports **commités**
+   de `tests/fixtures/reference-dataset/` : 176 / 178 / 178 `Tiers`
+   distincts, comptés dans les trois fichiers, ce que confirme le
+   `README.md` du jeu de données lui-même (« Membres actifs |
+   176 / 178 / 178 »).
+
+   Un premier jet écrivait 180, en lisant dans
+   `docs/chantiers/reference-dataset.md` la ligne « Effectifs
+   reconstruits » — qui décrit une instance jetable rebâtie par le
+   builder, pas les fichiers commités. Ce journal-là n'a pas tort ; c'est
+   la ligne qui avait été mal choisie. La citation renvoie désormais au
+   `README.md` du jeu de données, qui en est le manuel et qui est tenu à
+   jour.
+
+   **Le volume de galerie a dû être refait.** Un premier jet écrivait
+   3 Gio, en multipliant un nombre de médias par la taille d'une photo
+   *envoyée*. La galerie conserve **trois rendus** par photo
+   (`Modules\Gallery\Service\ImageProcessingService` : 3000 px q90,
+   1200 px q85, 300 px q80) et `ProcessPhotoHandler` ne supprime que
+   l'original — soit environ 2 Mio stockés par photo, et 8 Gio sur cinq
+   ans.
+
+   Le total `storage/` passe de 4 à 10 Gio, et **la correction ne portait
+   pas que sur la galerie** : la part non-galerie n'avait jamais été
+   chiffrée, elle valait 1 Gio implicitement, et elle en vaut 2. Elle est
+   désormais une ligne à elle dans le tableau — une dizaine d'archives
+   conservées à ~150 Mio pièce (une archive `full_no_gallery` embarque
+   `vendor/`, qui la domine) plus cinq ans de pièces jointes — pour que le
+   total soit une somme visible plutôt qu'un chiffre à croire. Le
+   déséquilibre arithmétique du premier jet (+5 Gio de galerie, +6 Gio de
+   total) a été relevé en revue.
+
+   10 Gio dépasse ce que donne l'hébergement mutualisé le moins cher :
+   c'est écrit noir sur blanc dans le document, avec ses trois issues
+   (payer plus, garder moins d'années en ligne, ou passer la galerie sur
+   `S3StorageBackend`). La
+   vidéo est exclue du chiffre et signalée à part —
+   `gallery_max_video_upload_mb` vaut 2 048 par défaut, donc une douzaine
+   de vidéos de camp pèse plus que cinq ans de photos.
+
+**Divergences constatées entre le document de chantier et le dépôt.**
+
+1. **La fréquence par défaut des sauvegardes automatiques contredit les
+   seuils d'alerte proposés.** `backup_auto_frequency` vaut `monthly` par
+   défaut (`public/index.php`), et le seuil « âge de la dernière
+   sauvegarde réussie » déclenche à 10 jours. Sur une installation
+   laissée dans sa configuration par défaut, cette alerte serait donc
+   **déclenchée en permanence** dès la mise en service d'IT-03 — c'est-à-
+   dire inutile, et exactement le mécanisme d'extinction que la décision
+   D1 cherche à éviter.
+
+   L'objectif de reprise écrit en IT-01 (RPO 7 jours) tranche dans
+   l'autre sens : une sauvegarde planifiée doit être **hebdomadaire**.
+   Changer le défaut est du code, donc hors du périmètre d'IT-01. **C'est
+   IT-03 qui portera ce changement**, dans la PR qui allume l'alerte —
+   c'est la seule qui puisse le faire sans livrer une alerte fausse.
+
+2. **`ARCHITECTURE.md` ne comportait aucun renvoi vers un document
+   d'exigences non fonctionnelles** parce qu'il n'en existait aucun : le
+   renvoi ajouté est une création, pas une mise à jour.
+
+**Reporté.** Rien pour cette itération. `axe-core` dans la suite
+Playwright reste explicitement hors chantier (section « Reporté » du
+document de chantier), désormais adossé à un niveau d'accessibilité
+énoncé.

--- a/docs/exigences-non-fonctionnelles.md
+++ b/docs/exigences-non-fonctionnelles.md
@@ -1,0 +1,155 @@
+# Non-functional requirements
+
+Numbers, not prose. Everything on this page is a figure something else
+reads: a review that has to answer "is that fast enough?", an alert that
+has to answer "is that too full?", a default that has to answer "how
+often?".
+
+**A figure here is a decision, not a measurement.** It is what the project
+commits to, and the thing to change when reality proves it wrong — never
+the thing to quietly stop checking. When a change makes one of these
+numbers unreachable, the number moves in the same pull request, with the
+reason written next to it.
+
+The target installation this whole page describes: **one Belgian scout
+unit, on shared hosting, administered by a volunteer who passes by once a
+week.** Not a fleet, not a datacentre, and nobody watching a dashboard.
+
+---
+
+## 1. Sizing target
+
+| Figure | Value | Where it comes from |
+|---|---|---|
+| Members per scout year, typical | 178 | What `tests/fixtures/reference-dataset/`'s **committed** exports actually hold: 176 / 178 / 178 distinct `Tiers` across its three years, matching that fixture's own `README.md` |
+| Members per scout year, design ceiling | 500 | `Core\Member\Service\MemberSearchService` reasons explicitly in "a few hundred members"; twice that is the point past which its in-memory, decrypt-everything search stops being defensible |
+| Scout years kept online | 5 | Same docblock: "across five scout years it is five times the AES work" |
+| Members in the whole database, ceiling | 2 500 | 500 × 5, the two rows above |
+| Photos published per scout year | 800 | Roughly ten albums — camp, weekends, a few section outings. `gallery_max_media_per_album` (200) is a ceiling per album, not a typical figure |
+| Stored bytes per photo | 2 MiB | **Three renditions are kept, not one**: `Modules\Gallery\Service\ImageProcessingService` writes large (`gallery_photo_max_dimension`, 3000 px, q90), medium (1200 px, q85) and thumb (300 px, q80), and `ProcessPhotoHandler` deletes only the original |
+| Gallery volume expected | 8 GiB | The two rows above, over five years |
+| Backups and attachments | 2 GiB | Around ten retained archives at roughly 150 MiB each — a `full_no_gallery` archive carries `vendor/`, which dominates it — plus five years of receipts, rental documents, mail attachments and member photos |
+| `storage/` total expected | 10 GiB | The sum of the two rows above, and nothing else |
+
+Three things that figure has to be read with.
+
+**Video is not in it, and can dwarf it.** `gallery_max_video_upload_mb`
+defaults to 2 048, so a dozen camp videos outweigh five years of photos.
+A unit that publishes video sizes its hosting for video; nothing here
+predicts that for them.
+
+**One archive that includes the gallery breaks the sum.** A
+`full_with_gallery` backup is larger than everything else in `storage/`
+put together, which is why only one of them is ever kept — the
+cross-family cap. The 2 GiB row above assumes that cap holds.
+
+**10 GiB is more than the cheapest shared hosting gives**, which is the
+point rather than an oversight: a unit keeping five years of gallery
+online needs a plan sized for it, or it keeps fewer years online, or it
+moves the gallery to object storage
+(`Modules\Gallery\Service\Storage\S3StorageBackend`). Saying so is what
+makes the disk block on Configuration > Maintenance worth reading — and
+the declared quota worth filling in.
+
+Past the ceiling the site is not expected to fail — it is expected to get
+slow in the way §2 describes, and that is the signal to revisit the search
+architecture rather than the hosting.
+
+## 2. Rendering budget
+
+Server-side render time, measured by `Core\Debug\RequestTimeline` on the
+shared hosting described above, at the sizing ceiling of §1. These are the
+numbers a timeline is read against; without them "is that slow?" has no
+answer a review can hold anyone to.
+
+| Page class | Budget | Examples |
+|---|---|---|
+| Ordinary page | **500 ms** | Home, a section's page, the calendar, a member's page |
+| Costly page | **2 000 ms** | Member search across past years, statistics, « Justesse des tarifs », the invoice report |
+| Background task pass | **20 s** | One `SchedulerRunner` pass; the budget `Core\Notification\Task\SendNotificationsHandler` already works under, and the shape every long task reuses (do some, reschedule the rest) |
+
+Two figures that bound the ones above, and that come from the host rather
+than from this project:
+
+| Constraint | Assumed value |
+|---|---|
+| `max_execution_time` on shared hosting | **30 s**, and never more than 120 s |
+| PHP memory limit | **128 MiB** |
+
+A feature that cannot finish inside `max_execution_time` does not get a
+bigger budget: it gets split into passes that reschedule themselves.
+
+## 3. Recovery objectives
+
+| Objective | Value | What it means |
+|---|---|---|
+| RPO — maximum data loss accepted | **7 days** | A restore may lose at most one week of the unit's work. This is what fixes the default frequency of scheduled backups at *weekly*. |
+| RTO — target time to service | **4 hours** | From "the site is gone" to "the site answers again", by a volunteer following the help topic, on a host they may have to sign up with that morning |
+| Off-site copies | **at least 1** | A backup that only exists on the server that died is not a backup |
+| Restorable on a *new* installation | **required** | A backup restorable only onto the installation that made it does not meet the RTO above in the one scenario that matters |
+
+The last row is why the portable backup exists at all: an archive without
+`storage/keys/master.key` restores onto this installation and nowhere
+else.
+
+## 4. Alert thresholds
+
+Every operational check is *armed* or *triggered*, and only ever
+re-arms below a **strictly lower** value than the one that triggered it.
+Without that gap, a value oscillating around a single threshold notifies
+on every scheduler pass, and the alert is switched off within days.
+
+| Check | Triggers at | Re-arms at |
+|---|---|---|
+| Disk usage | 85 % | 75 % |
+| Age of the last successful backup | 10 days | 3 days |
+| Age of the last real cron pass | 48 h | 6 h |
+| A portable backup left on the server | present for 7 days | deleted |
+| Age of the last successful off-site backup | 10 days | 3 days |
+| Off-site storage quota used | 90 % | 80 % |
+
+Read the backup-age rows together with §3. A 10-day alert only makes sense
+on top of a weekly scheduled backup, which is the RPO's other half — one
+missed run plus the time an upload takes, and no more.
+
+The **off-site** row carries the same two numbers as the local one on
+purpose, and it is the more important of the two: in the scenario the RPO
+is actually about — the server is gone — the off-site copy's staleness
+*is* the realised data loss, so letting it drift further than the local
+copy would be tolerating exactly what §3 refuses.
+
+Notification and attention point read the same check, run once. The
+notification says "this has just tipped over"; the attention point says
+"this is still true".
+
+## 5. Technical baseline
+
+| Item | Requirement |
+|---|---|
+| PHP | **>= 8.4** (`README.md` § Prérequis) |
+| MySQL | **>= 8.0**; the reference production installation is **MariaDB 10.11** and both engines are supported (`AGENTS.md` § Database) |
+| PHP extensions | `openssl`, `pdo_mysql`, `zip` (with libzip crypto support for encrypted archives — `BackupService::supportsZipEncryption()` degrades cleanly without it), `mbstring`, `sodium` when available |
+| Server-side runtime | No shell, no `mysqldump` binary, no Composer, no Node on the hosting server |
+| Cron | `php public/cron.php` every minute (`README.md` § La tâche cron) |
+
+### Supported browsers
+
+The last two major versions of Chrome, Firefox, Edge and Safari, desktop
+and mobile, plus the installed PWA on Android and iOS. That is what
+`tsconfig.json`'s `ES2020` target already assumes; production JavaScript
+is shipped unbundled and untranspiled (`AGENTS.md` § CSS / frontend), so
+the language level in the source *is* the browser requirement.
+
+### Accessibility
+
+**WCAG 2.2 level AA** is the target for every page an end user reaches.
+Two consequences already written down elsewhere, restated here only
+because they are the ones with a number: touch targets meet the 24×24 CSS
+pixel minimum AA requires, with 44 px as a comfort goal for small controls
+(`design.md` §7.2), and every interactive control has an accessible name —
+which is what the end-to-end suite asserts by reaching elements through
+`getByRole`/`getByLabel` (`README.md` § Tests de bout en bout).
+
+Nothing measures this automatically yet. Adding `axe-core` to the existing
+Playwright suite is the natural next step and is deliberately not in this
+document's scope.

--- a/docs/exigences-non-fonctionnelles.md
+++ b/docs/exigences-non-fonctionnelles.md
@@ -83,7 +83,7 @@ bigger budget: it gets split into passes that reschedule themselves.
 
 | Objective | Value | What it means |
 |---|---|---|
-| RPO — maximum data loss accepted | **7 days** | A restore may lose at most one week of the unit's work. This is what fixes the default frequency of scheduled backups at *weekly*. |
+| RPO — maximum data loss accepted | **7 days** | A restore may lose at most one week of the unit's work. This is what fixes the target default frequency of scheduled backups at *weekly* — **`backup_auto_frequency` still ships as `monthly`**, which is issue #286 |
 | RTO — target time to service | **4 hours** | From "the site is gone" to "the site answers again", by a volunteer following the help topic, on a host they may have to sign up with that morning |
 | Off-site copies | **at least 1** | A backup that only exists on the server that died is not a backup |
 | Restorable on a *new* installation | **required** | A backup restorable only onto the installation that made it does not meet the RTO above in the one scenario that matters |
@@ -111,6 +111,14 @@ on every scheduler pass, and the alert is switched off within days.
 Read the backup-age rows together with §3. A 10-day alert only makes sense
 on top of a weekly scheduled backup, which is the RPO's other half — one
 missed run plus the time an upload takes, and no more.
+
+**That half is not shipped yet**, and the gap is worth stating here rather
+than only in a journal, because this page is meant to be cited on its own:
+`backup_auto_frequency` still defaults to `monthly`, so turning this alert
+on before changing that default would leave it *triggered* on a default
+installation two-thirds of the time — which is D1's own extinction
+mechanism, aimed at the alert it was meant to protect. The two land
+together, in the iteration that turns the check on (issue #286).
 
 The **off-site** row carries the same two numbers as the local one on
 purpose, and it is the more important of the two: in the scenario the RPO


### PR DESCRIPTION
## Description

Première itération du chantier « Exigences opérationnelles : disque, alertes, sauvegardes ». **Documentation seule, aucun code** — elle passe d'abord parce qu'elle fixe les nombres que les huit itérations suivantes vont lire.

> **Titre, description et message de commit repassés en français**, et l'historique de la branche écrasé en un seul commit, après le merge de #283 : `AGENTS.md` § Language dit désormais que tout ce qui est écrit *à propos* d'un changement est en français. La PR avait été ouverte sous l'ancienne règle. Les réponses dans les fils de revue restent en anglais — c'est l'exception que la nouvelle règle énonce explicitement, et les fils de cette PR sont en anglais.

`docs/exigences-non-fonctionnelles.md` :

- **Cible de dimensionnement** — déduite du dépôt, pas inventée.
- **Budget de rendu** — `Core\Debug\RequestTimeline` mesure déjà ; il manquait le nombre auquel comparer. 500 ms pour une page ordinaire, 2 000 ms pour une page coûteuse, 20 s pour une passe de tâche de fond (le budget sous lequel `SendNotificationsHandler` travaille déjà), plus les deux contraintes d'hôte qui les bornent.
- **Objectifs de reprise** — RPO 7 jours, RTO 4 heures, au moins une copie hors site, et l'exigence « restaurable sur une installation neuve » qui est la raison d'être de la suite du chantier.
- **Seuils d'alerte** — repris tels quels par IT-03. Deux valeurs par seuil, déclenchement et réarmement : un contrôle à seuil unique notifie à chaque passage du planificateur dès que la valeur oscille autour, et l'alerte est coupée en trois jours.
- **Socle technique** — PHP/MySQL rapatriés de `README.md`, navigateurs supportés, et le niveau d'accessibilité visé (WCAG 2.2 AA), qui n'était énoncé nulle part.

Référencé depuis `CONTRIBUTING.md` § Before you start et depuis l'en-tête d'`ARCHITECTURE.md`. `docs/chantiers/exigences-operationnelles.md` ouvre le journal d'exécution du chantier.

## Les nombres ont été refaits trois fois

Sept remarques de revue, toutes réelles, toutes vérifiées contre la source primaire plutôt que contre le document qui avait été mal lu. C'est la partie de cette PR qui compte, puisque ce tableau sera lu comme une vérité de base par les six itérations suivantes.

- **178 membres par année**, pas 250 ni 180. En comptant les `Tiers` distincts — la colonne par laquelle `Core\Import\DeskCsvParser` regroupe un membre — dans les trois exports commités : 176 / 178 / 178, ce que confirme le `README.md` du jeu de données. 250 était le nombre de *lignes* d'export ; 180 venait de la ligne « Effectifs reconstruits » d'un journal, qui décrit une instance jetable rebâtie par le builder et non les fichiers commités.
- **8 Gio de galerie**, pas 3. L'estimation dimensionnait une photo *envoyée* : la galerie conserve **trois rendus** par photo (`ImageProcessingService`, 3000 px q90 / 1200 px q85 / 300 px q80) et `ProcessPhotoHandler` ne supprime que l'original — environ 2 Mio stockés par photo. La vidéo est hors du chiffre et signalée à part (`gallery_max_video_upload_mb` vaut 2 048 par défaut).
- **10 Gio de `storage/`, comme somme visible.** La part non-galerie n'avait jamais été chiffrée : implicitement 1 Gio, réellement 2. Elle est désormais une ligne à elle — une dizaine d'archives conservées à ~150 Mio pièce, une `full_no_gallery` étant dominée par `vendor/`, plus cinq ans de pièces jointes. Avec sa précondition : une archive `full_with_gallery` pèse plus que tout le reste de `storage/` réuni, donc les 2 Gio ne tiennent que tant que le plafond transversal d'IT-04 n'en garde qu'une.
- **L'alerte de sauvegarde hors site déclenchait à 21 jours**, trois fois le RPO qu'elle garde — alors que dans le seul scénario dont parle le RPO, le serveur ayant disparu, la vétusté de la copie hors site *est* la perte réalisée. Elle porte les mêmes 10 / 3 jours que la copie locale.
- **`§8.15–§8.18`** nommait deux sections qui ne sont pas des mécanismes de sauvegarde (§8.16 est de la plomberie de planificateur, §8.17 le canal de mise à jour). Corrigé en `§8.15, §8.18`.

## Le défaut relevé et non corrigé ici

`backup_auto_frequency` vaut `monthly` par défaut contre un RPO de 7 jours et une alerte à 10 jours : cette alerte serait **déclenchée en permanence** sur une installation par défaut, ce qui est exactement le mécanisme d'extinction que la décision D1 du chantier cherche à éviter.

Corriger le défaut est du code, donc hors du périmètre de cette itération. C'est l'**issue #286**, comme l'exige `AGENTS.md` § A problem you decide not to fix now becomes a GitHub issue — un journal et un corps de PR ne sont pas un backlog. IT-03 la fermera, dans la PR qui allume l'alerte.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] This PR's title and description, and every commit message in it, are in French (`AGENTS.md` § Language)
- [x] Automated tests are written/updated for this change — *sans objet : documentation seule, aucun comportement à épingler. La suite complète a été exécutée pour vérifier que rien ne régresse.*
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse`) — *aucun PHP modifié*
- [x] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — *sans objet*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vhwT2cPeo1wz4LDAid9vB