### PR TITLE
Incrémenter mass_mail à 1.15.0 et corriger les quinze S1808 laissés par #289

### DIFF
--- a/modules/mass_mail/module.json
+++ b/modules/mass_mail/module.json
@@ -2,7 +2,7 @@
   "id": "mass_mail",
   "name": "Envoi de mails",
   "description": "Envoi de mails groupés aux membres de l'unité : listes de diffusion par défaut ou personnalisées, publipostage depuis un fichier Excel avec variables personnalisées, mode test, envoi en arrière-plan par lots, suivi détaillé des envois. Accueille aussi, lorsque le module inscriptions est actif, une liste prédéfinie non modifiable pour l'année scoute cible.",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "enabled_by_default": false,
   "routes": [
     {

--- a/modules/mass_mail/src/Service/MassMailService.php
+++ b/modules/mass_mail/src/Service/MassMailService.php
@@ -716,9 +716,12 @@ class MassMailService
         $this->ensureBatchTaskScheduled(true);
 
         $this->journalService->log(
-            'mass_mail', 'email_sending_started', 'info',
+            'mass_mail',
+            'email_sending_started',
+            'info',
             self::emailPrefix($id) . ' : envoi démarré',
-            ['email_id' => $id, 'recipient_count' => $validCount, 'invalid_address_count' => $invalidCount], $actorId
+            ['email_id' => $id, 'recipient_count' => $validCount, 'invalid_address_count' => $invalidCount],
+            $actorId
         );
 
         return $this->requireEmail($id);
@@ -779,10 +782,20 @@ class MassMailService
             $addresses = $this->memberEmailService->resolveValidAddressesForMassMail($member['member_id'], $deskEmail);
 
             if ($addresses === []) {
-                $recipientId = $this->recipientRepository->create($email->id, $member['member_id'],
-                    $member['scout_year_id'], null, Recipient::STATUS_ERROR, 'Adresse invalide');
-                $this->journalRecipientNotSendable($email->id, $recipientId, $member['member_id'],
-                    'Adresse invalide');
+                $recipientId = $this->recipientRepository->create(
+                    $email->id,
+                    $member['member_id'],
+                    $member['scout_year_id'],
+                    null,
+                    Recipient::STATUS_ERROR,
+                    'Adresse invalide'
+                );
+                $this->journalRecipientNotSendable(
+                    $email->id,
+                    $recipientId,
+                    $member['member_id'],
+                    'Adresse invalide'
+                );
                 $invalidCount++;
                 continue;
             }
@@ -851,8 +864,12 @@ class MassMailService
                 $email->id, null, null, $address,
                 Recipient::STATUS_ERROR, 'Adresse désinscrite des emails groupés'
             );
-            $this->journalRecipientNotSendable($email->id, $recipientId, null,
-                'Adresse désinscrite des emails groupés');
+            $this->journalRecipientNotSendable(
+                $email->id,
+                $recipientId,
+                null,
+                'Adresse désinscrite des emails groupés'
+            );
             return [$validCount, $invalidCount + 1];
         }
 
@@ -906,8 +923,12 @@ class MassMailService
                         $email->id, $row->memberId, $profile['scout_year_id'] ?? null, null,
                         Recipient::STATUS_ERROR, 'Adresse invalide', null, $row->id
                     );
-                    $this->journalRecipientNotSendable($email->id, $recipientId, $row->memberId,
-                        'Adresse invalide');
+                    $this->journalRecipientNotSendable(
+                        $email->id,
+                        $recipientId,
+                        $row->memberId,
+                        'Adresse invalide'
+                    );
                     $invalidCount++;
                     continue;
                 }
@@ -928,8 +949,12 @@ class MassMailService
                         $email->id, null, null, $address,
                         Recipient::STATUS_ERROR, 'Adresse désinscrite des emails groupés', null, $row->id
                     );
-                    $this->journalRecipientNotSendable($email->id, $recipientId, null,
-                        'Adresse désinscrite des emails groupés');
+                    $this->journalRecipientNotSendable(
+                        $email->id,
+                        $recipientId,
+                        null,
+                        'Adresse désinscrite des emails groupés'
+                    );
                     $invalidCount++;
                     continue;
                 }
@@ -973,9 +998,12 @@ class MassMailService
         $this->emailRepository->updateStatus($emailId, Email::STATUS_SENT, true);
 
         $this->journalService->log(
-            'mass_mail', 'email_sent', 'info',
+            'mass_mail',
+            'email_sent',
+            'info',
             self::emailPrefix($emailId) . ' : envoi terminé',
-            ['email_id' => $emailId], $actorId
+            ['email_id' => $emailId],
+            $actorId
         );
     }
 
