### PR TITLE
Écrire les listes d'arguments de core/ comme la règle de mise en forme les attend

### DIFF
--- a/core/Audit/AuditRepository.php
+++ b/core/Audit/AuditRepository.php
@@ -220,11 +220,17 @@ class AuditRepository
 
         $changed = 0;
         foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $row) {
-            $haystack = implode("\n", array_filter([
-                $this->decryptNullable($row['from_value'], 'entity_changes.value'),
-                $this->decryptNullable($row['to_value'], 'entity_changes.value'),
-                $this->decryptNullable($row['summary'], 'entity_changes.value'),
-            ], static fn(?string $v): bool => $v !== null));
+            $haystack = implode(
+                "\n",
+                array_filter(
+                    [
+                        $this->decryptNullable($row['from_value'], 'entity_changes.value'),
+                        $this->decryptNullable($row['to_value'], 'entity_changes.value'),
+                        $this->decryptNullable($row['summary'], 'entity_changes.value'),
+                    ],
+                    static fn(?string $v): bool => $v !== null
+                )
+            );
             if ($haystack === '') {
                 continue;
             }

--- a/core/Config/ScoutYearService.php
+++ b/core/Config/ScoutYearService.php
@@ -115,12 +115,15 @@ class ScoutYearService
         if ($stmt === false) {
             return [];
         }
-        return array_map(fn(array $row) => [
-            'id' => (int) $row['id'],
-            'label' => (string) $row['label'],
-            'start_date' => (string) $row['start_date'],
-            'end_date' => (string) $row['end_date'],
-        ], $stmt->fetchAll(\PDO::FETCH_ASSOC));
+        return array_map(
+            fn(array $row) => [
+                'id' => (int) $row['id'],
+                'label' => (string) $row['label'],
+                'start_date' => (string) $row['start_date'],
+                'end_date' => (string) $row['end_date'],
+            ],
+            $stmt->fetchAll(\PDO::FETCH_ASSOC)
+        );
     }
 
     /**

--- a/core/Http/Controller/AccountController.php
+++ b/core/Http/Controller/AccountController.php
@@ -156,8 +156,10 @@ class AccountController extends AbstractController
         // Validate current password if user already has one
         if ($hasPassword) {
             $account = $this->userAccountRepo->findById($userId);
-            if ($account === null || $account->passwordHash === null || !password_verify($currentPassword,
-                $account->passwordHash)) {
+            if ($account === null || $account->passwordHash === null || !password_verify(
+                $currentPassword,
+                $account->passwordHash
+            )) {
                 FlashMessage::set('error', 'Le mot de passe actuel est incorrect.');
                 return $this->redirect('/account');
             }

--- a/core/Http/Controller/ConfigModulesController.php
+++ b/core/Http/Controller/ConfigModulesController.php
@@ -47,14 +47,17 @@ class ConfigModulesController extends AbstractController
         // string on ModuleInfo->manifest->id, one level deeper than that
         // partial looks, so each entry is wrapped here rather than
         // reworking the shared partial around a configurable id path.
-        $moduleItems = array_map(fn($mod) => [
-            'id' => $mod->manifest->id,
-            'info' => $mod,
-            // Whether this module's hard dependencies (manifest "requires")
-            // are all present, valid and enabled — resolved here rather
-            // than in Twig, which has no access to the discovered set.
-            'requirements_met' => $this->moduleManager->areRequirementsSatisfied($mod->manifest->id, $modules),
-        ], $modules);
+        $moduleItems = array_map(
+            fn($mod) => [
+                'id' => $mod->manifest->id,
+                'info' => $mod,
+                // Whether this module's hard dependencies (manifest "requires")
+                // are all present, valid and enabled — resolved here rather
+                // than in Twig, which has no access to the discovered set.
+                'requirements_met' => $this->moduleManager->areRequirementsSatisfied($mod->manifest->id, $modules),
+            ],
+            $modules
+        );
 
         return $this->render('config/modules.html.twig', [
             'modules' => $moduleItems,

--- a/core/Http/Controller/DuplicateMemberController.php
+++ b/core/Http/Controller/DuplicateMemberController.php
@@ -59,8 +59,10 @@ class DuplicateMemberController extends AbstractController
                 // site knows, newest first.
                 'kept' => $this->identityOf($candidate['kept_member_id'], $years),
                 'duplicate' => $this->identityOf($candidate['duplicate_member_id'], $years),
-                'preview' => $this->mergeService->preview($candidate['kept_member_id'],
-                    $candidate['duplicate_member_id']),
+                'preview' => $this->mergeService->preview(
+                    $candidate['kept_member_id'],
+                    $candidate['duplicate_member_id']
+                ),
             ];
         }
 
@@ -125,8 +127,10 @@ class DuplicateMemberController extends AbstractController
         }
 
         $this->mergeService->markDistinct($candidate['id'], AuthSession::getUserAccountId());
-        FlashMessage::set('success',
-            'Ces deux fiches sont bien deux personnes distinctes. Elles ne seront plus proposées.');
+        FlashMessage::set(
+            'success',
+            'Ces deux fiches sont bien deux personnes distinctes. Elles ne seront plus proposées.'
+        );
 
         return $this->redirect('/admin/doublons');
     }

--- a/core/Http/Controller/EditableContentController.php
+++ b/core/Http/Controller/EditableContentController.php
@@ -86,7 +86,10 @@ class EditableContentController extends AbstractController
         $this->editableContentService->set($key, $value, $type, $userId);
 
         $this->journalService?->log(
-            'core', 'content_updated', 'info', 'Contenu éditable modifié',
+            'core',
+            'content_updated',
+            'info',
+            'Contenu éditable modifié',
             // The address is already event_log.ip_address.
             ['key' => $key, 'type' => $type],
             $userId
@@ -150,7 +153,10 @@ class EditableContentController extends AbstractController
         $this->editableContentService->set($key, $value, $type, $userId);
 
         $this->journalService?->log(
-            'core', 'content_updated', 'info', 'Contenu éditable modifié',
+            'core',
+            'content_updated',
+            'info',
+            'Contenu éditable modifié',
             // The address is already event_log.ip_address.
             ['key' => $key, 'type' => $type],
             $userId

--- a/core/Http/Controller/EmailTemplateController.php
+++ b/core/Http/Controller/EmailTemplateController.php
@@ -162,8 +162,10 @@ class EmailTemplateController extends AbstractController
         $payload = json_decode($request->getRawBody(), true);
         $payload = is_array($payload) ? $payload : [];
 
-        if (($guard = $this->guardCsrfJson($request,
-            isset($payload['_csrf_token']) ? (string) $payload['_csrf_token'] : null)) !== null) {
+        if (($guard = $this->guardCsrfJson(
+            $request,
+            isset($payload['_csrf_token']) ? (string) $payload['_csrf_token'] : null
+        )) !== null) {
             return $guard;
         }
 

--- a/core/Http/Controller/FileController.php
+++ b/core/Http/Controller/FileController.php
@@ -54,7 +54,10 @@ class FileController extends AbstractController
 
         if ($file === null) {
             $this->journalService?->log(
-                'core', 'file_access_denied', 'security', 'Accès à un fichier refusé',
+                'core',
+                'file_access_denied',
+                'security',
+                'Accès à un fichier refusé',
                 ['file_id' => $id, 'ip' => $_SERVER['REMOTE_ADDR'] ?? ''],
                 AuthSession::getUserAccountId()
             );
@@ -351,7 +354,10 @@ class FileController extends AbstractController
 
         if ($file === null) {
             $this->journalService?->log(
-                'core', 'file_access_denied', 'security', 'Accès à un fichier refusé',
+                'core',
+                'file_access_denied',
+                'security',
+                'Accès à un fichier refusé',
                 ['file_id' => $id, 'ip' => $_SERVER['REMOTE_ADDR'] ?? ''],
                 AuthSession::getUserAccountId()
             );

--- a/core/Http/Controller/HelpAssistantController.php
+++ b/core/Http/Controller/HelpAssistantController.php
@@ -97,8 +97,10 @@ class HelpAssistantController extends AbstractController
         $body = json_decode((string) $request->getRawBody(), true);
         $body = is_array($body) ? $body : [];
 
-        if (($guard = $this->guardCsrfJson($request,
-            isset($body['_csrf_token']) && is_string($body['_csrf_token']) ? $body['_csrf_token'] : null)) !== null) {
+        if (($guard = $this->guardCsrfJson(
+            $request,
+            isset($body['_csrf_token']) && is_string($body['_csrf_token']) ? $body['_csrf_token'] : null
+        )) !== null) {
             return $guard;
         }
 

--- a/core/Http/Controller/JournalController.php
+++ b/core/Http/Controller/JournalController.php
@@ -50,8 +50,17 @@ class JournalController extends AbstractController
             $userAccountId = $account !== null ? $account->id : -1;
         }
 
-        $entries = $this->journalRepository->search($category, $level, $search, $dateFrom, $dateTo, $ip, $userAccountId,
-            $perPage, $offset);
+        $entries = $this->journalRepository->search(
+            $category,
+            $level,
+            $search,
+            $dateFrom,
+            $dateTo,
+            $ip,
+            $userAccountId,
+            $perPage,
+            $offset
+        );
         $total = $this->journalRepository->count($category, $level, $search, $dateFrom, $dateTo, $ip, $userAccountId);
         $categories = $this->journalRepository->getDistinctCategories();
         $totalPages = max(1, (int) ceil($total / $perPage));

--- a/core/Http/Controller/MaintenanceController.php
+++ b/core/Http/Controller/MaintenanceController.php
@@ -142,8 +142,11 @@ class MaintenanceController extends AbstractController
         $latestVersion = (string) ($this->settingService->get('update_latest_version') ?: '');
         $installedVersion = VersionFile::read(dirname($this->storagePath));
         $level = (string) ($this->settingService->get('auto_update_level') ?: 'minor');
-        $updateAvailable = $latestVersion !== '' && VersionFile::isNewerThan($latestVersion, $installedVersion,
-            $level === 'dev');
+        $updateAvailable = $latestVersion !== '' && VersionFile::isNewerThan(
+            $latestVersion,
+            $installedVersion,
+            $level === 'dev'
+        );
 
         $autoUpdateEnabled = (bool) ((int) ($this->settingService->get('auto_update_enabled') ?: '0'));
         $webhookConfigured = $this->webhookSecret() !== '';
@@ -295,8 +298,12 @@ class MaintenanceController extends AbstractController
 
         $dependenciesChanged = (bool) ((int) ($this->settingService->get('update_dependencies_changed') ?: '0'));
 
-        $historyId = $this->updateHistoryRepository->create($installedVersion, $latestVersion, $dependenciesChanged,
-            $userId);
+        $historyId = $this->updateHistoryRepository->create(
+            $installedVersion,
+            $latestVersion,
+            $dependenciesChanged,
+            $userId
+        );
 
         $this->schedulerService->scheduleAfter(
             'core',
@@ -308,8 +315,12 @@ class MaintenanceController extends AbstractController
         );
 
         $this->journalService->log(
-            'core', 'update_requested', 'info', 'Installation de mise à jour demandée',
-            ['history_id' => $historyId, 'version_from' => $installedVersion, 'version_to' => $latestVersion], $userId
+            'core',
+            'update_requested',
+            'info',
+            'Installation de mise à jour demandée',
+            ['history_id' => $historyId, 'version_from' => $installedVersion, 'version_to' => $latestVersion],
+            $userId
         );
 
         return $this->json(['success' => true, 'history_id' => $historyId]);
@@ -401,8 +412,12 @@ class MaintenanceController extends AbstractController
         );
 
         $this->journalService->log(
-            'core', 'update_requested', 'info', 'Installation de mise à jour demandée (mode développement)',
-            ['history_id' => $historyId, 'version_from' => $installedVersion, 'version_to' => $versionTo], $userId
+            'core',
+            'update_requested',
+            'info',
+            'Installation de mise à jour demandée (mode développement)',
+            ['history_id' => $historyId, 'version_from' => $installedVersion, 'version_to' => $versionTo],
+            $userId
         );
 
         return $this->json(['success' => true, 'history_id' => $historyId]);
@@ -656,8 +671,12 @@ class MaintenanceController extends AbstractController
             $this->retention()->purgeAfterCreating('database');
 
             $this->journalService->log(
-                'core', 'backup_completed', 'info', 'Sauvegarde de la base de données générée',
-                ['backup_id' => $backupId], $userId
+                'core',
+                'backup_completed',
+                'info',
+                'Sauvegarde de la base de données générée',
+                ['backup_id' => $backupId],
+                $userId
             );
             FlashMessage::set('success', 'Sauvegarde de la base de données générée.');
         } catch (BackupException | \Core\Storage\InsufficientDiskSpaceException $e) {
@@ -681,8 +700,12 @@ class MaintenanceController extends AbstractController
             );
             $this->backupRepository->markFailed($backupId, substr($message, 0, 500));
             $this->journalService->log(
-                'core', 'backup_failed', 'info', 'Échec de la génération d\'une sauvegarde de base de données',
-                ['backup_id' => $backupId, 'error' => $e->getMessage()], $userId
+                'core',
+                'backup_failed',
+                'info',
+                'Échec de la génération d\'une sauvegarde de base de données',
+                ['backup_id' => $backupId, 'error' => $e->getMessage()],
+                $userId
             );
             FlashMessage::set('error', $message);
         }
@@ -741,8 +764,12 @@ class MaintenanceController extends AbstractController
         );
 
         $this->journalService->log(
-            'core', 'backup_requested', 'info', 'Sauvegarde complète demandée',
-            ['backup_id' => $backupId, 'scope' => $scope], $userId
+            'core',
+            'backup_requested',
+            'info',
+            'Sauvegarde complète demandée',
+            ['backup_id' => $backupId, 'scope' => $scope],
+            $userId
         );
 
         return $this->json(['success' => true, 'backup_id' => $backupId]);
@@ -849,8 +876,12 @@ class MaintenanceController extends AbstractController
         $this->settingService->set('backup_auto_frequency', $frequency);
 
         $this->journalService->log(
-            'core', 'setting_changed', 'info', 'Fréquence de sauvegarde automatique modifiée',
-            ['key' => 'backup_auto_frequency', 'new_value' => $frequency], $userId
+            'core',
+            'setting_changed',
+            'info',
+            'Fréquence de sauvegarde automatique modifiée',
+            ['key' => 'backup_auto_frequency', 'new_value' => $frequency],
+            $userId
         );
 
         return $this->json(['success' => true]);
@@ -1018,8 +1049,14 @@ class MaintenanceController extends AbstractController
         $userId = AuthSession::getUserAccountId();
         $actionId = $this->schedulerService->scheduleAfter('core', 'reset_settings', 0, [], null, $userId);
 
-        $this->journalService->log('core', 'settings_reset_requested', 'security',
-            'Réinitialisation des paramètres par défaut demandée', [], $userId);
+        $this->journalService->log(
+            'core',
+            'settings_reset_requested',
+            'security',
+            'Réinitialisation des paramètres par défaut demandée',
+            [],
+            $userId
+        );
 
         return $this->json(['success' => true, 'action_id' => $actionId]);
     }
@@ -1048,8 +1085,14 @@ class MaintenanceController extends AbstractController
         $userId = AuthSession::getUserAccountId();
         $actionId = $this->schedulerService->scheduleAfter('core', 'full_reset', 0, [], null, $userId);
 
-        $this->journalService->log('core', 'full_reset_requested', 'security', 'Réinitialisation complète demandée', [],
-            $userId);
+        $this->journalService->log(
+            'core',
+            'full_reset_requested',
+            'security',
+            'Réinitialisation complète demandée',
+            [],
+            $userId
+        );
 
         return $this->json(['success' => true, 'action_id' => $actionId]);
     }
@@ -1160,8 +1203,14 @@ class MaintenanceController extends AbstractController
 
         $actionId = $this->schedulerService->scheduleAfter('core', 'restore_backup', 0, $payload, null, $userId);
 
-        $this->journalService->log('core', 'backup_restore_requested', 'security',
-            'Restauration de sauvegarde demandée', ['source' => $source], $userId);
+        $this->journalService->log(
+            'core',
+            'backup_restore_requested',
+            'security',
+            'Restauration de sauvegarde demandée',
+            ['source' => $source],
+            $userId
+        );
 
         return $this->redirect('/config/maintenance?restore_id=' . $actionId);
     }
@@ -1323,9 +1372,12 @@ class MaintenanceController extends AbstractController
             $this->reconcilePendingScheduledInstall($enabled, $level, null, null, $userId);
 
             $this->journalService->log(
-                'core', 'auto_update_settings_changed', 'security',
+                'core',
+                'auto_update_settings_changed',
+                'security',
                 'Préférences de mise à jour automatique modifiées (mode développement)',
-                ['enabled' => $enabled, 'level' => $level, 'branch' => $branch], $userId
+                ['enabled' => $enabled, 'level' => $level, 'branch' => $branch],
+                $userId
             );
 
             return $this->json(['success' => true]);
@@ -1349,8 +1401,12 @@ class MaintenanceController extends AbstractController
         $this->reconcilePendingScheduledInstall($enabled, $level, $day, $time, $userId);
 
         $this->journalService->log(
-            'core', 'auto_update_settings_changed', 'info', 'Préférences de mise à jour automatique modifiées',
-            ['enabled' => $enabled, 'level' => $level, 'day' => $day, 'time' => $time], $userId
+            'core',
+            'auto_update_settings_changed',
+            'info',
+            'Préférences de mise à jour automatique modifiées',
+            ['enabled' => $enabled, 'level' => $level, 'day' => $day, 'time' => $time],
+            $userId
         );
 
         return $this->json(['success' => true]);
@@ -1375,8 +1431,11 @@ class MaintenanceController extends AbstractController
         ?int $userId
     ): void
     {
-        $pending = $this->schedulerService->find('core', 'install_update',
-            GitHubWebhookService::SCHEDULED_INSTALL_REFERENCE);
+        $pending = $this->schedulerService->find(
+            'core',
+            'install_update',
+            GitHubWebhookService::SCHEDULED_INSTALL_REFERENCE
+        );
         if ($pending === null) {
             return;
         }
@@ -1423,9 +1482,12 @@ class MaintenanceController extends AbstractController
         }
 
         $this->journalService->log(
-            'core', 'auto_update_canceled', 'info',
+            'core',
+            'auto_update_canceled',
+            'info',
             'Installation automatique planifiée annulée suite au changement des préférences',
-            ['history_id' => $historyId], $userId
+            ['history_id' => $historyId],
+            $userId
         );
     }
 

--- a/core/Http/Controller/MemberController.php
+++ b/core/Http/Controller/MemberController.php
@@ -66,8 +66,13 @@ class MemberController extends AbstractController
         $isSelf = $this->memberService->canAccess($userEmail, $memberYearId, 'identified');
         $isChiefOrAbove = Role::fromString($userRole)->hasAccess(Role::CHIEF);
 
-        $pageData = $this->memberPageService->buildPageData($profile, $scoutYearId, $isSelf, $isChiefOrAbove,
-            Role::fromString($userRole));
+        $pageData = $this->memberPageService->buildPageData(
+            $profile,
+            $scoutYearId,
+            $isSelf,
+            $isChiefOrAbove,
+            Role::fromString($userRole)
+        );
 
         return $this->render('members/show.html.twig', array_merge($pageData, [
             'member' => $profile,

--- a/core/Http/Controller/MemberEmailAddressController.php
+++ b/core/Http/Controller/MemberEmailAddressController.php
@@ -56,8 +56,11 @@ class MemberEmailAddressController extends AbstractController
         }
 
         try {
-            $this->memberEmailService->addEmail($memberId, (string) $request->getBody('email', ''),
-                AuthSession::getUserAccountId());
+            $this->memberEmailService->addEmail(
+                $memberId,
+                (string) $request->getBody('email', ''),
+                AuthSession::getUserAccountId()
+            );
             FlashMessage::set('success', 'Adresse ajoutée — un email de confirmation vient de vous être envoyé.');
         } catch (MemberEmailException $e) {
             FlashMessage::set('error', $e->getMessage());
@@ -87,8 +90,11 @@ class MemberEmailAddressController extends AbstractController
         }
 
         try {
-            $this->memberEmailService->resendConfirmation($memberId, (int) $params['email_id'],
-                AuthSession::getUserAccountId());
+            $this->memberEmailService->resendConfirmation(
+                $memberId,
+                (int) $params['email_id'],
+                AuthSession::getUserAccountId()
+            );
             FlashMessage::set('success', 'Email de confirmation renvoyé.');
         } catch (MemberEmailException $e) {
             FlashMessage::set('error', $e->getMessage());
@@ -148,8 +154,11 @@ class MemberEmailAddressController extends AbstractController
         }
 
         try {
-            $this->memberEmailService->reactivateEmail($memberId, (int) $params['email_id'],
-                AuthSession::getUserAccountId());
+            $this->memberEmailService->reactivateEmail(
+                $memberId,
+                (int) $params['email_id'],
+                AuthSession::getUserAccountId()
+            );
             FlashMessage::set('success', 'Adresse réactivée.');
         } catch (MemberEmailException $e) {
             FlashMessage::set('error', $e->getMessage());

--- a/core/Http/Controller/NotificationConfigController.php
+++ b/core/Http/Controller/NotificationConfigController.php
@@ -104,8 +104,11 @@ class NotificationConfigController extends AbstractController
             AuthSession::getUserAccountId()
         );
 
-        FlashMessage::set('success', "Clés VAPID régénérées. {$deviceCount} appareil(s) déconnecté(s) — chacun devra "
-            . "réactiver les notifications push.");
+        FlashMessage::set(
+            'success',
+            "Clés VAPID régénérées. {$deviceCount} appareil(s) déconnecté(s) — chacun devra "
+            . "réactiver les notifications push."
+        );
 
         return $this->redirect('/config/notifications');
     }

--- a/core/Http/Controller/PasswordResetController.php
+++ b/core/Http/Controller/PasswordResetController.php
@@ -135,8 +135,10 @@ class PasswordResetController extends AbstractController
     {
         $id = (int) ($params['id'] ?? 0);
 
-        if (($guard = $this->guardCsrf($request,
-            '/password-reset/' . $id . '#' . rawurlencode((string) $request->getBody('token', '')))) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            '/password-reset/' . $id . '#' . rawurlencode((string) $request->getBody('token', ''))
+        )) !== null) {
             return $guard;
         }
 
@@ -157,8 +159,10 @@ class PasswordResetController extends AbstractController
         }
 
         if (!$this->passwordResetService->resetPassword($id, $token, $newPassword)) {
-            FlashMessage::set('error',
-                'Ce lien de réinitialisation n\'est plus valide. Veuillez en demander un nouveau.');
+            FlashMessage::set(
+                'error',
+                'Ce lien de réinitialisation n\'est plus valide. Veuillez en demander un nouveau.'
+            );
             return $this->redirect('/login');
         }
 

--- a/core/Http/Controller/PushSubscriptionController.php
+++ b/core/Http/Controller/PushSubscriptionController.php
@@ -63,8 +63,13 @@ class PushSubscriptionController extends AbstractController
             return $this->json(['success' => false, 'error' => 'Non authentifié.'], 401);
         }
 
-        $this->notificationService->subscribe($userId, $endpoint, $authKey, $p256dhKey,
-            $this->deviceLabelFromUserAgent($request));
+        $this->notificationService->subscribe(
+            $userId,
+            $endpoint,
+            $authKey,
+            $p256dhKey,
+            $this->deviceLabelFromUserAgent($request)
+        );
 
         $this->journalService->log(
             'core',

--- a/core/Http/Controller/ScoutYearController.php
+++ b/core/Http/Controller/ScoutYearController.php
@@ -237,13 +237,16 @@ class ScoutYearController extends AbstractController
                 ['blocking_request_count' => $count],
                 AuthSession::getUserAccountId()
             );
-            FlashMessage::set('error', sprintf(
-                "Impossible de basculer : %d demande(s) d'inscription ne sont pas encore clôturées, toutes années "
-                    . "confondues. "
-                . 'Traitez-les depuis la page de gestion des inscriptions avant de poursuivre — le traitement en masse '
-                . "(« tout refuser », « tout retirer ») y est disponible.",
-                $count
-            ));
+            FlashMessage::set(
+                'error',
+                sprintf(
+                    "Impossible de basculer : %d demande(s) d'inscription ne sont pas encore clôturées, toutes "
+                    . "années confondues. "
+                    . 'Traitez-les depuis la page de gestion des inscriptions avant de poursuivre — le traitement '
+                    . "en masse (« tout refuser », « tout retirer ») y est disponible.",
+                    $count
+                )
+            );
             return $this->redirect('/admin/scout-year');
         }
 

--- a/core/Http/Controller/SectionDocumentController.php
+++ b/core/Http/Controller/SectionDocumentController.php
@@ -130,8 +130,14 @@ class SectionDocumentController extends AbstractController
 
         try {
             $this->service->upload(
-                $sectionId, $scoutYearId, $content, $mimeType, (string) $file['name'],
-                $title, $description !== '' ? $description : null, AuthSession::getUserAccountId()
+                $sectionId,
+                $scoutYearId,
+                $content,
+                $mimeType,
+                (string) $file['name'],
+                $title,
+                $description !== '' ? $description : null,
+                AuthSession::getUserAccountId()
             );
             FlashMessage::set('success', 'Document ajouté.');
         } catch (SectionDocumentException $e) {
@@ -164,7 +170,10 @@ class SectionDocumentController extends AbstractController
 
         try {
             $this->service->updateTitleAndDescription(
-                $id, (string) ($data['title'] ?? ''), $data['description'] ?? null, AuthSession::getUserAccountId()
+                $id,
+                (string) ($data['title'] ?? ''),
+                $data['description'] ?? null,
+                AuthSession::getUserAccountId()
             );
         } catch (SectionDocumentException $e) {
             return $this->json(['success' => false, 'error' => $e->getMessage()], 400);

--- a/core/Http/Controller/SetupController.php
+++ b/core/Http/Controller/SetupController.php
@@ -236,8 +236,10 @@ class SetupController extends AbstractController
         }
 
         if ($this->secretManager->isInitialized()) {
-            return $this->json(['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'],
-                403);
+            return $this->json(
+                ['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'],
+                403
+            );
         }
         // setup.js reads `message`, not `error` — keep the key, unify the sentence.
         if (!CsrfGuard::validateRequest()) {
@@ -317,7 +319,10 @@ class SetupController extends AbstractController
             return $gate;
         }
         if ($this->secretManager->isInitialized()) {
-            return $this->json(['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'], 403);
+            return $this->json(
+                ['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'],
+                403
+            );
         }
         if (!CsrfGuard::validateRequest()) {
             return $this->json(['success' => false, 'message' => self::SESSION_EXPIRED_MESSAGE], 403);
@@ -396,7 +401,10 @@ class SetupController extends AbstractController
             return $gate;
         }
         if ($this->secretManager->isInitialized()) {
-            return $this->json(['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'], 403);
+            return $this->json(
+                ['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'],
+                403
+            );
         }
         if (!CsrfGuard::validateRequest()) {
             return $this->json(['success' => false, 'message' => self::SESSION_EXPIRED_MESSAGE], 403);
@@ -443,7 +451,9 @@ class SetupController extends AbstractController
             // and a restore's statements are the site's own data — the
             // journal is read on screen and travels in a support archive.
             $this->journalService?->log(
-                'core', 'setup_portable_restore_failed', 'security',
+                'core',
+                'setup_portable_restore_failed',
+                'security',
                 'Restauration portable depuis l\'assistant : échec',
                 ['error' => $e instanceof UserFacingException ? $e->getMessage() : $e::class]
             );
@@ -542,7 +552,9 @@ class SetupController extends AbstractController
             $restore->adoptNewIdentity($connection->getPdo(), $archive->originInstallationId(), $baseUrl);
 
             $this->journalService?->log(
-                'core', 'setup_portable_restored', 'security',
+                'core',
+                'setup_portable_restored',
+                'security',
                 'Site restauré depuis une sauvegarde portable par l\'assistant d\'installation',
                 ['restored_from' => $archive->originInstallationId(), 'version' => $archive->version()]
             );
@@ -674,8 +686,10 @@ class SetupController extends AbstractController
         }
 
         if ($this->secretManager->isInitialized()) {
-            return $this->json(['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'],
-                403);
+            return $this->json(
+                ['success' => false, 'message' => 'Action indisponible : le site est déjà configuré.'],
+                403
+            );
         }
         // setup.js reads `message`, not `error` — keep the key, unify the sentence.
         if (!CsrfGuard::validateRequest()) {
@@ -1109,7 +1123,10 @@ class SetupController extends AbstractController
             SessionStore::remove('setup_token_attempts', 'setup_token_locked_until', 'setup_token_error');
             SessionStore::set('setup_token_verified', true);
             $this->journalService?->log(
-                'core', 'setup_token_verified', 'security', 'Jeton d\'installation vérifié avec succès',
+                'core',
+                'setup_token_verified',
+                'security',
+                'Jeton d\'installation vérifié avec succès',
                 // The address is already in event_log.ip_address (JournalService::log());
                 // a second copy in the JSON stores the same personal datum twice.
                 []
@@ -1133,7 +1150,10 @@ class SetupController extends AbstractController
         }
 
         $this->journalService?->log(
-            'core', 'setup_token_failed', 'security', 'Tentative de jeton d\'installation invalide',
+            'core',
+            'setup_token_failed',
+            'security',
+            'Tentative de jeton d\'installation invalide',
             // Only what event_log.ip_address does not already hold.
             ['attempts' => $attempts]
         );
@@ -1369,8 +1389,13 @@ class SetupController extends AbstractController
             $this->secretManager->writeSecrets($secrets);
 
             // Create initial admin account (base64 keys decoded to match the boot sequence)
-            $this->createAdminAccount($connection, $secrets['encryption_key'], $secrets['blind_index_key'],
-                $data['admin_email'], $data['admin_password']);
+            $this->createAdminAccount(
+                $connection,
+                $secrets['encryption_key'],
+                $secrets['blind_index_key'],
+                $data['admin_email'],
+                $data['admin_password']
+            );
 
             // Record the installation date now, while "now" is genuinely the
             // moment this site came into existence (Core\Statistics\
@@ -1387,11 +1412,20 @@ class SetupController extends AbstractController
             // own register() call, which would otherwise create the row with
             // its default (on) and silently ignore an operator who unchecked
             // the box.
-            $setupSettingService->register('statistics_enabled', '1', 'boolean', 'Envoi automatique des statistiques '
+            $setupSettingService->register(
+                'statistics_enabled',
+                '1',
+                'boolean',
+                'Envoi automatique des statistiques '
                 . 'd\'utilisation',
                 'Autorise l\'envoi quotidien d\'un rapport d\'utilisation agrégé vers ScoutMagic. Le rapport contient '
                     . 'l\'adresse de ce site, jamais de donnée de membre. Géré depuis la page Support.',
-                null, null, null, true, 280);
+                null,
+                null,
+                null,
+                true,
+                280
+            );
             $setupSettingService->setInternal('statistics_enabled', $data['statistics_enabled']);
 
             $tokenDeleted = $this->deleteTokenFileWithWarning();
@@ -1494,7 +1528,10 @@ class SetupController extends AbstractController
             }
 
             $this->journalService?->log(
-                'core', 'setup_completed', 'security', 'Configuration du site enregistrée',
+                'core',
+                'setup_completed',
+                'security',
+                'Configuration du site enregistrée',
                 // Already event_log.ip_address — see above.
                 [],
                 AuthSession::getUserAccountId()
@@ -1639,8 +1676,10 @@ class SetupController extends AbstractController
             if ($data['admin_password'] === '') {
                 $errors['admin_password'] = 'Le mot de passe administrateur est requis.';
             } else {
-                $violation = self::passwordPolicyError($data['admin_password'],
-                    (string) ($data['admin_password_confirm'] ?? ''));
+                $violation = self::passwordPolicyError(
+                    $data['admin_password'],
+                    (string) ($data['admin_password_confirm'] ?? '')
+                );
                 if ($violation !== null) {
                     $errors['admin_password'] = $violation;
                 }
@@ -1652,8 +1691,10 @@ class SetupController extends AbstractController
             }
             // Password is only required when changing admin email to a new address without existing account
             if ($data['admin_password'] !== '') {
-                $violation = self::passwordPolicyError($data['admin_password'],
-                    (string) ($data['admin_password_confirm'] ?? ''));
+                $violation = self::passwordPolicyError(
+                    $data['admin_password'],
+                    (string) ($data['admin_password_confirm'] ?? '')
+                );
                 if ($violation !== null) {
                     $errors['admin_password'] = $violation;
                 }
@@ -1820,7 +1861,9 @@ class SetupController extends AbstractController
         }
 
         $this->journalService?->log(
-            'core', 'setup_token_gate_blocked', 'security',
+            'core',
+            'setup_token_gate_blocked',
+            'security',
             'Accès à un point d\'entrée d\'installation sans jeton vérifié',
             // The address is already in event_log.ip_address (JournalService::log());
             // a second copy in the JSON stores the same personal datum twice.
@@ -1938,7 +1981,9 @@ class SetupController extends AbstractController
         }
 
         $this->journalService?->log(
-            'core', 'setup_token_delete_failed', 'security',
+            'core',
+            'setup_token_delete_failed',
+            'security',
             'Impossible de supprimer token.php après l\'installation — à retirer manuellement via FTP.',
             []
         );

--- a/core/Http/Controller/StaffsController.php
+++ b/core/Http/Controller/StaffsController.php
@@ -132,8 +132,10 @@ class StaffsController extends AbstractController
         // be assigned to Staff d'U members"; BadgeService::toggleAssignment()
         // enforces this server-side too, regardless of this filtering).
         if ($currentSection !== null && $currentSection['desk_code'] !== UnitStaffSectionService::DESK_CODE) {
-            $availableBadges = array_values(array_filter($availableBadges,
-                fn(Badge $b) => $b->referentSectionId === null));
+            $availableBadges = array_values(array_filter(
+                $availableBadges,
+                fn(Badge $b) => $b->referentSectionId === null
+            ));
         }
 
         // Documents de section (module addendum) — built for any selected
@@ -143,8 +145,10 @@ class StaffsController extends AbstractController
         // request site-wide, since it's a real subprocess spawn.
         $sectionDocumentYears = [];
         if ($currentSection !== null) {
-            $sectionDocumentYears = $this->sectionDocumentService->listYearsForStaffsPage($currentSection['id'],
-                $scoutYearId);
+            $sectionDocumentYears = $this->sectionDocumentService->listYearsForStaffsPage(
+                $currentSection['id'],
+                $scoutYearId
+            );
         }
         $compressionBackend = $this->sectionDocumentService->refreshDetectedBackend();
 

--- a/core/Http/Controller/SupportController.php
+++ b/core/Http/Controller/SupportController.php
@@ -561,8 +561,10 @@ class SupportController extends AbstractController
         } elseif ($result->isSkipped()) {
             FlashMessage::set('warning', self::skipMessage((string) $result->reason));
         } else {
-            FlashMessage::set('error',
-                'Le rapport de test n\'a pas pu être transmis. Motif : ' . (string) $result->reason);
+            FlashMessage::set(
+                'error',
+                'Le rapport de test n\'a pas pu être transmis. Motif : ' . (string) $result->reason
+            );
         }
 
         return $this->redirect('/config/support');

--- a/core/Http/Controller/UploadController.php
+++ b/core/Http/Controller/UploadController.php
@@ -72,8 +72,10 @@ class UploadController extends AbstractController
      */
     public function store(Request $request, array $params): Response
     {
-        if (($guard = $this->guardCsrf($request,
-            SafeRedirect::internalPath((string) $request->getBody('return_url', '/')))) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            SafeRedirect::internalPath((string) $request->getBody('return_url', '/'))
+        )) !== null) {
             return $guard;
         }
 