@@ -1005,10 +1033,16 @@ class MassMailService
         $this->ensureBatchTaskScheduled(true);
 
         $this->journalService->log(
-            'mass_mail', 'recipient_resent', 'info',
+            'mass_mail',
+            'recipient_resent',
+            'info',
             self::emailPrefix($recipient->emailId) . ' : renvoi demandé au destinataire #' . $recipientId,
-            ['email_id' => $recipient->emailId, 'recipient_id' => $recipientId,
-                'member_id' => $recipient->memberId], $actorId
+            [
+                'email_id' => $recipient->emailId,
+                'recipient_id' => $recipientId,
+                'member_id' => $recipient->memberId,
+            ],
+            $actorId
         );
     }
 

--- a/modules/mass_mail/src/Task/SendBatchHandler.php
+++ b/modules/mass_mail/src/Task/SendBatchHandler.php
@@ -79,7 +79,10 @@ class SendBatchHandler implements TaskHandlerInterface
                 // branch is defensive, not an expected path.
                 $recipientRepository->recordSendFailure($recipient->id, 'Adresse invalide');
                 $massMailService->journalRecipientNotSendable(
-                    $recipient->emailId, $recipient->id, $recipient->memberId, 'Adresse invalide'
+                    $recipient->emailId,
+                    $recipient->id,
+                    $recipient->memberId,
+                    'Adresse invalide'
                 );
                 $errorCount++;
                 continue;
@@ -98,7 +101,10 @@ class SendBatchHandler implements TaskHandlerInterface
                 if ($mergeRow === null) {
                     $recipientRepository->recordSendFailure($recipient->id, 'Données de publipostage purgées');
                     $massMailService->journalRecipientNotSendable(
-                        $email->id, $recipient->id, $recipient->memberId, 'Données de publipostage purgées'
+                        $email->id,
+                        $recipient->id,
+                        $recipient->memberId,
+                        'Données de publipostage purgées'
                     );
                     $errorCount++;
                     continue;


### PR DESCRIPTION
## Description

Deux restes de #289. L'auto-merge de cette PR a déclenché sur son head précédent à 21:30:45, à l'instant même où ces deux corrections étaient poussées : elles n'ont donc jamais atteint `main`.

### La version du manifeste

#285 (« Anciens ») et #289 ont incrémenté `mass_mail` à **1.14.0** chacune de son côté. Les deux valeurs étant identiques, la fusion n'a rien eu à signaler — c'est le genre de collision qu'aucun conflit ne rattrape. `main` porte donc aujourd'hui les changements des deux sous un seul numéro, et #289 se retrouve sans incrément à elle.

À dire honnêtement : **c'est le récit qui est faux, pas une installation qui casse.** Le schéma entier est migré par ce qui déploie le code quel que soit le numéro (AGENTS.md § Database, depuis que la comparaison de versions ne pilote plus la ré-application d'un `schema.sql`), et #289 ne déclarait aucun nouveau réglage — donc l'élagage que cette comparaison pilote encore n'avait rien à faire non plus. Passage à 1.15.0.

### Les quinze `php:S1808`

SonarCloud les a signalées sur le diff de #289 : des listes d'arguments coupées en deux lignes sans être alignées, dans les appels ajoutés par ce changement. Le Quality Gate était **passé** malgré elles, mais `.claude/skills/steward/SKILL.md` § SonarCloud est explicite — les nouvelles remarques d'une PR sont à elle, quelle que soit leur sévérité.

Contexte utile pour juger : cette règle est de la dette ancienne ici, **1576 occurrences ouvertes sur `main`**. Rien de neuf n'était donc cassé ; ce qui change est que le code écrit par #289 respecte une règle que ses voisins n'ont jamais respectée. Chaque appel touché passe à un argument par ligne, jamais à la coupure partielle que la règle refuse.

Aucun changement de comportement : ni signature, ni argument, ni ordre. Le diff est du reformatage plus une chaîne de version.

## Checklist
- [x] J'ai lu `ARCHITECTURE.md` et mes changements s'y conforment
- [x] J'ai lu `SECURITY.md` et appliqué la checklist de sécurité
- [x] Tout le code et les commentaires sont en anglais
- [x] Tout le texte d'interface est en français
- [x] Des tests automatisés sont écrits/mis à jour pour ce changement — *aucun test nouveau : ce diff est du reformatage et une chaîne de version, et les tests de #289 couvrent déjà le comportement des appels reformatés*
- [x] Les tests passent localement (`vendor/bin/phpunit` — 16 526 tests, vert)
- [x] PHPStan passe (`vendor/bin/phpstan analyse`)
- [ ] Ce changement ne touche pas `public/assets/js/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WwyhYdAmchwn1283Y4kecu

---
_Generated by [Claude Code](https://claude.ai/code/session_01WwyhYdAmchwn1283Y4kecu)_