--- a/core/Import/FeeCategoryRepository.php
+++ b/core/Import/FeeCategoryRepository.php
@@ -30,11 +30,14 @@ class FeeCategoryRepository
             return [];
         }
 
-        return array_map(static fn(array $row) => [
-            'id' => (int) $row['id'],
-            'desk_code' => (string) $row['desk_code'],
-            'label' => (string) $row['label'],
-        ], $stmt->fetchAll(\PDO::FETCH_ASSOC));
+        return array_map(
+            static fn(array $row) => [
+                'id' => (int) $row['id'],
+                'desk_code' => (string) $row['desk_code'],
+                'label' => (string) $row['label'],
+            ],
+            $stmt->fetchAll(\PDO::FETCH_ASSOC)
+        );
     }
 
     /**

--- a/core/Mail/Template/EmailTemplateRegistry.php
+++ b/core/Mail/Template/EmailTemplateRegistry.php
@@ -69,8 +69,11 @@ class EmailTemplateRegistry
                 defaultSubject: 'Votre lien de connexion',
                 template: 'email/magic_link.html.twig',
                 variables: [
-                    new EmailTemplateVariable('magic_link_url', 'Lien de connexion',
-                        'https://exemple.be/auth/verify?token=…'),
+                    new EmailTemplateVariable(
+                        'magic_link_url',
+                        'Lien de connexion',
+                        'https://exemple.be/auth/verify?token=…'
+                    ),
                     new EmailTemplateVariable('expiry_minutes', 'Durée de validité (minutes)', '15'),
                 ],
                 editable: false
@@ -82,8 +85,11 @@ class EmailTemplateRegistry
                 defaultSubject: 'Réinitialisation de votre mot de passe',
                 template: 'email/password_reset.html.twig',
                 variables: [
-                    new EmailTemplateVariable('reset_url', 'Lien de réinitialisation',
-                        'https://exemple.be/password-reset/12'),
+                    new EmailTemplateVariable(
+                        'reset_url',
+                        'Lien de réinitialisation',
+                        'https://exemple.be/password-reset/12'
+                    ),
                     new EmailTemplateVariable('expiry_minutes', 'Durée de validité (minutes)', '30'),
                 ],
                 editable: false
@@ -95,8 +101,11 @@ class EmailTemplateRegistry
                 defaultSubject: 'Confirmez votre adresse email',
                 template: 'email/member_email_confirmation.html.twig',
                 variables: [
-                    new EmailTemplateVariable('confirm_url', 'Lien de confirmation',
-                        'https://exemple.be/members/emails/confirm/7'),
+                    new EmailTemplateVariable(
+                        'confirm_url',
+                        'Lien de confirmation',
+                        'https://exemple.be/members/emails/confirm/7'
+                    ),
                     new EmailTemplateVariable('expiry_hours', 'Durée de validité (heures)', '48'),
                 ],
                 editable: false
@@ -132,12 +141,21 @@ class EmailTemplateRegistry
                 template: 'email/notification.html.twig',
                 variables: [
                     new EmailTemplateVariable('title', 'Titre de la notification', 'Sauvegarde terminée'),
-                    new EmailTemplateVariable('body', 'Texte de la notification',
-                        'La sauvegarde que vous avez demandée est prête.'),
-                    new EmailTemplateVariable('url', 'Lien vers la page concernée',
-                        'https://exemple.be/config/maintenance'),
-                    new EmailTemplateVariable('preferences_url', 'Lien vers les préférences',
-                        'https://exemple.be/notifications/preferences'),
+                    new EmailTemplateVariable(
+                        'body',
+                        'Texte de la notification',
+                        'La sauvegarde que vous avez demandée est prête.'
+                    ),
+                    new EmailTemplateVariable(
+                        'url',
+                        'Lien vers la page concernée',
+                        'https://exemple.be/config/maintenance'
+                    ),
+                    new EmailTemplateVariable(
+                        'preferences_url',
+                        'Lien vers les préférences',
+                        'https://exemple.be/notifications/preferences'
+                    ),
                 ]
             ),
             new EmailTemplate(

--- a/core/Maintenance/GitHubWebhookService.php
+++ b/core/Maintenance/GitHubWebhookService.php
@@ -233,8 +233,12 @@ class GitHubWebhookService
         $time = (string) ($this->settings->get('auto_update_time') ?: '03:00');
         $runAt = self::nextOccurrence($day, $time, new \DateTimeImmutable());
 
-        $historyId = $this->updateHistoryRepository->create($installedVersion, $latestVersion, $dependenciesChanged,
-            null);
+        $historyId = $this->updateHistoryRepository->create(
+            $installedVersion,
+            $latestVersion,
+            $dependenciesChanged,
+            null
+        );
 
         // A later release arriving before the previous one's slot fires
         // replaces it — only the newest known release should ever be

--- a/core/Maintenance/Task/AutoBackupHandler.php
+++ b/core/Maintenance/Task/AutoBackupHandler.php
@@ -116,8 +116,13 @@ class AutoBackupHandler implements TaskHandlerInterface
 
             $context->settings->setInternal('backup_auto_last_run', (new \DateTimeImmutable())->format('Y-m-d H:i:s'));
 
-            $context->journal->log('core', 'auto_backup_completed', 'info', 'Sauvegarde automatique effectuée',
-                ['backup_id' => $backupId]);
+            $context->journal->log(
+                'core',
+                'auto_backup_completed',
+                'info',
+                'Sauvegarde automatique effectuée',
+                ['backup_id' => $backupId]
+            );
 
             (new \Core\Maintenance\BackupRetention(
                 $backupRepository,
@@ -127,8 +132,13 @@ class AutoBackupHandler implements TaskHandlerInterface
                 \Core\Maintenance\BackupSafetyNet::forPdo($context->connection->getPdo())
             ))->purgeAfterCreating('auto_backup');
         } catch (\Throwable $e) {
-            $context->journal->log('core', 'auto_backup_failed', 'info', 'Échec de la sauvegarde automatique',
-                ['error' => $e->getMessage()]);
+            $context->journal->log(
+                'core',
+                'auto_backup_failed',
+                'info',
+                'Échec de la sauvegarde automatique',
+                ['error' => $e->getMessage()]
+            );
         }
     }
 

--- a/core/Maintenance/Task/CheckStableUpdateHandler.php
+++ b/core/Maintenance/Task/CheckStableUpdateHandler.php
@@ -73,8 +73,11 @@ class CheckStableUpdateHandler implements TaskHandlerInterface
             $service->checkForNewRelease();
         } catch (\Throwable $e) {
             $context->journal->log(
-                'core', 'auto_update_check_failed', 'info',
-                'Échec de la vérification quotidienne des mises à jour', ['error' => $e->getMessage()]
+                'core',
+                'auto_update_check_failed',
+                'info',
+                'Échec de la vérification quotidienne des mises à jour',
+                ['error' => $e->getMessage()]
             );
         }
     }

--- a/core/Maintenance/Task/CreateBackupHandler.php
+++ b/core/Maintenance/Task/CreateBackupHandler.php
@@ -152,11 +152,18 @@ class CreateBackupHandler implements TaskHandlerInterface
             // caught, so anything at all can arrive — the gate keeps a
             // ZipArchive/PDO message off that page while the journal entry
             // just below keeps the real text.
-            $backupRepository->markFailed($backupId, substr(UserFacingMessage::from(
-                $e,
-                'La sauvegarde n\'a pas pu être générée — vérifiez l\'espace disque disponible et les droits '
-                . 'd\'écriture sur storage/, puis relancez-la.'
-            ), 0, 500));
+            $backupRepository->markFailed(
+                $backupId,
+                substr(
+                    UserFacingMessage::from(
+                        $e,
+                        'La sauvegarde n\'a pas pu être générée — vérifiez l\'espace disque disponible et les droits '
+                        . 'd\'écriture sur storage/, puis relancez-la.'
+                    ),
+                    0,
+                    500
+                )
+            );
             $context->journal->log(
                 'core',
                 'backup_failed',

--- a/core/Maintenance/Task/InstallUpdateHandler.php
+++ b/core/Maintenance/Task/InstallUpdateHandler.php
@@ -128,8 +128,16 @@ class InstallUpdateHandler implements TaskHandlerInterface
         // must never be repeated: installFiles() is not safe to re-run
         // over files that may already reflect the new version.
         if ($history->status === 'migrating') {
-            $this->resumeMigration($historyId, $history, $downloadUrl, $sourceType, $context, $updateHistoryRepository,
-                $backupRepository, $fileRepository);
+            $this->resumeMigration(
+                $historyId,
+                $history,
+                $downloadUrl,
+                $sourceType,
+                $context,
+                $updateHistoryRepository,
+                $backupRepository,
+                $fileRepository
+            );
             return;
         }
 
@@ -431,8 +439,14 @@ class InstallUpdateHandler implements TaskHandlerInterface
 
             $this->refuseUnconvergedMigration($migrationResult);
 
-            $this->finishInstall($historyId, $history, $context, $updateHistoryRepository, $backupRepository,
-                $fileRepository);
+            $this->finishInstall(
+                $historyId,
+                $history,
+                $context,
+                $updateHistoryRepository,
+                $backupRepository,
+                $fileRepository
+            );
         } catch (\Throwable $migrationError) {
             // Unlike the initial attempt, this invocation never created its
             // own backup — reconstruct the safety backup's file paths from

--- a/core/Maintenance/Task/RestoreBackupHandler.php
+++ b/core/Maintenance/Task/RestoreBackupHandler.php
@@ -226,8 +226,14 @@ class RestoreBackupHandler implements TaskHandlerInterface
 
                 return;
             } catch (\Throwable $restoreError) {
-                $this->rollbackToSafetyBackup($context, $backupService, (string) $safetyDbDump, (string) $safetyZip,
-                    $requestedBy, $restoreError);
+                $this->rollbackToSafetyBackup(
+                    $context,
+                    $backupService,
+                    (string) $safetyDbDump,
+                    (string) $safetyZip,
+                    $requestedBy,
+                    $restoreError
+                );
             }
         } catch (\Throwable $e) {
             $context->journal->log(

--- a/core/Member/Controller/MemberSearchController.php
+++ b/core/Member/Controller/MemberSearchController.php
@@ -160,35 +160,38 @@ class MemberSearchController extends AbstractController
         );
         $departureStatus = $this->departureService->getStatus($profile->memberYearId);
 
-        return $this->render('admin/members/show.html.twig', array_merge(
-            $this->adminMemberPageService->buildPageData($profile, $effective->id),
-            [
-                'member' => $profile,
-                'breadcrumb_current' => trim($profile->lastName . ' ' . $profile->firstName),
-                'effective_age' => $effectiveAge,
-                'departure_leaving' => $departureStatus?->leaving ?? false,
-                'departure_comment' => $departureStatus?->comment ?? '',
-                'is_temporary_member' => TemporaryMemberSession::get() === $profile->memberYearId,
-                // Keyed on the PERSISTENT member id, not the annual row:
-                // a note about a person outlives the scout year that saw
-                // it written.
-                'notes' => $this->memberNoteService->listForMember($profile->memberId),
-                'note_max_length' => MemberNoteService::MAX_LENGTH,
-                // The year the page is actually showing, which is the
-                // member's own latest — not necessarily the effective one.
-                'year_label' => $profile->scoutYearLabel,
-                'is_past_year' => $profile->scoutYearLabel !== $effective->label,
-                // « Année dans la branche » is an ANIMÉ's fact, and the
-                // write behind those buttons refuses anybody else
-                // (Core\Http\Controller\MemberController::
-                // updateScoutYearOffset()). Asked here with the same
-                // predicate rather than a second rule, so the card is
-                // never rendered where saving is guaranteed to fail — a
-                // staff member-year, an inactive row, or an animé of a
-                // section this account does not staff.
-                'can_edit_scout_year_offset' => $this->canEditScoutYearOffset($profile->memberYearId),
-            ]
-        ));
+        return $this->render(
+            'admin/members/show.html.twig',
+            array_merge(
+                $this->adminMemberPageService->buildPageData($profile, $effective->id),
+                [
+                    'member' => $profile,
+                    'breadcrumb_current' => trim($profile->lastName . ' ' . $profile->firstName),
+                    'effective_age' => $effectiveAge,
+                    'departure_leaving' => $departureStatus?->leaving ?? false,
+                    'departure_comment' => $departureStatus?->comment ?? '',
+                    'is_temporary_member' => TemporaryMemberSession::get() === $profile->memberYearId,
+                    // Keyed on the PERSISTENT member id, not the annual row:
+                    // a note about a person outlives the scout year that saw
+                    // it written.
+                    'notes' => $this->memberNoteService->listForMember($profile->memberId),
+                    'note_max_length' => MemberNoteService::MAX_LENGTH,
+                    // The year the page is actually showing, which is the
+                    // member's own latest — not necessarily the effective one.
+                    'year_label' => $profile->scoutYearLabel,
+                    'is_past_year' => $profile->scoutYearLabel !== $effective->label,
+                    // « Année dans la branche » is an ANIMÉ's fact, and the
+                    // write behind those buttons refuses anybody else
+                    // (Core\Http\Controller\MemberController::
+                    // updateScoutYearOffset()). Asked here with the same
+                    // predicate rather than a second rule, so the card is
+                    // never rendered where saving is guaranteed to fail — a
+                    // staff member-year, an inactive row, or an animé of a
+                    // section this account does not staff.
+                    'can_edit_scout_year_offset' => $this->canEditScoutYearOffset($profile->memberYearId),
+                ]
+            )
+        );
     }
 
     /**

--- a/core/Member/Controller/TemporaryMemberController.php
+++ b/core/Member/Controller/TemporaryMemberController.php
@@ -59,8 +59,10 @@ class TemporaryMemberController extends AbstractController
      */
     public function add(Request $request, array $params): Response
     {
-        if (($guard = $this->guardCsrf($request,
-            SafeRedirect::internalPathFromUrl($request->getReferer() ?? '/admin/members'))) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            SafeRedirect::internalPathFromUrl($request->getReferer() ?? '/admin/members')
+        )) !== null) {
             return $guard;
         }
 
@@ -164,8 +166,10 @@ class TemporaryMemberController extends AbstractController
      */
     public function remove(Request $request, array $params): Response
     {
-        if (($guard = $this->guardCsrf($request,
-            SafeRedirect::internalPathFromUrl($request->getReferer() ?? '/admin/members'))) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            SafeRedirect::internalPathFromUrl($request->getReferer() ?? '/admin/members')
+        )) !== null) {
             return $guard;
         }
 

--- a/core/Member/Export/MemberExportColumns.php
+++ b/core/Member/Export/MemberExportColumns.php
@@ -50,81 +50,246 @@ final class MemberExportColumns
     public static function all(): array
     {
         return [
-            new MemberExportField('member_id', 'ID interne', Role::INTENDANT, MemberExportField::TYPE_INT,
-                fn(MemberExportRow $r) => $r->memberId),
-            new MemberExportField('desk_id', 'Identifiant Desk', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->deskId),
-            new MemberExportField('first_name', 'Prénom', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->firstName),
-            new MemberExportField('last_name', 'Nom', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->lastName),
-            new MemberExportField('totem', 'Totem', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->totem),
-            new MemberExportField('gender', 'Genre', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->gender),
-            new MemberExportField('birth_date', 'Date de naissance', Role::INTENDANT, MemberExportField::TYPE_DATE,
-                fn(MemberExportRow $r) => $r->birthDate),
-            new MemberExportField('quali', 'Qualification', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->quali),
+            new MemberExportField(
+                'member_id',
+                'ID interne',
+                Role::INTENDANT,
+                MemberExportField::TYPE_INT,
+                fn(MemberExportRow $r) => $r->memberId
+            ),
+            new MemberExportField(
+                'desk_id',
+                'Identifiant Desk',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->deskId
+            ),
+            new MemberExportField(
+                'first_name',
+                'Prénom',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->firstName
+            ),
+            new MemberExportField(
+                'last_name',
+                'Nom',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->lastName
+            ),
+            new MemberExportField(
+                'totem',
+                'Totem',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->totem
+            ),
+            new MemberExportField(
+                'gender',
+                'Genre',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->gender
+            ),
+            new MemberExportField(
+                'birth_date',
+                'Date de naissance',
+                Role::INTENDANT,
+                MemberExportField::TYPE_DATE,
+                fn(MemberExportRow $r) => $r->birthDate
+            ),
+            new MemberExportField(
+                'quali',
+                'Qualification',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->quali
+            ),
 
-            new MemberExportField('emails', 'Email(s)', Role::INTENDANT, MemberExportField::TYPE_MULTI,
-                fn(MemberExportRow $r) => $r->emails),
-            new MemberExportField('phones', 'Téléphone(s)', Role::INTENDANT, MemberExportField::TYPE_MULTI,
-                fn(MemberExportRow $r) => $r->phones),
-            new MemberExportField('street', 'Rue', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->street),
-            new MemberExportField('number', 'Numéro', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->number),
-            new MemberExportField('box', 'Boîte', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->box),
-            new MemberExportField('postal_code', 'Code postal', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->postalCode),
-            new MemberExportField('city', 'Localité', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->city),
-            new MemberExportField('country', 'Pays', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->country),
+            new MemberExportField(
+                'emails',
+                'Email(s)',
+                Role::INTENDANT,
+                MemberExportField::TYPE_MULTI,
+                fn(MemberExportRow $r) => $r->emails
+            ),
+            new MemberExportField(
+                'phones',
+                'Téléphone(s)',
+                Role::INTENDANT,
+                MemberExportField::TYPE_MULTI,
+                fn(MemberExportRow $r) => $r->phones
+            ),
+            new MemberExportField(
+                'street',
+                'Rue',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->street
+            ),
+            new MemberExportField(
+                'number',
+                'Numéro',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->number
+            ),
+            new MemberExportField(
+                'box',
+                'Boîte',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->box
+            ),
+            new MemberExportField(
+                'postal_code',
+                'Code postal',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->postalCode
+            ),
+            new MemberExportField(
+                'city',
+                'Localité',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->city
+            ),
+            new MemberExportField(
+                'country',
+                'Pays',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->country
+            ),
 
-            new MemberExportField('scout_year_label', 'Année scoute', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->scoutYearLabel),
-            new MemberExportField('section_name', 'Section', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->sectionName),
-            new MemberExportField('section_code', 'Code section', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->sectionCode),
-            new MemberExportField('branch_name', 'Branche', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->branchName),
-            new MemberExportField('role_bucket', 'Catégorie', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->roleBucketLabel),
-            new MemberExportField('main_function', 'Fonction principale', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->functionLabels[0] ?? null),
-            new MemberExportField('all_functions', 'Fonctions', Role::INTENDANT, MemberExportField::TYPE_MULTI,
-                fn(MemberExportRow $r) => $r->functionLabels),
-            new MemberExportField('is_active', 'Actif cette année', Role::INTENDANT, MemberExportField::TYPE_BOOL,
-                fn(MemberExportRow $r) => $r->isActive),
-            new MemberExportField('scout_year_offset', 'Décalage année scoute', Role::INTENDANT,
-                MemberExportField::TYPE_INT, fn(MemberExportRow $r) => $r->scoutYearOffset),
-            new MemberExportField('formation_level', 'Niveau de formation', Role::INTENDANT,
-                MemberExportField::TYPE_TEXT, fn(MemberExportRow $r) => $r->formationLevel),
-            new MemberExportField('supplementary_insurance', 'Assurance complémentaire', Role::INTENDANT,
-                MemberExportField::TYPE_TEXT, fn(MemberExportRow $r) => $r->supplementaryInsurance),
+            new MemberExportField(
+                'scout_year_label',
+                'Année scoute',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->scoutYearLabel
+            ),
+            new MemberExportField(
+                'section_name',
+                'Section',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->sectionName
+            ),
+            new MemberExportField(
+                'section_code',
+                'Code section',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->sectionCode
+            ),
+            new MemberExportField(
+                'branch_name',
+                'Branche',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->branchName
+            ),
+            new MemberExportField(
+                'role_bucket',
+                'Catégorie',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->roleBucketLabel
+            ),
+            new MemberExportField(
+                'main_function',
+                'Fonction principale',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->functionLabels[0] ?? null
+            ),
+            new MemberExportField(
+                'all_functions',
+                'Fonctions',
+                Role::INTENDANT,
+                MemberExportField::TYPE_MULTI,
+                fn(MemberExportRow $r) => $r->functionLabels
+            ),
+            new MemberExportField(
+                'is_active',
+                'Actif cette année',
+                Role::INTENDANT,
+                MemberExportField::TYPE_BOOL,
+                fn(MemberExportRow $r) => $r->isActive
+            ),
+            new MemberExportField(
+                'scout_year_offset',
+                'Décalage année scoute',
+                Role::INTENDANT,
+                MemberExportField::TYPE_INT,
+                fn(MemberExportRow $r) => $r->scoutYearOffset
+            ),
+            new MemberExportField(
+                'formation_level',
+                'Niveau de formation',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->formationLevel
+            ),
+            new MemberExportField(
+                'supplementary_insurance',
+                'Assurance complémentaire',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->supplementaryInsurance
+            ),
 
             // Same access floor as the "Départs" page (role_min: chief) —
             // never wider here just because the export mechanism is core.
-            new MemberExportField('leaving', 'Ne revient pas l\'an prochain', Role::CHIEF, MemberExportField::TYPE_BOOL,
-                fn(MemberExportRow $r) => $r->leaving),
-            new MemberExportField('leaving_comment', 'Motif de départ', Role::CHIEF, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->leavingComment),
+            new MemberExportField(
+                'leaving',
+                'Ne revient pas l\'an prochain',
+                Role::CHIEF,
+                MemberExportField::TYPE_BOOL,
+                fn(MemberExportRow $r) => $r->leaving
+            ),
+            new MemberExportField(
+                'leaving_comment',
+                'Motif de départ',
+                Role::CHIEF,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->leavingComment
+            ),
 
             // GDPR special-category health data — deliberately gated
             // stricter than the rest of this generic member data.
-            new MemberExportField('handicap', 'Situation de handicap', Role::ADMIN, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->handicap),
+            new MemberExportField(
+                'handicap',
+                'Situation de handicap',
+                Role::ADMIN,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->handicap
+            ),
 
-            new MemberExportField('movement_status', 'Situation vs année précédente', Role::INTENDANT,
-                MemberExportField::TYPE_TEXT, fn(MemberExportRow $r) => $r->movementStatusLabel),
-            new MemberExportField('previous_section', 'Ancienne section', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->previousSectionName),
-            new MemberExportField('previous_branch', 'Ancienne branche', Role::INTENDANT, MemberExportField::TYPE_TEXT,
-                fn(MemberExportRow $r) => $r->previousBranchName),
+            new MemberExportField(
+                'movement_status',
+                'Situation vs année précédente',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->movementStatusLabel
+            ),
+            new MemberExportField(
+                'previous_section',
+                'Ancienne section',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->previousSectionName
+            ),
+            new MemberExportField(
+                'previous_branch',
+                'Ancienne branche',
+                Role::INTENDANT,
+                MemberExportField::TYPE_TEXT,
+                fn(MemberExportRow $r) => $r->previousBranchName
+            ),
         ];
     }
 

--- a/core/Member/Export/MemberExportRowBuilder.php
+++ b/core/Member/Export/MemberExportRowBuilder.php
@@ -149,12 +149,13 @@ final class MemberExportRowBuilder
             );
         }
 
-        usort($rows,
+        usort(
+            $rows,
             fn(
                 MemberExportRow $a,
                 MemberExportRow $b
             ) => [$a->sectionName, $a->lastName, $a->firstName] <=> [$b->sectionName, $b->lastName, $b->firstName]
-            );
+        );
 
         return $rows;
     }

--- a/core/Member/Export/MemberExportService.php
+++ b/core/Member/Export/MemberExportService.php
@@ -159,8 +159,11 @@ final class MemberExportService
 
             case MemberExportField::TYPE_TEXT:
             default:
-                $sheet->setCellValueExplicit([$column, $row], $value === null ? '' : (string) $value,
-                    DataType::TYPE_STRING);
+                $sheet->setCellValueExplicit(
+                    [$column, $row],
+                    $value === null ? '' : (string) $value,
+                    DataType::TYPE_STRING
+                );
                 return;
         }
     }

--- a/core/Member/MemberEmailService.php
+++ b/core/Member/MemberEmailService.php
@@ -126,8 +126,14 @@ class MemberEmailService
         $tokenHash = password_hash($rawToken, PASSWORD_DEFAULT);
         $expiresAt = new \DateTimeImmutable('+' . self::CONFIRMATION_EXPIRY_HOURS . ' hours');
 
-        $id = $this->repository->create($memberId, $normalized, MemberEmail::SOURCE_MANUAL, MemberEmail::STATUS_PENDING,
-            $tokenHash, $expiresAt);
+        $id = $this->repository->create(
+            $memberId,
+            $normalized,
+            MemberEmail::SOURCE_MANUAL,
+            MemberEmail::STATUS_PENDING,
+            $tokenHash,
+            $expiresAt
+        );
         $created = $this->repository->findById($id);
         \assert($created !== null);
 
@@ -138,8 +144,12 @@ class MemberEmailService
         // without ever putting the address itself — personal data — in
         // the journal (SECURITY.md §11: "reference member_id only").
         $this->journalService->log(
-            'core', 'member_email_added', 'info', 'Adresse email secondaire ajoutée',
-            ['member_id' => $memberId, 'member_email_id' => $created->id], $actorId
+            'core',
+            'member_email_added',
+            'info',
+            'Adresse email secondaire ajoutée',
+            ['member_id' => $memberId, 'member_email_id' => $created->id],
+            $actorId
         );
 
         return $created;
@@ -163,9 +173,13 @@ class MemberEmailService
         $this->regenerateAndSendConfirmation($row, $actorId);
 
         $this->journalService->log(
-            'core', 'member_email_confirmation_resent', 'info', "Renvoi de la confirmation d'une adresse email "
+            'core',
+            'member_email_confirmation_resent',
+            'info',
+            "Renvoi de la confirmation d'une adresse email "
                 . "secondaire",
-            ['member_id' => $memberId, 'member_email_id' => $emailId], $actorId
+            ['member_id' => $memberId, 'member_email_id' => $emailId],
+            $actorId
         );
 
         $updated = $this->repository->findById($emailId);
@@ -187,8 +201,12 @@ class MemberEmailService
         $this->repository->delete($emailId);
 
         $this->journalService->log(
-            'core', 'member_email_deleted', 'info', 'Adresse email secondaire supprimée',
-            ['member_id' => $memberId, 'member_email_id' => $emailId], $actorId
+            'core',
+            'member_email_deleted',
+            'info',
+            'Adresse email secondaire supprimée',
+            ['member_id' => $memberId, 'member_email_id' => $emailId],
+            $actorId
         );
     }
 
@@ -206,8 +224,12 @@ class MemberEmailService
         $this->repository->reactivate($emailId);
 
         $this->journalService->log(
-            'core', 'member_email_reactivated', 'info', 'Adresse email réactivée',
-            ['member_id' => $memberId, 'member_email_id' => $emailId], $actorId
+            'core',
+            'member_email_reactivated',
+            'info',
+            'Adresse email réactivée',
+            ['member_id' => $memberId, 'member_email_id' => $emailId],
+            $actorId
         );
 
         $updated = $this->repository->findById($emailId);
@@ -245,8 +267,12 @@ class MemberEmailService
         $this->repository->markValid($emailId);
 
         $this->journalService->log(
-            'core', 'member_email_confirmed', 'info', 'Adresse email secondaire confirmée',
-            ['member_id' => $row->memberId, 'member_email_id' => $emailId], null
+            'core',
+            'member_email_confirmed',
+            'info',
+            'Adresse email secondaire confirmée',
+            ['member_id' => $row->memberId, 'member_email_id' => $emailId],
+            null
         );
 
         return true;
@@ -322,8 +348,10 @@ class MemberEmailService
             return;
         }
 
-        $validRows = array_filter($this->repository->findAllByEmail($triggerRow->email),
-            fn(MemberEmail $r) => $r->isValid());
+        $validRows = array_filter(
+            $this->repository->findAllByEmail($triggerRow->email),
+            fn(MemberEmail $r) => $r->isValid()
+        );
         if ($validRows === []) {
             // Already fully unsubscribed everywhere — idempotent no-op,
             // including no duplicate notification emails.
@@ -335,8 +363,12 @@ class MemberEmailService
         foreach ($validRows as $row) {
             $this->repository->markInactive($row->id);
             $this->journalService->log(
-                'core', 'member_email_unsubscribed', 'info', 'Adresse email désinscrite des emails groupés',
-                ['member_id' => $row->memberId, 'member_email_id' => $row->id], null
+                'core',
+                'member_email_unsubscribed',
+                'info',
+                'Adresse email désinscrite des emails groupés',
+                ['member_id' => $row->memberId, 'member_email_id' => $row->id],
+                null
             );
 
             $profile = $this->memberService->findProfileByMemberAndYear($row->memberId, (int) $currentYear['id']);
@@ -441,14 +473,21 @@ class MemberEmailService
         $email = $this->emailTemplateRenderer->render('member_email_confirmation', $context);
 
         try {
-            $this->mailService->send(to: $to, subject: $email->subject, bodyHtml: $email->bodyHtml,
-                bodyText: $email->bodyText);
+            $this->mailService->send(
+                to: $to,
+                subject: $email->subject,
+                bodyHtml: $email->bodyHtml,
+                bodyText: $email->bodyText
+            );
         } catch (MailException $e) {
             $reason = str_replace($to, '[adresse]', $e->getMessage());
             $this->journalService->log(
-                'core', 'member_email_confirmation_send_failed', 'info',
+                'core',
+                'member_email_confirmation_send_failed',
+                'info',
                 "Échec de l'envoi de l'email de confirmation d'une adresse email secondaire",
-                ['member_id' => $memberId, 'member_email_id' => $emailId, 'error' => $reason], $actorId
+                ['member_id' => $memberId, 'member_email_id' => $emailId, 'error' => $reason],
+                $actorId
             );
             throw $e;
         }

--- a/core/Member/MemberPageService.php
+++ b/core/Member/MemberPageService.php
@@ -139,8 +139,10 @@ class MemberPageService
                 ? ($this->hooks?->getOptional(MemberPaymentProvider::class)?->getOpenPayments($profile->memberId) ?? [])
                 : [],
             'formation_path' => $isSelf
-                ? $this->hooks?->getOptional(FormationPathProvider::class)?->getFormationPath($profile->memberId,
-                    $scoutYearId)
+                ? $this->hooks?->getOptional(FormationPathProvider::class)?->getFormationPath(
+                    $profile->memberId,
+                    $scoutYearId
+                )
                 : null,
         ];
     }
@@ -220,8 +222,10 @@ class MemberPageService
     private function buildSectionInfo(MemberProfile $profile, array $section, int $scoutYearId): array
     {
         $responsable = null;
-        $lead = $this->hooks?->getOptional(SectionResponsableProvider::class)?->getResponsable($section['id'],
-            $scoutYearId);
+        $lead = $this->hooks?->getOptional(SectionResponsableProvider::class)?->getResponsable(
+            $section['id'],
+            $scoutYearId
+        );
         if ($lead !== null) {
             // SectionService::hydrateMemberProfile() (which every
             // SectionResponsableProvider implementation is built on)

--- a/core/Member/MemberService.php
+++ b/core/Member/MemberService.php
@@ -566,8 +566,10 @@ class MemberService
             );
         }
 
-        usort($entries, static fn(MemberDirectoryEntry $a, MemberDirectoryEntry $b) =>
-            strcasecmp($a->label(), $b->label()));
+        usort(
+            $entries,
+            static fn(MemberDirectoryEntry $a, MemberDirectoryEntry $b) => strcasecmp($a->label(), $b->label())
+        );
 
         return $entries;
     }

--- a/core/Member/Movement/MemberMovementClassifierService.php
+++ b/core/Member/Movement/MemberMovementClassifierService.php
@@ -127,15 +127,24 @@ final class MemberMovementClassifierService
     ): MemberMovementResult {
         if ($previousSection !== null) {
             if ($previousSection['section_id'] === $current['section_id']) {
-                return new MemberMovementResult(MemberMovementStatus::CONTINUING, $previousSection['section_id'],
-                    $previousSection['age_branch_id']);
+                return new MemberMovementResult(
+                    MemberMovementStatus::CONTINUING,
+                    $previousSection['section_id'],
+                    $previousSection['age_branch_id']
+                );
             }
             if ($previousSection['age_branch_id'] === $current['age_branch_id']) {
-                return new MemberMovementResult(MemberMovementStatus::SECTION_CHANGE, $previousSection['section_id'],
-                    $previousSection['age_branch_id']);
+                return new MemberMovementResult(
+                    MemberMovementStatus::SECTION_CHANGE,
+                    $previousSection['section_id'],
+                    $previousSection['age_branch_id']
+                );
             }
-            return new MemberMovementResult(MemberMovementStatus::BRANCH_CHANGE, $previousSection['section_id'],
-                $previousSection['age_branch_id']);
+            return new MemberMovementResult(
+                MemberMovementStatus::BRANCH_CHANGE,
+                $previousSection['section_id'],
+                $previousSection['age_branch_id']
+            );
         }
 
         if ($activeLastYearWithoutSection) {

--- a/core/Member/SectionDocumentOwnershipChecker.php
+++ b/core/Member/SectionDocumentOwnershipChecker.php
@@ -58,8 +58,12 @@ class SectionDocumentOwnershipChecker implements FileOwnershipCheckerInterface
         $referenceDate = SectionMembershipService::resolveReferenceDate($referenceDateSetting, $scoutYear);
 
         foreach ($linkedMemberIds as $memberId) {
-            if ($this->membershipRepository->hasPeriodCovering($memberId, $document->sectionId, $document->scoutYearId,
-                $referenceDate)) {
+            if ($this->membershipRepository->hasPeriodCovering(
+                $memberId,
+                $document->sectionId,
+                $document->scoutYearId,
+                $referenceDate
+            )) {
                 return true;
             }
         }

--- a/core/Member/SectionDocumentRepository.php
+++ b/core/Member/SectionDocumentRepository.php
@@ -111,10 +111,13 @@ class SectionDocumentRepository
         );
         $stmt->execute($params);
 
-        return array_map(fn(array $row) => [
-            'section_id' => (int) $row['section_id'],
-            'scout_year_id' => (int) $row['scout_year_id'],
-        ], $stmt->fetchAll(\PDO::FETCH_ASSOC));
+        return array_map(
+            fn(array $row) => [
+                'section_id' => (int) $row['section_id'],
+                'scout_year_id' => (int) $row['scout_year_id'],
+            ],
+            $stmt->fetchAll(\PDO::FETCH_ASSOC)
+        );
     }
 
     public function create(

--- a/core/Member/SectionDocumentService.php
+++ b/core/Member/SectionDocumentService.php
@@ -175,7 +175,13 @@ class SectionDocumentService
         // (chicken-and-egg with file_id) — stored ownerless, then
         // FileRepository::updateOwner() right after.
         $fileId = $this->fileStorage->store(
-            $content, $mimeType, $originalFilename, self::STORAGE_SUBDIRECTORY, 'identified', 'core', $uploadedBy
+            $content,
+            $mimeType,
+            $originalFilename,
+            self::STORAGE_SUBDIRECTORY,
+            'identified',
+            'core',
+            $uploadedBy
         );
 
         // store() wrote the encrypted file and its `files` row; the two
@@ -186,8 +192,15 @@ class SectionDocumentService
         // CampaignService::createFromFile(), Core\Import\DeskImportService
         // ::import(), Modules\Finance\Service\BatchDepositService::deposit()).
         try {
-            $documentId = $this->repository->create($sectionId, $scoutYearId, $fileId, $title, $description,
-                strlen($content), $uploadedBy);
+            $documentId = $this->repository->create(
+                $sectionId,
+                $scoutYearId,
+                $fileId,
+                $title,
+                $description,
+                strlen($content),
+                $uploadedBy
+            );
             $this->fileRepository->updateOwner($fileId, 'section_document', $documentId);
         } catch (\Throwable $e) {
             $this->fileStorage->delete($fileId);
@@ -196,12 +209,16 @@ class SectionDocumentService
         }
 
         $this->journalService->log(
-            'core', 'section_document_added', 'info', 'Document de section ajouté',
+            'core',
+            'section_document_added',
+            'info',
+            'Document de section ajouté',
             [
                 'section_id' => $sectionId,
                 'scout_year_id' => $scoutYearId,
                 'section_document_id' => $documentId
-            ], $uploadedBy
+            ],
+            $uploadedBy
         );
 
         // Background compression (Core\Member\Task\CompressSectionDocumentHandler)
@@ -213,8 +230,12 @@ class SectionDocumentService
             $mimeType === 'application/pdf'
             && $this->settingService->get('section_document_compression_enabled') !== '0'
         ) {
-            $this->schedulerService->scheduleAfter('core', 'compress_section_document', 0,
-                ['section_document_id' => $documentId]);
+            $this->schedulerService->scheduleAfter(
+                'core',
+                'compress_section_document',
+                0,
+                ['section_document_id' => $documentId]
+            );
         }
 
         $document = $this->repository->findById($documentId);
@@ -233,16 +254,23 @@ class SectionDocumentService
         }
         $document = $this->requireDocument($documentId);
 
-        $this->repository->updateTitleAndDescription($documentId, $cleanTitle,
-            $description !== null && trim($description) !== '' ? trim($description) : null);
+        $this->repository->updateTitleAndDescription(
+            $documentId,
+            $cleanTitle,
+            $description !== null && trim($description) !== '' ? trim($description) : null
+        );
 
         $this->journalService->log(
-            'core', 'section_document_renamed', 'info', 'Document de section renommé',
+            'core',
+            'section_document_renamed',
+            'info',
+            'Document de section renommé',
             [
                 'section_id' => $document->sectionId,
                 'scout_year_id' => $document->scoutYearId,
                 'section_document_id' => $documentId
-            ], $actorId
+            ],
+            $actorId
         );
     }
 
@@ -278,12 +306,16 @@ class SectionDocumentService
         $this->repository->delete($documentId);
 
         $this->journalService->log(
-            'core', 'section_document_deleted', 'info', 'Document de section supprimé',
+            'core',
+            'section_document_deleted',
+            'info',
+            'Document de section supprimé',
             [
                 'section_id' => $document->sectionId,
                 'scout_year_id' => $document->scoutYearId,
                 'section_document_id' => $documentId
-            ], $actorId
+            ],
+            $actorId
         );
     }
 

--- a/core/Member/SectionMembershipService.php
+++ b/core/Member/SectionMembershipService.php
@@ -98,8 +98,12 @@ class SectionMembershipService
                 continue;
             }
 
-            $periodId = $this->repository->open($triple['member_id'], $triple['section_id'], $triple['scout_year_id'],
-                $scoutYear['start_date']);
+            $periodId = $this->repository->open(
+                $triple['member_id'],
+                $triple['section_id'],
+                $triple['scout_year_id'],
+                $scoutYear['start_date']
+            );
             if ($triple['scout_year_id'] !== $currentScoutYearId) {
                 $this->repository->close($periodId, $scoutYear['end_date']);
             }

--- a/core/Member/SectionRosterService.php
+++ b/core/Member/SectionRosterService.php
@@ -68,9 +68,12 @@ final class SectionRosterService
         $movementByMemberId = $this->movementClassifier->classifyBatch($scoutYearId, $currentRoster);
 
         foreach ($entries as $entry) {
-            $row = $this->buildRow($entry, $memberYearRows[$entry->memberYearId] ?? null,
+            $row = $this->buildRow(
+                $entry,
+                $memberYearRows[$entry->memberYearId] ?? null,
                 $validEmailsByMember[$entry->memberId] ?? [],
-                $movementByMemberId[$entry->memberId] ?? new MemberMovementResult(MemberMovementStatus::UNKNOWN));
+                $movementByMemberId[$entry->memberId] ?? new MemberMovementResult(MemberMovementStatus::UNKNOWN)
+            );
             if ($row === null) {
                 continue;
             }

--- a/core/Member/SectionService.php
+++ b/core/Member/SectionService.php
@@ -315,8 +315,10 @@ class SectionService
         $profiles = array_values($this->hydrateMemberProfiles($memberYearIds));
 
         // Sort by display name
-        usort($profiles, fn(MemberProfile $a, MemberProfile $b) =>
-            strcasecmp($a->getDisplayName(), $b->getDisplayName()));
+        usort(
+            $profiles,
+            fn(MemberProfile $a, MemberProfile $b) => strcasecmp($a->getDisplayName(), $b->getDisplayName())
+        );
 
         return $profiles;
     }
@@ -348,8 +350,10 @@ class SectionService
 
         $profiles = array_values($this->hydrateMemberProfiles($memberYearIds));
 
-        usort($profiles, fn(MemberProfile $a, MemberProfile $b) =>
-            strcasecmp($a->getDisplayName(), $b->getDisplayName()));
+        usort(
+            $profiles,
+            fn(MemberProfile $a, MemberProfile $b) => strcasecmp($a->getDisplayName(), $b->getDisplayName())
+        );
 
         return $profiles;
     }

--- a/core/Member/SectionStaffAuthorizationService.php
+++ b/core/Member/SectionStaffAuthorizationService.php
@@ -103,8 +103,10 @@ class SectionStaffAuthorizationService
                AND mf.section_id IS NOT NULL'
         );
         $stmt->execute([$blindIndex, ...$memberIds, $scoutYearId]);
-        $sectionIds = array_map(static fn(array $row): int => (int) $row['section_id'],
-            $stmt->fetchAll(\PDO::FETCH_ASSOC));
+        $sectionIds = array_map(
+            static fn(array $row): int => (int) $row['section_id'],
+            $stmt->fetchAll(\PDO::FETCH_ASSOC)
+        );
 
         $sections = [];
         foreach ($sectionIds as $sectionId) {

--- a/core/Member/Service/MemberSearchResult.php
+++ b/core/Member/Service/MemberSearchResult.php
@@ -82,16 +82,19 @@ class MemberSearchResult
      */
     public function haystack(): string
     {
-        return implode(' ', array_filter([
-            $this->lastName,
-            $this->firstName,
-            $this->totem,
-            $this->email,
-            $this->phone,
-            $this->mobile,
-            $this->sectionName,
-            $this->functionLabel,
-            $this->addressText,
-        ]));
+        return implode(
+            ' ',
+            array_filter([
+                $this->lastName,
+                $this->firstName,
+                $this->totem,
+                $this->email,
+                $this->phone,
+                $this->mobile,
+                $this->sectionName,
+                $this->functionLabel,
+                $this->addressText,
+            ])
+        );
     }
 }

--- a/core/Member/Service/MemberSearchService.php
+++ b/core/Member/Service/MemberSearchService.php
@@ -140,8 +140,10 @@ class MemberSearchService
      */
     public function searchGrouped(int $scoutYearId, string $query, string $scope, int $effectiveScoutYearId): array
     {
-        return $this->groupByMember($this->matchIn($this->allForYear($scoutYearId), $query, $scope),
-            $effectiveScoutYearId);
+        return $this->groupByMember(
+            $this->matchIn($this->allForYear($scoutYearId), $query, $scope),
+            $effectiveScoutYearId
+        );
     }
 
     /**

--- a/core/Member/Task/CompressSectionDocumentHandler.php
+++ b/core/Member/Task/CompressSectionDocumentHandler.php
@@ -94,7 +94,10 @@ class CompressSectionDocumentHandler implements TaskHandlerInterface
         if ($compressed === null) {
             $documentRepository->markSkipped($documentId);
             $context->journal->log(
-                'core', 'section_document_compression_skipped', 'info', "Compression du document de section ignorée "
+                'core',
+                'section_document_compression_skipped',
+                'info',
+                "Compression du document de section ignorée "
                     . "(pas de gain ou échec)",
                 ['section_document_id' => $documentId]
             );
@@ -105,7 +108,10 @@ class CompressSectionDocumentHandler implements TaskHandlerInterface
         $documentRepository->markCompressed($documentId, strlen($compressed));
 
         $context->journal->log(
-            'core', 'section_document_compressed', 'info', 'Document de section compressé',
+            'core',
+            'section_document_compressed',
+            'info',
+            'Document de section compressé',
             [
                 'section_document_id' => $documentId,
                 'size_before' => strlen($content),

--- a/core/Module/ModuleManifest.php
+++ b/core/Module/ModuleManifest.php
@@ -396,9 +396,24 @@ class ModuleManifest
             }
         }
 
-        return new self($id, $data['name'], $data['version'], $routes, $settings, $cookies, $scheduledTasks, $storage,
-            $enabledByDefault, $description, $notifications, $offline, $requires, $visibleWhen, $helpDirectory, $emails
-            );
+        return new self(
+            $id,
+            $data['name'],
+            $data['version'],
+            $routes,
+            $settings,
+            $cookies,
+            $scheduledTasks,
+            $storage,
+            $enabledByDefault,
+            $description,
+            $notifications,
+            $offline,
+            $requires,
+            $visibleWhen,
+            $helpDirectory,
+            $emails
+        );
     }
 
     /**

--- a/core/Notification/NotificationService.php
+++ b/core/Notification/NotificationService.php
@@ -227,8 +227,14 @@ class NotificationService
             // apply as declared.
             $defaultsOn = $role === null || $type->defaultsOnForRole($role);
 
-            $notificationId = $this->notificationRepository->create($userAccountId, $memberId, $typeId, $title, $body,
-                $url);
+            $notificationId = $this->notificationRepository->create(
+                $userAccountId,
+                $memberId,
+                $typeId,
+                $title,
+                $body,
+                $url
+            );
 
             $this->journalService->log(
                 'core',
@@ -263,13 +269,21 @@ class NotificationService
 
         foreach ($pushBuckets as $bucket) {
             $delaySeconds = max(0, $bucket['runAt']->getTimestamp() - time());
-            $this->schedulerService->scheduleAfter('core', 'send_notifications', $delaySeconds,
-                ['notification_ids' => $bucket['ids']]);
+            $this->schedulerService->scheduleAfter(
+                'core',
+                'send_notifications',
+                $delaySeconds,
+                ['notification_ids' => $bucket['ids']]
+            );
         }
 
         if ($emailIds !== []) {
-            $this->schedulerService->scheduleAfter('core', 'send_notification_emails', 0,
-                ['notification_ids' => $emailIds]);
+            $this->schedulerService->scheduleAfter(
+                'core',
+                'send_notification_emails',
+                0,
+                ['notification_ids' => $emailIds]
+            );
         }
     }
 
@@ -280,8 +294,14 @@ class NotificationService
      */
     public function notify(int $userAccountId, string $title, string $body, ?string $url = null): void
     {
-        $notificationId = $this->notificationRepository->create($userAccountId, null, self::SYSTEM_TYPE_ID, $title,
-            $body, $url);
+        $notificationId = $this->notificationRepository->create(
+            $userAccountId,
+            null,
+            self::SYSTEM_TYPE_ID,
+            $title,
+            $body,
+            $url
+        );
 
         $record = new NotificationRecord(
             id: $notificationId,

--- a/core/Pdf/PdfCompressor.php
+++ b/core/Pdf/PdfCompressor.php
@@ -132,7 +132,9 @@ class PdfCompressor
         $cmd = sprintf(
             'gs -dSAFER -dBATCH -dNOPAUSE -dQUIET -sDEVICE=pdfwrite -dCompatibilityLevel=1.5 -dPDFSETTINGS=%s '
                 . '-sOutputFile=%s %s',
-            escapeshellarg($pdfSettings), escapeshellarg($output), escapeshellarg($input)
+            escapeshellarg($pdfSettings),
+            escapeshellarg($output),
+            escapeshellarg($input)
         );
 
         return $this->runWithTimeout($cmd);
@@ -142,7 +144,8 @@ class PdfCompressor
     {
         $cmd = sprintf(
             'qpdf --compress-streams=y --recompress-flate --optimize-images %s %s',
-            escapeshellarg($input), escapeshellarg($output)
+            escapeshellarg($input),
+            escapeshellarg($output)
         );
 
         return $this->runWithTimeout($cmd);

--- a/core/Photo/PhotoIngestionService.php
+++ b/core/Photo/PhotoIngestionService.php
@@ -207,8 +207,11 @@ class PhotoIngestionService
                 }
                 $this->memberPhotoService->setPhoto($memberId, $scoutYearId, $fileId, $actorId);
 
-                return new PhotoIngestionResult($fileId, true,
-                    ['member_id' => $memberId, 'scout_year_id' => $scoutYearId]);
+                return new PhotoIngestionResult(
+                    $fileId,
+                    true,
+                    ['member_id' => $memberId, 'scout_year_id' => $scoutYearId]
+                );
 
             case self::CONTEXT_SECTION_PHOTO:
                 [$sectionId, $scoutYearId] = self::splitPairKey($key);
@@ -217,8 +220,11 @@ class PhotoIngestionService
                 }
                 $this->sectionPhotoService->setPhoto($sectionId, $scoutYearId, $fileId, $actorId);
 
-                return new PhotoIngestionResult($fileId, true,
-                    ['section_id' => $sectionId, 'scout_year_id' => $scoutYearId]);
+                return new PhotoIngestionResult(
+                    $fileId,
+                    true,
+                    ['section_id' => $sectionId, 'scout_year_id' => $scoutYearId]
+                );
 
             case self::CONTEXT_ACCOUNT_PHOTO:
                 // Nobody sets somebody else's face, configuration mode

--- a/core/Photo/UnitLogoProcessor.php
+++ b/core/Photo/UnitLogoProcessor.php
@@ -86,8 +86,12 @@ class UnitLogoProcessor
             180 => $this->encodePng($this->flattenOpaque($square, self::SIZE_180, 1.0, $backgroundColorHex)),
             192 => $this->encodePng($this->resizeSquare($square, self::SIZE_192)),
             512 => $this->encodePng($this->resizeSquare($square, self::SIZE_512)),
-            '512-maskable' => $this->encodePng($this->flattenOpaque($square, self::SIZE_512, self::MASKABLE_LOGO_RATIO,
-                $backgroundColorHex)),
+            '512-maskable' => $this->encodePng($this->flattenOpaque(
+                $square,
+                self::SIZE_512,
+                self::MASKABLE_LOGO_RATIO,
+                $backgroundColorHex
+            )),
         ];
         $result['ico'] = $this->packIco([
             self::SIZE_FAVICON_16 => $favicon16,

--- a/core/Scheduler/CronStatus.php
+++ b/core/Scheduler/CronStatus.php
@@ -55,8 +55,10 @@ final class CronStatus
      */
     public function lastSeenAt(): ?int
     {
-        $candidates = array_filter([$this->lastHeartbeatAt, $this->lastFullPassAt],
-            static fn(?int $at): bool => $at !== null);
+        $candidates = array_filter(
+            [$this->lastHeartbeatAt, $this->lastFullPassAt],
+            static fn(?int $at): bool => $at !== null
+        );
 
         return $candidates === [] ? null : max($candidates);
     }

--- a/core/Scheduler/SchedulerRunner.php
+++ b/core/Scheduler/SchedulerRunner.php
@@ -180,8 +180,10 @@ class SchedulerRunner
                 $this->repository->markDone((int) $task['id']);
                 $processed++;
                 $durationMs = (int) round((microtime(true) - $taskStart) * 1000);
-                RequestTimeline::mark('scheduler_task_done:' . $handlerKey,
-                    ['task_id' => $task['id'], 'duration_ms' => $durationMs]);
+                RequestTimeline::mark(
+                    'scheduler_task_done:' . $handlerKey,
+                    ['task_id' => $task['id'], 'duration_ms' => $durationMs]
+                );
 
                 $this->journal->log(
                     'core',
@@ -204,8 +206,10 @@ class SchedulerRunner
                     . 'événements (Configuration > Journal).'
                 ));
                 $durationMs = (int) round((microtime(true) - $taskStart) * 1000);
-                RequestTimeline::mark('scheduler_task_failed:' . $handlerKey,
-                    ['task_id' => $task['id'], 'duration_ms' => $durationMs]);
+                RequestTimeline::mark(
+                    'scheduler_task_failed:' . $handlerKey,
+                    ['task_id' => $task['id'], 'duration_ms' => $durationMs]
+                );
                 $this->journal->log(
                     'core',
                     'scheduler_task_failed',

--- a/core/Security/AuthService.php
+++ b/core/Security/AuthService.php
@@ -96,8 +96,12 @@ class AuthService
             } catch (\Throwable $e) {
                 $reason = str_replace($normalizedEmail, '[adresse]', $e->getMessage());
                 $this->journalService?->log(
-                    'core', 'magic_link_send_failed', 'info', "Échec de l'envoi de l'email de lien magique",
-                    ['error' => $reason, 'via_secondary_email' => $viaSecondaryEmail], $user?->id
+                    'core',
+                    'magic_link_send_failed',
+                    'info',
+                    "Échec de l'envoi de l'email de lien magique",
+                    ['error' => $reason, 'via_secondary_email' => $viaSecondaryEmail],
+                    $user?->id
                 );
 
                 return new MagicLinkResult(
@@ -108,8 +112,12 @@ class AuthService
             }
 
             $this->journalService?->log(
-                'core', 'magic_link_email_sent', 'info', 'Email de lien magique envoyé',
-                ['via_secondary_email' => $viaSecondaryEmail], $user?->id
+                'core',
+                'magic_link_email_sent',
+                'info',
+                'Email de lien magique envoyé',
+                ['via_secondary_email' => $viaSecondaryEmail],
+                $user?->id
             );
         } else {
             // No enumeration in the response (still returns success below)
@@ -118,14 +126,20 @@ class AuthService
             // to tell "no account matched at all" apart from "matched but
             // the send failed" apart from "sent fine, check spam".
             $this->journalService?->log(
-                'core', 'magic_link_no_account_found', 'info',
+                'core',
+                'magic_link_no_account_found',
+                'info',
                 'Demande de lien magique pour une adresse sans compte correspondant',
-                [], null
+                [],
+                null
             );
         }
 
         $this->journalService?->log(
-            'core', 'magic_link_requested', 'info', 'Demande de lien magique',
+            'core',
+            'magic_link_requested',
+            'info',
+            'Demande de lien magique',
             // No `ip` here: JournalService::log() already writes the
             // address into `event_log.ip_address`. A second copy in the
             // JSON is the same personal datum stored twice in one row
@@ -204,9 +218,12 @@ class AuthService
         }
 
         $this->journalService?->log(
-            'core', 'account_created_for_secondary_email', 'security',
+            'core',
+            'account_created_for_secondary_email',
+            'security',
             'Compte créé pour une adresse email secondaire confirmée',
-            [], $created->id
+            [],
+            $created->id
         );
 
         return $created;
@@ -257,7 +274,10 @@ class AuthService
         $this->userRepo->updateLastLogin($user->id);
 
         $this->journalService?->log(
-            'core', 'login_success', 'security', 'Connexion par lien magique',
+            'core',
+            'login_success',
+            'security',
+            'Connexion par lien magique',
             // No `ip` here: JournalService::log() already writes the
             // address into `event_log.ip_address`. A second copy in the
             // JSON is the same personal datum stored twice in one row

--- a/core/Security/HumanCheck/HumanCheckService.php
+++ b/core/Security/HumanCheck/HumanCheckService.php
@@ -147,16 +147,23 @@ class HumanCheckService
         // entry in this codebase); this is only about not ALSO
         // duplicating it into context, unlike a few other log() call
         // sites do.
-        $this->journal->log('core', 'human_check_failed', 'security', 'Échec de la vérification anti-robot',
-            ['form' => $formKey]);
+        $this->journal->log(
+            'core',
+            'human_check_failed',
+            'security',
+            'Échec de la vérification anti-robot',
+            ['form' => $formKey]
+        );
 
         return HumanCheckResult::rejected($reason);
     }
 
     private function sign(string $formKey, string $trapField, int $timestamp): string
     {
-        return $this->encryption->blindIndex(self::TOKEN_VERSION . ':' . $formKey . ':' . $trapField . ':' . $timestamp,
-            'human_check_sign');
+        return $this->encryption->blindIndex(
+            self::TOKEN_VERSION . ':' . $formKey . ':' . $trapField . ':' . $timestamp,
+            'human_check_sign'
+        );
     }
 
     /**

--- a/core/Security/LastLoginMethodCookie.php
+++ b/core/Security/LastLoginMethodCookie.php
@@ -45,8 +45,16 @@ class LastLoginMethodCookie
             // defaults to true, and a Secure cookie is silently dropped by
             // the browser over plain HTTP, which was why this never
             // actually persisted.
-            CookieHelper::set(self::NAME, $method, time() + self::EXPIRY_DAYS * 86400, 'functional', $consentService,
-                '/', true, $isHttps);
+            CookieHelper::set(
+                self::NAME,
+                $method,
+                time() + self::EXPIRY_DAYS * 86400,
+                'functional',
+                $consentService,
+                '/',
+                true,
+                $isHttps
+            );
         } catch (CookieConsentException) {
             // Functional cookies not consented to — simply don't remember.
         }

--- a/core/Security/PasswordAuthMethod.php
+++ b/core/Security/PasswordAuthMethod.php
@@ -68,7 +68,10 @@ class PasswordAuthMethod
         $lockout = $this->throttler->getLockoutRemaining($blindIndex, $ip);
         if ($lockout > 0) {
             $this->journalService?->log(
-                'core', 'login_lockout', 'security', 'Compte temporairement verrouillé (trop de tentatives)',
+                'core',
+                'login_lockout',
+                'security',
+                'Compte temporairement verrouillé (trop de tentatives)',
                 // The address is already event_log.ip_address; only the
                 // lockout length is not.
                 ['locked_seconds' => $lockout]
@@ -98,7 +101,10 @@ class PasswordAuthMethod
         $this->throttler->clearFailures($blindIndex);
 
         $this->journalService?->log(
-            'core', 'login_success', 'security', 'Connexion par mot de passe',
+            'core',
+            'login_success',
+            'security',
+            'Connexion par mot de passe',
             [],
             $account->id
         );

--- a/core/Security/PasswordResetService.php
+++ b/core/Security/PasswordResetService.php
@@ -84,9 +84,13 @@ class PasswordResetService
         }
 
         $this->journalService?->log(
-            'core', 'password_reset_requested', 'info', 'Demande de réinitialisation de mot de passe',
+            'core',
+            'password_reset_requested',
+            'info',
+            'Demande de réinitialisation de mot de passe',
             // See AuthService: the address is already event_log.ip_address.
-            [], null
+            [],
+            null
         );
     }
 
@@ -122,8 +126,12 @@ class PasswordResetService
         $this->userRepo->updatePasswordHash($user->id, password_hash($newPassword, PASSWORD_DEFAULT));
 
         $this->journalService?->log(
-            'core', 'password_reset_completed', 'security', 'Mot de passe réinitialisé via lien de réinitialisation',
-            [], $user->id
+            'core',
+            'password_reset_completed',
+            'security',
+            'Mot de passe réinitialisé via lien de réinitialisation',
+            [],
+            $user->id
         );
 
         return true;

--- a/core/Security/RoleResolver.php
+++ b/core/Security/RoleResolver.php
@@ -336,8 +336,10 @@ class RoleResolver
 
         $direct = array_values(array_filter(
             $direct,
-            fn(array $row) => !$this->memberEmailRepo->isBlindIndexInactiveForMember((int) $row['member_id'],
-                $blindIndex)
+            fn(array $row) => !$this->memberEmailRepo->isBlindIndexInactiveForMember(
+                (int) $row['member_id'],
+                $blindIndex
+            )
         ));
 
         $memberIds = $this->memberEmailRepo->findMemberIdsByValidBlindIndex($blindIndex);

--- a/core/Security/SessionRevalidator.php
+++ b/core/Security/SessionRevalidator.php
@@ -107,7 +107,9 @@ class SessionRevalidator
         $freshRole = $this->roleResolver->resolveAcrossYears($account->email, $years);
         if ($freshRole !== AuthSession::getRole()) {
             $this->journalService?->log(
-                'core', 'session_role_refreshed', 'security',
+                'core',
+                'session_role_refreshed',
+                'security',
                 'Rôle de session actualisé',
                 ['from' => AuthSession::getRole(), 'to' => $freshRole],
                 $userAccountId
@@ -143,8 +145,12 @@ class SessionRevalidator
     private function revoke(string $reason, int $userAccountId): void
     {
         $this->journalService?->log(
-            'core', 'session_revoked', 'security', 'Session invalidée',
-            ['reason' => $reason], $userAccountId
+            'core',
+            'session_revoked',
+            'security',
+            'Session invalidée',
+            ['reason' => $reason],
+            $userAccountId
         );
 
         AuthSession::logout();

--- a/core/Security/UserAccountRepository.php
+++ b/core/Security/UserAccountRepository.php
@@ -621,14 +621,18 @@ class UserAccountRepository
 
         $passwordChangedAt = null;
         if (!empty($row['password_changed_at'])) {
-            $passwordChangedAt = DateInput::requireFromStorage((string) $row['password_changed_at'],
-                'password_changed_at');
+            $passwordChangedAt = DateInput::requireFromStorage(
+                (string) $row['password_changed_at'],
+                'password_changed_at'
+            );
         }
 
         $sessionsValidFrom = null;
         if (!empty($row['sessions_valid_from'])) {
-            $sessionsValidFrom = DateInput::requireFromStorage((string) $row['sessions_valid_from'],
-                'sessions_valid_from');
+            $sessionsValidFrom = DateInput::requireFromStorage(
+                (string) $row['sessions_valid_from'],
+                'sessions_valid_from'
+            );
         }
 
         return new UserAccount(

--- a/core/Security/WebAuthnService.php
+++ b/core/Security/WebAuthnService.php
@@ -594,8 +594,11 @@ class WebAuthnService
 
     private function base64UrlDecode(string $data): string
     {
-        $padded = str_pad(strtr($data, '-_', '+/'),
-            strlen($data) % 4 === 0 ? strlen($data) : strlen($data) + (4 - strlen($data) % 4), '=');
+        $padded = str_pad(
+            strtr($data, '-_', '+/'),
+            strlen($data) % 4 === 0 ? strlen($data) : strlen($data) + (4 - strlen($data) % 4),
+            '='
+        );
         return base64_decode($padded, true) ?: '';
     }
 }

--- a/core/Service/TextNormalizerService.php
+++ b/core/Service/TextNormalizerService.php
@@ -312,18 +312,33 @@ class TextNormalizerService
 
         // Mobile: 4XX XX XX XX
         if ($len === 9 && $nat[0] === '4') {
-            return sprintf('+32 %s %s %s %s', substr($nat, 0, 3), substr($nat, 3, 2), substr($nat, 5, 2),
-                substr($nat, 7, 2));
+            return sprintf(
+                '+32 %s %s %s %s',
+                substr($nat, 0, 3),
+                substr($nat, 3, 2),
+                substr($nat, 5, 2),
+                substr($nat, 7, 2)
+            );
         }
 
         if ($len === 8) {
             // Brussels: 1-digit zone code (2). Others: 2-digit zone code.
             if ($nat[0] === '2') {
-                return sprintf('+32 %s %s %s %s', substr($nat, 0, 1), substr($nat, 1, 3), substr($nat, 4, 2),
-                    substr($nat, 6, 2));
+                return sprintf(
+                    '+32 %s %s %s %s',
+                    substr($nat, 0, 1),
+                    substr($nat, 1, 3),
+                    substr($nat, 4, 2),
+                    substr($nat, 6, 2)
+                );
             }
-            return sprintf('+32 %s %s %s %s', substr($nat, 0, 2), substr($nat, 2, 2), substr($nat, 4, 2),
-                substr($nat, 6, 2));
+            return sprintf(
+                '+32 %s %s %s %s',
+                substr($nat, 0, 2),
+                substr($nat, 2, 2),
+                substr($nat, 4, 2),
+                substr($nat, 6, 2)
+            );
         }
 
         // Doesn't match a known Belgian pattern: group generically.

--- a/core/Statistics/InstallationDateService.php
+++ b/core/Statistics/InstallationDateService.php
@@ -48,9 +48,18 @@ class InstallationDateService
      */
     public static function register(SettingService $settingService): void
     {
-        $settingService->register(self::SETTING_KEY, '', 'text', 'Date d\'installation de ScoutMagic',
+        $settingService->register(
+            self::SETTING_KEY,
+            '',
+            'text',
+            'Date d\'installation de ScoutMagic',
             'Date de première installation de ce site, au format ISO 8601 UTC. Renseignée automatiquement.',
-            null, null, null, false, 284);
+            null,
+            null,
+            null,
+            false,
+            284
+        );
     }
 
     /**

--- a/core/Statistics/InstallationIdentityService.php
+++ b/core/Statistics/InstallationIdentityService.php
@@ -64,14 +64,32 @@ class InstallationIdentityService
      */
     public static function register(SettingService $settingService): void
     {
-        $settingService->register(self::INSTALLATION_ID_SETTING, '', 'text', 'Identifiant de cette installation',
+        $settingService->register(
+            self::INSTALLATION_ID_SETTING,
+            '',
+            'text',
+            'Identifiant de cette installation',
             'Identifiant aléatoire attribué une seule fois à cette installation pour reconnaître ses rapports '
                 . 'd\'utilisation. Il ne dérive d\'aucune donnée personnelle.',
-            null, null, null, false, 282);
-        $settingService->register(self::RESTORED_FROM_SETTING, '', 'text', 'Installation d\'origine',
+            null,
+            null,
+            null,
+            false,
+            282
+        );
+        $settingService->register(
+            self::RESTORED_FROM_SETTING,
+            '',
+            'text',
+            'Installation d\'origine',
             'Identifiant de l\'installation dont celle-ci a été restaurée, le cas échéant. Permet de relier les '
                 . 'deux sans les confondre. Renseigné automatiquement.',
-            null, null, null, false, 290);
+            null,
+            null,
+            null,
+            false,
+            290
+        );
     }
 
     public function __construct(

--- a/core/Statistics/StatisticsPayloadBuilder.php
+++ b/core/Statistics/StatisticsPayloadBuilder.php
@@ -113,7 +113,9 @@ class StatisticsPayloadBuilder
             // between a unit that left and a unit that needs help. Null on
             // every installation that was not restored from an archive,
             // which is nearly all of them.
-            'restored_from' => $this->collect(fn(): ?string => $this->settingValue(InstallationIdentityService::RESTORED_FROM_SETTING)),
+            'restored_from' => $this->collect(
+                fn(): ?string => $this->settingValue(InstallationIdentityService::RESTORED_FROM_SETTING)
+            ),
             'instance_url' => $this->collect(fn(): ?string => $this->settingValue('base_url')),
             'generated_at' => (new \DateTimeImmutable('now', new \DateTimeZone('UTC')))
                 ->format(\DateTimeInterface::ATOM),

--- a/core/Support/Collector/FilesystemCollector.php
+++ b/core/Support/Collector/FilesystemCollector.php
@@ -183,8 +183,16 @@ class FilesystemCollector implements SupportCollectorInterface
 
         $stat = @lstat($path);
         if ($stat === false) {
-            return sprintf('%-4s | %-9s | %-12s | %-12s | %10s | %-19s | %s',
-                '?', '?', '?', '?', '?', '?', $relative);
+            return sprintf(
+                '%-4s | %-9s | %-12s | %-12s | %10s | %-19s | %s',
+                '?',
+                '?',
+                '?',
+                '?',
+                '?',
+                '?',
+                $relative
+            );
         }
 
         $type = is_link($path) ? 'lien' : (is_dir($path) ? 'rép' : 'fich');

--- a/core/Support/Collector/LogsCollector.php
+++ b/core/Support/Collector/LogsCollector.php
@@ -386,8 +386,11 @@ class LogsCollector implements SupportCollectorInterface
             // 203.0.113.1 - - [20/Aug/2026:03:00:00 +0200] — access log
             '/\[(\d{2}\/[A-Za-z]{3}\/\d{4}):(\d{2}:\d{2}:\d{2}) ([+\-]\d{4})\]/' => static fn(
                 array $m
-            ): string => str_replace('/',
-                ' ', $m[1]) . ' ' . $m[2] . ' ' . $m[3],
+            ): string => str_replace(
+                '/',
+                ' ',
+                $m[1]
+            ) . ' ' . $m[2] . ' ' . $m[3],
             // 2026-08-20T03:00:00+00:00 or 2026-08-20 03:00:00
             '/^(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:[+\-]\d{2}:?\d{2}|Z)?)/' => static fn(
                 array $m

--- a/core/Support/Collector/OpcacheCollector.php
+++ b/core/Support/Collector/OpcacheCollector.php
@@ -70,22 +70,25 @@ class OpcacheCollector implements SupportCollectorInterface
             $context->addNote('OPcache présent mais désactivé pour ce SAPI');
         }
 
-        $context->addFileFromContent('opcache.json', (string) json_encode(
-            [
-                'enabled' => $status['opcache_enabled'] ?? false,
-                'cache_full' => $status['cache_full'] ?? null,
-                'restart_pending' => $status['restart_pending'] ?? null,
-                'restart_in_progress' => $status['restart_in_progress'] ?? null,
-                'memory' => $status['memory_usage'] ?? null,
-                'interned_strings' => $status['interned_strings_usage'] ?? null,
-                'statistics' => $status['opcache_statistics'] ?? null,
-                'jit' => $status['jit'] ?? null,
-                'key_directives' => self::keyDirectives($directives),
-                'stale_window_seconds' => self::staleWindowSeconds($directives),
-                'note' => self::note($directives),
-            ],
-            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
-        ));
+        $context->addFileFromContent(
+            'opcache.json',
+            (string) json_encode(
+                [
+                    'enabled' => $status['opcache_enabled'] ?? false,
+                    'cache_full' => $status['cache_full'] ?? null,
+                    'restart_pending' => $status['restart_pending'] ?? null,
+                    'restart_in_progress' => $status['restart_in_progress'] ?? null,
+                    'memory' => $status['memory_usage'] ?? null,
+                    'interned_strings' => $status['interned_strings_usage'] ?? null,
+                    'statistics' => $status['opcache_statistics'] ?? null,
+                    'jit' => $status['jit'] ?? null,
+                    'key_directives' => self::keyDirectives($directives),
+                    'stale_window_seconds' => self::staleWindowSeconds($directives),
+                    'note' => self::note($directives),
+                ],
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE
+            )
+        );
     }
 
     /**

--- a/core/Support/SupportPackageService.php
+++ b/core/Support/SupportPackageService.php
@@ -219,8 +219,12 @@ class SupportPackageService
             $unavailable = $context->unavailableReason();
 
             return $unavailable !== null
-                ? SupportCollectionOutcome::unavailable($collector->name(), $context->redact($unavailable), $durationMs,
-                    $context->notes())
+                ? SupportCollectionOutcome::unavailable(
+                    $collector->name(),
+                    $context->redact($unavailable),
+                    $durationMs,
+                    $context->notes()
+                )
                 : SupportCollectionOutcome::success($collector->name(), $durationMs, $context->notes());
         } catch (\Throwable $e) {
             return SupportCollectionOutcome::failed(

--- a/core/View/TextNormalizerExtension.php
+++ b/core/View/TextNormalizerExtension.php
@@ -24,14 +24,22 @@ class TextNormalizerExtension extends AbstractExtension
     public function getFilters(): array
     {
         return [
-            new TwigFilter('normalize_name',
-                static fn(?string $v): string => TextNormalizerService::normalizeName((string) $v)),
-            new TwigFilter('normalize_totem',
-                static fn(?string $v): string => TextNormalizerService::normalizeTotem((string) $v)),
-            new TwigFilter('normalize_phone',
-                static fn(?string $v): string => TextNormalizerService::normalizePhone((string) $v)),
-            new TwigFilter('normalize_address',
-                static fn(?string $v): string => TextNormalizerService::normalizeAddress((string) $v)),
+            new TwigFilter(
+                'normalize_name',
+                static fn(?string $v): string => TextNormalizerService::normalizeName((string) $v)
+            ),
+            new TwigFilter(
+                'normalize_totem',
+                static fn(?string $v): string => TextNormalizerService::normalizeTotem((string) $v)
+            ),
+            new TwigFilter(
+                'normalize_phone',
+                static fn(?string $v): string => TextNormalizerService::normalizePhone((string) $v)
+            ),
+            new TwigFilter(
+                'normalize_address',
+                static fn(?string $v): string => TextNormalizerService::normalizeAddress((string) $v)
+            ),
         ];
     }
 }

--- a/core/View/TwigFactory.php
+++ b/core/View/TwigFactory.php
@@ -393,8 +393,10 @@ class TwigFactory
                     ) . '" class="' . htmlspecialchars($cssClass, ENT_QUOTES) . '" style="' . $imgStyle . '">';
                 } else {
                     $img = '<div class="d-flex align-items-center justify-content-center bg-light rounded '
-                        . htmlspecialchars($cssClass,
-                        ENT_QUOTES) . '" style="' . $imgStyle . '">'
+                        . htmlspecialchars(
+                            $cssClass,
+                            ENT_QUOTES
+                        ) . '" style="' . $imgStyle . '">'
                         . '<span class="text-muted"><i class="bi bi-image"></i> Cliquer pour ajouter la photo du '
                         . 'staff</span></div>';
                 }

--- a/core/View/templates/admin/members/search.html.twig
+++ b/core/View/templates/admin/members/search.html.twig
@@ -11,7 +11,7 @@
     <form method="get" action="/admin/members" class="mb-4">
         <div class="input-group">
             <input type="search" name="q" class="form-control" value="{{ query }}"
-                   placeholder="Nom, prénom, email, téléphone…" aria-label="Recherche" autofocus>
+                   placeholder="Nom, prénom, email, téléphone…" aria-label="Recherche">
             <button type="submit" class="btn btn-primary">Rechercher</button>
         </div>
         {# The membership filter travels with the query, so a submit keeps

--- a/core/View/templates/setup/token_gate.html.twig
+++ b/core/View/templates/setup/token_gate.html.twig
@@ -28,7 +28,8 @@
             <input type="hidden" name="_csrf_token" value="{{ csrf_token }}">
             <div class="mb-3">
                 <label for="token" class="form-label">Jeton</label>
-                <input type="text" class="form-control font-monospace" id="token" name="token" autocomplete="off" required autofocus>
+                <input type="text" class="form-control font-monospace" id="token" name="token" autocomplete="off"
+                       required>
             </div>
             <button type="submit" class="btn btn-primary">Continuer</button>
         </form>


### PR DESCRIPTION
## Description

Troisième lot du solde des anomalies SonarCloud ([#308](https://github.com/xdubois-57/scoutmagic/pull/308) était le premier), et le premier des quatre qui traitent `php:S1808` — 1 570 anomalies de mise en forme sur `main`, dont **309 dans `core/`**, soldées ici. **Six anomalies d'autre nature**, toutes dans `core/` elles aussi, suivent dans le même lot (voir plus bas).

### Ce que la règle demande

Une liste d'arguments tient **sur une ligne**, ou bien **chaque argument a la sienne**, alignés d'un niveau, parenthèse fermante sur une ligne à elle. Ce dépôt écrit souvent la forme intermédiaire — quelques arguments sur la ligne d'appel, le reste replié dessous pour tenir sous 120 caractères — et c'est celle-là que `php:S1808` refuse, en deux messages : « Either split this list into multiple lines… » et « Move the closing parenthesis on the next line. »

```php
-        $this->journalService->log('core', 'settings_reset_requested', 'security',
-            'Réinitialisation des paramètres par défaut demandée', [], $userId);
+        $this->journalService->log(
+            'core',
+            'settings_reset_requested',
+            'security',
+            'Réinitialisation des paramètres par défaut demandée',
+            [],
+            $userId
+        );
```

### Comment

Mécaniquement, et appliqué comme tel :

1. `friendsofphp/php-cs-fixer` avec **la seule** règle `method_argument_space` (`on_multiline: ensure_fully_multiline`), sur les 61 fichiers de `core/` qu'elle couvre. **Aucun outil n'est ajouté au dépôt** : il a été installé hors de l'arbre, a servi une fois, et `composer.json`/`composer.lock` ne bougent pas.
2. Treize fichiers à la main, pour les cas que cette règle ne voit pas : ceux où c'est *un argument* qui s'étale sur plusieurs lignes (un `sprintf`, un tableau, une fonction fléchée) plutôt que la liste elle-même. `array_map(fn(...) => [ … ], $rows)`, `usort($x, fn(...) =>\n …)`, `implode("\n", array_filter([ … ], …))`.

Rien d'autre ne change : aucun argument ajouté, retiré ou réordonné, aucune valeur touchée, aucun texte modifié. Les **17 008 tests passent sans qu'un seul ait été retouché** — c'est exactement la garantie que vaut un lot de mise en forme.

### Les six autres anomalies, toutes dans `core/`

Elles sont arrivées sur `main` après l'instantané qui a servi au premier lot.

| Règle | Fichier | Ce qui change |
|---|---|---|
| `php:S103` ×2 | `SetupController` | Deux lignes de 124 caractères arrivées avec la restauration portable (#303), repliées dans la forme du reste du fichier. MEDIUM, donc bloquantes pour une release — pas des nits. |
| `php:S103` | `StatisticsPayloadBuilder` | Une ligne de 136 caractères, repliée de même. |
| `Web:S9379` ×2 | `setup/token_gate.html.twig`, `admin/members/search.html.twig` | Deux attributs `autofocus` retirés. La règle les compte en **fiabilité MEDIUM**, et le motif est réel : un `autofocus` déplace le point de lecture au chargement, ce qui fait perdre le début de la page à un lecteur d'écran. Les deux champs restent les premiers de leur formulaire ; ils ne prennent simplement plus le focus sans qu'on le leur demande. Le partiel `partials/form_field.html.twig` garde son option `autofocus` et son test — la règle ne la voit pas au travers de la condition Twig, et ce n'est pas à ce lot de décider qu'elle doit disparaître. |

### La suite

`modules/` (676), `public/` (542), puis `bootstrap/` + `scripts/` (37 de mise en forme et 185 de nommage `php:S100`, qui vivent dans les mêmes fichiers). Ce dernier lot pose une question de couverture du code neuf — ces fichiers sont à 0 % et 27 % — que je poserai avec lui plutôt qu'ici.

Vérifié localement : `vendor/bin/phpstan analyse` (0 erreur), `vendor/bin/phpunit` (17 008 tests, OK), `php -l` sur les 77 fichiers, et aucune ligne de plus de 120 caractères.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] This PR's title and description, and every commit message in it, are in French (`AGENTS.md` § Language)
- [x] Automated tests are written/updated for this change — aucun test n'est nécessaire ni possible pour un changement à comportement nul ; la suite existante non modifiée est ce qui le prouve
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: sans objet, aucun fichier JavaScript touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcpzpreZ2NU5kxcdGYdrtE
