### PR TITLE
Écrire les listes d'arguments des modules comme la règle de mise en forme les attend

### DIFF
--- a/modules/attestations/src/Controller/AttestationsController.php
+++ b/modules/attestations/src/Controller/AttestationsController.php
@@ -119,18 +119,21 @@ class AttestationsController extends AbstractController
         } catch (PageCountMismatchException $e) {
             $this->journalRefusal($e);
 
-            return $this->render('@attestations/index.html.twig', array_merge(
-                $this->pageContext(
-                    ['scout_year_id' => $scoutYearId, 'category' => $category->value, 'label' => $label]
-                ),
-                [
-                    'refusal' => [
-                        'page_count' => $e->pageCount,
-                        'pages_per_document' => $e->pagesPerDocument,
-                        'remainder' => $e->remainder(),
-                    ],
-                ]
-            ));
+            return $this->render(
+                '@attestations/index.html.twig',
+                array_merge(
+                    $this->pageContext(
+                        ['scout_year_id' => $scoutYearId, 'category' => $category->value, 'label' => $label]
+                    ),
+                    [
+                        'refusal' => [
+                            'page_count' => $e->pageCount,
+                            'pages_per_document' => $e->pagesPerDocument,
+                            'remainder' => $e->remainder(),
+                        ],
+                    ]
+                )
+            );
         } catch (AttestationsException $e) {
             return $this->renderWithError($e->getMessage(), $scoutYearId, $category->value, $label);
         } catch (\Throwable $e) {

--- a/modules/attestations/src/Controller/BatchController.php
+++ b/modules/attestations/src/Controller/BatchController.php
@@ -139,10 +139,13 @@ class BatchController extends AbstractController
             $this->verification->assignMember($batchId, $lineId, $memberId);
             FlashMessage::set('success', 'Attestation rattachée.');
         } catch (\Throwable $e) {
-            FlashMessage::set('error', UserFacingMessage::from(
-                $e,
-                'Le rattachement a échoué. Rechargez la page et réessayez.'
-            ));
+            FlashMessage::set(
+                'error',
+                UserFacingMessage::from(
+                    $e,
+                    'Le rattachement a échoué. Rechargez la page et réessayez.'
+                )
+            );
         }
 
         return $this->redirect($path);
@@ -187,18 +190,24 @@ class BatchController extends AbstractController
 
         try {
             $result = $this->publication->publish($batchId, $selected, AuthSession::getUserAccountId());
-            FlashMessage::set('success', sprintf(
-                '%d attestation(s) publiée(s)%s.',
-                $result['published'],
-                $result['discarded'] === 0
-                    ? ''
-                    : sprintf(', %d écartée(s) et supprimée(s)', $result['discarded'])
-            ));
+            FlashMessage::set(
+                'success',
+                sprintf(
+                    '%d attestation(s) publiée(s)%s.',
+                    $result['published'],
+                    $result['discarded'] === 0
+                        ? ''
+                        : sprintf(', %d écartée(s) et supprimée(s)', $result['discarded'])
+                )
+            );
         } catch (\Throwable $e) {
-            FlashMessage::set('error', UserFacingMessage::from(
-                $e,
-                'La publication a échoué. Rechargez la page et réessayez.'
-            ));
+            FlashMessage::set(
+                'error',
+                UserFacingMessage::from(
+                    $e,
+                    'La publication a échoué. Rechargez la page et réessayez.'
+                )
+            );
         }
 
         return $this->redirect($path);
@@ -232,10 +241,13 @@ class BatchController extends AbstractController
                 'Envoi lancé. Les messages partent par petits groupes ; revenez sur cette page pour suivre.'
             );
         } catch (\Throwable $e) {
-            FlashMessage::set('error', UserFacingMessage::from(
-                $e,
-                'L\'envoi n\'a pas pu être lancé. Rechargez la page et réessayez.'
-            ));
+            FlashMessage::set(
+                'error',
+                UserFacingMessage::from(
+                    $e,
+                    'L\'envoi n\'a pas pu être lancé. Rechargez la page et réessayez.'
+                )
+            );
         }
 
         return $this->redirect($path);
@@ -269,16 +281,22 @@ class BatchController extends AbstractController
 
         try {
             $result = $this->reset->reset($batchId, AuthSession::getUserAccountId());
-            FlashMessage::set('success', sprintf(
-                'Lot repris : %d document(s) retiré(s) des pages des membres. '
-                . 'Les e-mails déjà partis, eux, ne reviennent pas.',
-                $result['documents']
-            ));
+            FlashMessage::set(
+                'success',
+                sprintf(
+                    'Lot repris : %d document(s) retiré(s) des pages des membres. '
+                    . 'Les e-mails déjà partis, eux, ne reviennent pas.',
+                    $result['documents']
+                )
+            );
         } catch (\Throwable $e) {
-            FlashMessage::set('error', UserFacingMessage::from(
-                $e,
-                'La reprise a échoué. Rechargez la page et réessayez.'
-            ));
+            FlashMessage::set(
+                'error',
+                UserFacingMessage::from(
+                    $e,
+                    'La reprise a échoué. Rechargez la page et réessayez.'
+                )
+            );
 
             return $this->redirect(AttestationsController::PATH . '/' . $batchId);
         }

--- a/modules/calendar/src/Controller/CalendarPublicController.php
+++ b/modules/calendar/src/Controller/CalendarPublicController.php
@@ -102,8 +102,12 @@ class CalendarPublicController extends AbstractController
 
         [$year, $month] = $this->resolveRequestedMonth($request->getQuery('month'));
 
-        $calendarIds = $this->calendarPickerService->resolveCalendarIdsForGrid($selectedCalendarId, $eligibleCalendars,
-            $email, $effectiveYear->id);
+        $calendarIds = $this->calendarPickerService->resolveCalendarIdsForGrid(
+            $selectedCalendarId,
+            $eligibleCalendars,
+            $email,
+            $effectiveYear->id
+        );
 
         $events = $this->calendarService->getEventsForGrid($year, $month, $calendarIds);
         $weeks = $this->monthGridBuilder->build($year, $month, $this->calendarService->toGridEvents($events));

--- a/modules/calendar/src/Service/CalendarNotificationService.php
+++ b/modules/calendar/src/Service/CalendarNotificationService.php
@@ -327,8 +327,11 @@ class CalendarNotificationService
 
     public function cancelActivityReminderForEvent(int $eventId): void
     {
-        $existing = $this->schedulerService->find(self::MODULE_ID, self::REMINDER_TASK_KEY,
-            $this->reminderReferenceFor($eventId));
+        $existing = $this->schedulerService->find(
+            self::MODULE_ID,
+            self::REMINDER_TASK_KEY,
+            $this->reminderReferenceFor($eventId)
+        );
         if ($existing !== null && $existing['status'] === 'pending') {
             $this->schedulerService->cancel((int) $existing['id']);
         }

--- a/modules/calendar/src/Service/CalendarService.php
+++ b/modules/calendar/src/Service/CalendarService.php
@@ -175,10 +175,10 @@ class CalendarService implements
         return array_map(
             static fn(array $calendar): \Modules\Calendar\Api\SelectableCalendar =>
                 new \Modules\Calendar\Api\SelectableCalendar(
-                (int) $calendar['id'],
-                (string) $calendar['label'],
-                (bool) $calendar['is_section']
-            ),
+                    (int) $calendar['id'],
+                    (string) $calendar['label'],
+                    (bool) $calendar['is_section']
+                ),
             $this->listSelectableCalendars()
         );
     }
@@ -645,8 +645,11 @@ class CalendarService implements
         $isoWeekdayOfLast = (int) $lastOfMonth->format('N');
         $gridEnd = $lastOfMonth->modify('+' . (7 - $isoWeekdayOfLast) . ' days');
 
-        return $this->eventRepository->findByCalendarIdsInRange($calendarIds, $gridStart->format('Y-m-d'),
-            $gridEnd->format('Y-m-d'));
+        return $this->eventRepository->findByCalendarIdsInRange(
+            $calendarIds,
+            $gridStart->format('Y-m-d'),
+            $gridEnd->format('Y-m-d')
+        );
     }
 
     /**
@@ -711,8 +714,12 @@ class CalendarService implements
             if ($viewerRole !== null && $this->retroEventLinkLookup !== null) {
                 $data['auto-create-retro'] = $event->autoCreateRetro ? '1' : '0';
                 $data['has-linked-retro'] = $this->retroEventLinkLookup->hasLinkedBoard($event->id) ? '1' : '0';
-                $link = $this->retroEventLinkLookup->findLinkedBoardLink($event->id, $viewerRole, $viewerEmail,
-                    $scoutYearId);
+                $link = $this->retroEventLinkLookup->findLinkedBoardLink(
+                    $event->id,
+                    $viewerRole,
+                    $viewerEmail,
+                    $scoutYearId
+                );
                 $data['retro-link'] = $link?->url ?? '';
                 $data['retro-link-title'] = $link?->title ?? '';
             }

--- a/modules/calendar/src/Service/IcsBuilder.php
+++ b/modules/calendar/src/Service/IcsBuilder.php
@@ -153,10 +153,13 @@ class IcsBuilder implements \Modules\Calendar\Api\IcsFeedBuilderInterface
         // (Core\Config\AppClock) — read as such and then converted, rather
         // than relabelled as UTC, which would put LAST-MODIFIED an hour or
         // two ahead of the change it describes.
-        $lines[] = $this->property('LAST-MODIFIED', $this->formatUtc(
-            $this->read($event->updatedAt, AppClock::zone())
-                ->setTimezone(new \DateTimeZone('UTC'))
-        ));
+        $lines[] = $this->property(
+            'LAST-MODIFIED',
+            $this->formatUtc(
+                $this->read($event->updatedAt, AppClock::zone())
+                    ->setTimezone(new \DateTimeZone('UTC'))
+            )
+        );
 
         $lines[] = 'END:VEVENT';
 
@@ -228,9 +231,12 @@ class IcsBuilder implements \Modules\Calendar\Api\IcsFeedBuilderInterface
         // the following week.
         $lines[] = $this->property('STATUS', $event->icsStatus());
         $lines[] = $this->property('SEQUENCE', (string) $event->sequence);
-        $lines[] = $this->property('LAST-MODIFIED', $this->formatUtc(
-            ($event->updatedAt ?? new \DateTimeImmutable('now'))->setTimezone(new \DateTimeZone('UTC'))
-        ));
+        $lines[] = $this->property(
+            'LAST-MODIFIED',
+            $this->formatUtc(
+                ($event->updatedAt ?? new \DateTimeImmutable('now'))->setTimezone(new \DateTimeZone('UTC'))
+            )
+        );
 
         $lines[] = 'END:VEVENT';
 

--- a/modules/camps/src/Controller/CampsAttachmentController.php
+++ b/modules/camps/src/Controller/CampsAttachmentController.php
@@ -183,13 +183,16 @@ class CampsAttachmentController extends AbstractController
         }
 
         $result = $this->contactService->anonymise($contact, AuthSession::getUserAccountId());
-        FlashMessage::set('success', sprintf(
-            'Contact anonymisé : %d fiche%s de contact et l\'historique de %d séjour%s.',
-            $result['contacts'],
-            $result['contacts'] > 1 ? 's' : '',
-            $result['camps'],
-            $result['camps'] > 1 ? 's' : ''
-        ));
+        FlashMessage::set(
+            'success',
+            sprintf(
+                'Contact anonymisé : %d fiche%s de contact et l\'historique de %d séjour%s.',
+                $result['contacts'],
+                $result['contacts'] > 1 ? 's' : '',
+                $result['camps'],
+                $result['camps'] > 1 ? 's' : ''
+            )
+        );
 
         return $this->redirect('/chefs/camps/sejours/' . $contact->campId);
     }
@@ -424,9 +427,12 @@ class CampsAttachmentController extends AbstractController
         $albumId = $this->albumId($camp, $place?->name);
         $file = $request->getFile('photo');
         if ($albumId === null || $file === null) {
-            FlashMessage::set('error', $albumId === null
-                ? 'Les photos ne sont pas disponibles pour ce séjour.'
-                : 'Choisissez une photo à envoyer.');
+            FlashMessage::set(
+                'error',
+                $albumId === null
+                    ? 'Les photos ne sont pas disponibles pour ce séjour.'
+                    : 'Choisissez une photo à envoyer.'
+            );
 
             return $this->redirect($target);
         }

--- a/modules/camps/src/Controller/CampsChiefController.php
+++ b/modules/camps/src/Controller/CampsChiefController.php
@@ -842,13 +842,16 @@ class CampsChiefController extends AbstractController
      */
     private function decorateContacts(array $contacts): array
     {
-        return array_map(fn(Contact $contact): array => [
-            'contact' => $contact,
-            'role_options' => $this->options(
-                ContactService::ROLES,
-                ContactService::roleKeyForLabel($contact->roleLabel)
-            ),
-        ], $contacts);
+        return array_map(
+            fn(Contact $contact): array => [
+                'contact' => $contact,
+                'role_options' => $this->options(
+                    ContactService::ROLES,
+                    ContactService::roleKeyForLabel($contact->roleLabel)
+                ),
+            ],
+            $contacts
+        );
     }
 
     /**

--- a/modules/camps/src/Controller/CampsConfigController.php
+++ b/modules/camps/src/Controller/CampsConfigController.php
@@ -61,8 +61,11 @@ class CampsConfigController extends AbstractController
             return $guard;
         }
 
-        $this->settings->set('camps_default_country', trim((string) $request->getBody('camps_default_country', '')),
-            self::MODULE);
+        $this->settings->set(
+            'camps_default_country',
+            trim((string) $request->getBody('camps_default_country', '')),
+            self::MODULE
+        );
 
         // Clamped rather than rejected: this is a display convenience, and
         // an out-of-range value here should not stop an administrator

--- a/modules/camps/src/Controller/CampsMergeController.php
+++ b/modules/camps/src/Controller/CampsMergeController.php
@@ -97,12 +97,15 @@ class CampsMergeController extends AbstractController
             return $this->redirect('/chefs/camps/lieux/' . $place->id . '/fusionner');
         }
 
-        FlashMessage::set('success', sprintf(
-            '%d séjour%s repris. « %s » est archivé.',
-            $moved,
-            $moved > 1 ? 's' : '',
-            $place->name
-        ));
+        FlashMessage::set(
+            'success',
+            sprintf(
+                '%d séjour%s repris. « %s » est archivé.',
+                $moved,
+                $moved > 1 ? 's' : '',
+                $place->name
+            )
+        );
 
         return $this->redirect('/chefs/camps/lieux/' . $target->id);
     }
@@ -224,9 +227,12 @@ class CampsMergeController extends AbstractController
             return $this->redirect('/chefs/camps/sejours/' . $camp->id . '/fusionner');
         }
 
-        FlashMessage::set('success', $lost === []
-            ? 'Séjours fusionnés.'
-            : 'Séjours fusionnés. Les valeurs remplacées ont été ajoutées à la note.');
+        FlashMessage::set(
+            'success',
+            $lost === []
+                ? 'Séjours fusionnés.'
+                : 'Séjours fusionnés. Les valeurs remplacées ont été ajoutées à la note.'
+        );
 
         return $this->redirect('/chefs/camps/sejours/' . $target->id);
     }

--- a/modules/camps/src/Mail/CampsMessageConsumer.php
+++ b/modules/camps/src/Mail/CampsMessageConsumer.php
@@ -192,10 +192,13 @@ class CampsMessageConsumer implements
         // what the chief's screen requires before it files anything.
         $campId = self::campIdFromReference(trim($query));
         if ($campId !== null && $this->camps->findById($campId) !== null) {
-            array_unshift($suggestions, new ReferenceSuggestion(
-                self::referenceFor($campId),
-                $this->describeReference(self::referenceFor($campId)) ?? self::referenceFor($campId)
-            ));
+            array_unshift(
+                $suggestions,
+                new ReferenceSuggestion(
+                    self::referenceFor($campId),
+                    $this->describeReference(self::referenceFor($campId)) ?? self::referenceFor($campId)
+                )
+            );
         }
 
         return array_slice($suggestions, 0, max(1, $limit));

--- a/modules/camps/src/Mail/MailFieldCompletionService.php
+++ b/modules/camps/src/Mail/MailFieldCompletionService.php
@@ -68,8 +68,12 @@ class MailFieldCompletionService
                     $filled[] = 'dates';
                 } else {
                     $this->proposals->save(
-                        $camp->id, 'dates', $current, $incoming,
-                        $range['start'] . '|' . $range['end'], $sourceReference
+                        $camp->id,
+                        'dates',
+                        $current,
+                        $incoming,
+                        $range['start'] . '|' . $range['end'],
+                        $sourceReference
                     );
                     $proposed[] = 'dates';
                 }
@@ -135,10 +139,15 @@ class MailFieldCompletionService
         // a proposal that cannot be applied is not worth offering twice.
         if (!$written) {
             $this->audit->record(
-                CampService::ENTITY_TYPE, $camp->id, $proposal->fieldKey,
-                $proposal->currentValue, $proposal->currentValue,
-                AuditSource::System, "Information du message inapplicable — proposition retirée",
-                $proposal->sourceReference, $actorUserAccountId
+                CampService::ENTITY_TYPE,
+                $camp->id,
+                $proposal->fieldKey,
+                $proposal->currentValue,
+                $proposal->currentValue,
+                AuditSource::System,
+                "Information du message inapplicable — proposition retirée",
+                $proposal->sourceReference,
+                $actorUserAccountId
             );
             $this->proposals->delete($proposal->id);
 
@@ -146,10 +155,15 @@ class MailFieldCompletionService
         }
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $camp->id, $proposal->fieldKey,
-            $proposal->currentValue, $proposal->proposedValue,
-            AuditSource::Email, 'Information du message acceptée',
-            $proposal->sourceReference, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $camp->id,
+            $proposal->fieldKey,
+            $proposal->currentValue,
+            $proposal->proposedValue,
+            AuditSource::Email,
+            'Information du message acceptée',
+            $proposal->sourceReference,
+            $actorUserAccountId
         );
         $this->proposals->delete($proposal->id);
     }
@@ -162,10 +176,15 @@ class MailFieldCompletionService
     public function dismiss(FieldProposal $proposal, ?int $actorUserAccountId): void
     {
         $this->audit->record(
-            CampService::ENTITY_TYPE, $proposal->campId, $proposal->fieldKey,
-            $proposal->proposedValue, $proposal->currentValue,
-            AuditSource::Human, 'Information du message ignorée',
-            $proposal->sourceReference, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $proposal->campId,
+            $proposal->fieldKey,
+            $proposal->proposedValue,
+            $proposal->currentValue,
+            AuditSource::Human,
+            'Information du message ignorée',
+            $proposal->sourceReference,
+            $actorUserAccountId
         );
         $this->proposals->delete($proposal->id);
     }
@@ -179,10 +198,15 @@ class MailFieldCompletionService
         $this->write($camp, ['start_date' => $range['start'], 'end_date' => $range['end'], 'year_only' => null]);
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $camp->id, 'dates',
+            CampService::ENTITY_TYPE,
+            $camp->id,
+            'dates',
             $before !== '' ? $before : null,
             CampLabels::dateRange($range['start'], $range['end'], null),
-            AuditSource::Email, 'Dates complétées depuis un message reçu', $sourceReference, null
+            AuditSource::Email,
+            'Dates complétées depuis un message reçu',
+            $sourceReference,
+            null
         );
     }
 
@@ -191,8 +215,15 @@ class MailFieldCompletionService
         $this->write($camp, ['price_cents' => $cents]);
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $camp->id, 'price', null, $formatted,
-            AuditSource::Email, 'Prix complété depuis un message reçu', $sourceReference, null
+            CampService::ENTITY_TYPE,
+            $camp->id,
+            'price',
+            null,
+            $formatted,
+            AuditSource::Email,
+            'Prix complété depuis un message reçu',
+            $sourceReference,
+            null
         );
     }
 

--- a/modules/camps/src/Mail/StayFromMailService.php
+++ b/modules/camps/src/Mail/StayFromMailService.php
@@ -302,8 +302,11 @@ class StayFromMailService
      */
     private function shortStayMaxDays(): int
     {
-        $raw = (int) ($this->settings->get('camps_short_stay_max_days', 'camps',
-            (string) self::DEFAULT_SHORT_STAY_MAX_DAYS)
+        $raw = (int) ($this->settings->get(
+            'camps_short_stay_max_days',
+            'camps',
+            (string) self::DEFAULT_SHORT_STAY_MAX_DAYS
+        )
             ?? self::DEFAULT_SHORT_STAY_MAX_DAYS);
 
         return max(1, $raw);

--- a/modules/camps/src/Repository/FieldProposalRepository.php
+++ b/modules/camps/src/Repository/FieldProposalRepository.php
@@ -99,8 +99,10 @@ class FieldProposalRepository
                 ? $this->encryption->decrypt((string) $row['current_value'], 'camp_field_proposals.value')
                 : null,
             proposedValue: $this->encryption->decrypt((string) $row['proposed_value'], 'camp_field_proposals.value'),
-            proposedMachineValue: $this->encryption->decrypt((string) $row['proposed_machine_value'],
-                'camp_field_proposals.value'),
+            proposedMachineValue: $this->encryption->decrypt(
+                (string) $row['proposed_machine_value'],
+                'camp_field_proposals.value'
+            ),
             sourceReference: $row['source_reference'] !== null ? (string) $row['source_reference'] : null,
             createdAt: (string) $row['created_at'],
         );

--- a/modules/camps/src/Service/CampAlbumService.php
+++ b/modules/camps/src/Service/CampAlbumService.php
@@ -124,8 +124,15 @@ class CampAlbumService
         }
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $camp->id, 'photos', null, null,
-            AuditSource::Human, 'Photo ajoutée', null, $accountId
+            CampService::ENTITY_TYPE,
+            $camp->id,
+            'photos',
+            null,
+            null,
+            AuditSource::Human,
+            'Photo ajoutée',
+            null,
+            $accountId
         );
     }
 
@@ -142,8 +149,15 @@ class CampAlbumService
         }
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $camp->id, 'photos', null, null,
-            AuditSource::Human, 'Photo supprimée', null, $accountId
+            CampService::ENTITY_TYPE,
+            $camp->id,
+            'photos',
+            null,
+            null,
+            AuditSource::Human,
+            'Photo supprimée',
+            null,
+            $accountId
         );
     }
 

--- a/modules/camps/src/Service/CampService.php
+++ b/modules/camps/src/Service/CampService.php
@@ -113,8 +113,15 @@ class CampService
         // sections were set from the fact that no line ever set them.
         if ($values['section_ids'] !== []) {
             $this->audit->record(
-                self::ENTITY_TYPE, $id, 'sections', null, $describeSections($values['section_ids']),
-                $source, null, null, $actorUserAccountId
+                self::ENTITY_TYPE,
+                $id,
+                'sections',
+                null,
+                $describeSections($values['section_ids']),
+                $source,
+                null,
+                null,
+                $actorUserAccountId
             );
         }
 
@@ -150,29 +157,62 @@ class CampService
 
         $this->markPlaceSummaryStale($camp->placeId);
 
-        $this->recordChange($camp->id, 'stay_type',
-            CampLabels::stayType($camp->stayType), CampLabels::stayType($values['stay_type']),
-            $source, $actorUserAccountId);
-        $this->recordChange($camp->id, 'dates',
+        $this->recordChange(
+            $camp->id,
+            'stay_type',
+            CampLabels::stayType($camp->stayType),
+            CampLabels::stayType($values['stay_type']),
+            $source,
+            $actorUserAccountId
+        );
+        $this->recordChange(
+            $camp->id,
+            'dates',
             CampLabels::dateRange($camp->startDate, $camp->endDate, $camp->yearOnly),
             CampLabels::dateRange($values['start_date'], $values['end_date'], $values['year_only']),
-            $source, $actorUserAccountId);
-        $this->recordChange($camp->id, 'status',
-            CampLabels::status($camp->status), CampLabels::status($values['status']),
-            $source, $actorUserAccountId);
-        $this->recordChange($camp->id, 'price',
-            CampLabels::money($camp->priceCents), CampLabels::money($values['price_cents']),
-            $source, $actorUserAccountId);
-        $this->recordChange($camp->id, 'participants',
+            $source,
+            $actorUserAccountId
+        );
+        $this->recordChange(
+            $camp->id,
+            'status',
+            CampLabels::status($camp->status),
+            CampLabels::status($values['status']),
+            $source,
+            $actorUserAccountId
+        );
+        $this->recordChange(
+            $camp->id,
+            'price',
+            CampLabels::money($camp->priceCents),
+            CampLabels::money($values['price_cents']),
+            $source,
+            $actorUserAccountId
+        );
+        $this->recordChange(
+            $camp->id,
+            'participants',
             $camp->participantCount !== null ? (string) $camp->participantCount : null,
             $values['participant_count'] !== null ? (string) $values['participant_count'] : null,
-            $source, $actorUserAccountId);
-        $this->recordChange($camp->id, 'booked_by',
-            $camp->bookedByName, $values['booked_by_name'],
-            $source, $actorUserAccountId);
-        $this->recordChange($camp->id, 'sections',
-            $describeSections($camp->sectionIds), $describeSections($values['section_ids']),
-            $source, $actorUserAccountId);
+            $source,
+            $actorUserAccountId
+        );
+        $this->recordChange(
+            $camp->id,
+            'booked_by',
+            $camp->bookedByName,
+            $values['booked_by_name'],
+            $source,
+            $actorUserAccountId
+        );
+        $this->recordChange(
+            $camp->id,
+            'sections',
+            $describeSections($camp->sectionIds),
+            $describeSections($values['section_ids']),
+            $source,
+            $actorUserAccountId
+        );
     }
 
     /**

--- a/modules/camps/src/Service/DocumentService.php
+++ b/modules/camps/src/Service/DocumentService.php
@@ -88,8 +88,15 @@ class DocumentService
         }
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $campId, 'document', null, $title,
-            AuditSource::Human, 'Document ajouté', null, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $campId,
+            'document',
+            null,
+            $title,
+            AuditSource::Human,
+            'Document ajouté',
+            null,
+            $actorUserAccountId
         );
 
         return $id;
@@ -110,8 +117,15 @@ class DocumentService
         $id = $this->documents->create($campId, $title, $fileId, Document::SOURCE_EMAIL, $sourceReference);
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $campId, 'document', null, $title,
-            AuditSource::Email, 'Pièce jointe rattachée depuis un message', $sourceReference, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $campId,
+            'document',
+            null,
+            $title,
+            AuditSource::Email,
+            'Pièce jointe rattachée depuis un message',
+            $sourceReference,
+            $actorUserAccountId
         );
 
         return $id;
@@ -149,12 +163,22 @@ class DocumentService
     public function delete(Document $document, ?int $actorUserAccountId): void
     {
         $this->fileRemover->remove(
-            $this->documents, $document->id, $document->fileId, $document->ownsItsFile()
+            $this->documents,
+            $document->id,
+            $document->fileId,
+            $document->ownsItsFile()
         );
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $document->campId, 'document', $document->title, null,
-            AuditSource::Human, 'Document supprimé', null, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $document->campId,
+            'document',
+            $document->title,
+            null,
+            AuditSource::Human,
+            'Document supprimé',
+            null,
+            $actorUserAccountId
         );
     }
 

--- a/modules/camps/src/Service/LinkService.php
+++ b/modules/camps/src/Service/LinkService.php
@@ -66,8 +66,15 @@ class LinkService
 
         $recorded = $preview !== null && $preview->title !== null ? $preview->title : $url;
         $this->audit->record(
-            CampService::ENTITY_TYPE, $campId, 'link', null,
-            $recorded, AuditSource::Human, 'Lien ajouté', null, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $campId,
+            'link',
+            null,
+            $recorded,
+            AuditSource::Human,
+            'Lien ajouté',
+            null,
+            $actorUserAccountId
         );
 
         return $id;
@@ -78,8 +85,15 @@ class LinkService
         $this->links->delete($link->id);
 
         $this->audit->record(
-            CampService::ENTITY_TYPE, $link->campId, 'link', $link->heading(), null,
-            AuditSource::Human, 'Lien retiré', null, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $link->campId,
+            'link',
+            $link->heading(),
+            null,
+            AuditSource::Human,
+            'Lien retiré',
+            null,
+            $actorUserAccountId
         );
     }
 

--- a/modules/camps/src/Service/MergeService.php
+++ b/modules/camps/src/Service/MergeService.php
@@ -190,14 +190,26 @@ class MergeService
             $this->places->archive($from->id, true);
 
             $this->audit->record(
-                PlaceService::ENTITY_TYPE, $to->id, 'name', null, $to->name, AuditSource::Human,
+                PlaceService::ENTITY_TYPE,
+                $to->id,
+                'name',
+                null,
+                $to->name,
+                AuditSource::Human,
                 sprintf('Fusion : %d séjour(s) repris depuis « %s »', $moved, $from->name),
-                null, $actorUserAccountId
+                null,
+                $actorUserAccountId
             );
             $this->audit->record(
-                PlaceService::ENTITY_TYPE, $from->id, 'name', $from->name, $to->name, AuditSource::Human,
+                PlaceService::ENTITY_TYPE,
+                $from->id,
+                'name',
+                $from->name,
+                $to->name,
+                AuditSource::Human,
                 'Lieu fusionné dans un autre et archivé',
-                null, $actorUserAccountId
+                null,
+                $actorUserAccountId
             );
 
             // What the AI wrote about either place describes stays that
@@ -260,9 +272,15 @@ class MergeService
             $this->camps->delete($from->id);
 
             $this->audit->record(
-                CampService::ENTITY_TYPE, $to->id, 'camp', null, null, AuditSource::Human,
+                CampService::ENTITY_TYPE,
+                $to->id,
+                'camp',
+                null,
+                null,
+                AuditSource::Human,
                 'Séjour fusionné depuis un autre — les valeurs remplacées sont reprises dans la note',
-                null, $actorUserAccountId
+                null,
+                $actorUserAccountId
             );
 
             // The place has one stay fewer, and the surviving one carries

--- a/modules/camps/src/Service/PlaceArchiveService.php
+++ b/modules/camps/src/Service/PlaceArchiveService.php
@@ -60,9 +60,15 @@ class PlaceArchiveService
 
         $this->places->archive($place->id, true);
         $this->audit->record(
-            PlaceService::ENTITY_TYPE, $place->id, 'archived', null, 'Archivé', AuditSource::Human,
+            PlaceService::ENTITY_TYPE,
+            $place->id,
+            'archived',
+            null,
+            'Archivé',
+            AuditSource::Human,
             'Lieu retiré des écrans courants — rien n\'est supprimé',
-            null, $actorUserAccountId
+            null,
+            $actorUserAccountId
         );
     }
 
@@ -70,8 +76,15 @@ class PlaceArchiveService
     {
         $this->places->archive($place->id, false);
         $this->audit->record(
-            PlaceService::ENTITY_TYPE, $place->id, 'archived', 'Archivé', null, AuditSource::Human,
-            'Lieu restauré', null, $actorUserAccountId
+            PlaceService::ENTITY_TYPE,
+            $place->id,
+            'archived',
+            'Archivé',
+            null,
+            AuditSource::Human,
+            'Lieu restauré',
+            null,
+            $actorUserAccountId
         );
     }
 

--- a/modules/camps/src/Service/PlaceService.php
+++ b/modules/camps/src/Service/PlaceService.php
@@ -48,8 +48,15 @@ class PlaceService
         );
 
         $this->audit->record(
-            self::ENTITY_TYPE, $id, 'name', null, $name, $source,
-            'Lieu créé', null, $actorUserAccountId
+            self::ENTITY_TYPE,
+            $id,
+            'name',
+            null,
+            $name,
+            $source,
+            'Lieu créé',
+            null,
+            $actorUserAccountId
         );
 
         return $id;
@@ -141,9 +148,15 @@ class PlaceService
 
         $this->places->setManualCoordinates($place->id, $latitude, $longitude);
         $this->audit->record(
-            self::ENTITY_TYPE, $place->id, 'coordinates', $before, $after, $source,
+            self::ENTITY_TYPE,
+            $place->id,
+            'coordinates',
+            $before,
+            $after,
+            $source,
             'Coordonnées saisies à la main — le géocodage automatique ne touchera plus ce lieu',
-            null, $actorUserAccountId
+            null,
+            $actorUserAccountId
         );
     }
 
@@ -202,8 +215,17 @@ class PlaceService
             return;
         }
 
-        $this->audit->record(self::ENTITY_TYPE, $placeId, $fieldKey, $from, $to, $source, null, null,
-            $actorUserAccountId);
+        $this->audit->record(
+            self::ENTITY_TYPE,
+            $placeId,
+            $fieldKey,
+            $from,
+            $to,
+            $source,
+            null,
+            null,
+            $actorUserAccountId
+        );
     }
 
     /**

--- a/modules/camps/src/Service/ReviewService.php
+++ b/modules/camps/src/Service/ReviewService.php
@@ -116,9 +116,15 @@ class ReviewService
         $this->reviews->delete($camp->id);
         $this->places?->markSummaryStale($camp->placeId);
         $this->audit->record(
-            CampService::ENTITY_TYPE, $camp->id, 'review',
-            $this->describe($before->rating, $before->comment), null,
-            AuditSource::Human, 'Avis supprimé', null, $actorUserAccountId
+            CampService::ENTITY_TYPE,
+            $camp->id,
+            'review',
+            $this->describe($before->rating, $before->comment),
+            null,
+            AuditSource::Human,
+            'Avis supprimé',
+            null,
+            $actorUserAccountId
         );
     }
 

--- a/modules/camps/src/Service/StaySearchService.php
+++ b/modules/camps/src/Service/StaySearchService.php
@@ -176,17 +176,20 @@ class StaySearchService
         // screen shows (place, French dates, kind of stay, status) AND the
         // stored dates, so « 2026-09 » and « 18/09/2026 » work for the
         // people who think in dates rather than in months.
-        $haystack = TextNormalizerService::fold(implode(' ', array_filter([
-            $placeName,
-            $label,
-            CampLabels::stayType($camp->stayType),
-            CampLabels::status($camp->status),
-            $camp->startDate,
-            $camp->endDate,
-            self::slashed($camp->startDate),
-            self::slashed($camp->endDate),
-            $camp->yearOnly !== null ? (string) $camp->yearOnly : null,
-        ])));
+        $haystack = TextNormalizerService::fold(implode(
+            ' ',
+            array_filter([
+                $placeName,
+                $label,
+                CampLabels::stayType($camp->stayType),
+                CampLabels::status($camp->status),
+                $camp->startDate,
+                $camp->endDate,
+                self::slashed($camp->startDate),
+                self::slashed($camp->endDate),
+                $camp->yearOnly !== null ? (string) $camp->yearOnly : null,
+            ])
+        ));
 
         foreach ($terms as $term) {
             if (!str_contains($haystack, $term)) {

--- a/modules/fees/src/Controller/FeeAccuracyController.php
+++ b/modules/fees/src/Controller/FeeAccuracyController.php
@@ -345,16 +345,28 @@ class FeeAccuracyController extends AbstractController
                     $sheet->setCellValueExplicit([1, $rowNum], $tab, DataType::TYPE_STRING);
                     $sheet->setCellValueExplicit([2, $rowNum], $review->addressLabel, DataType::TYPE_STRING);
                     $sheet->setCellValueExplicit([3, $rowNum], (string) $review->deskSize, DataType::TYPE_NUMERIC);
-                    $sheet->setCellValueExplicit([4, $rowNum], HouseholdCategoryLabel::for($review->expectedCategory),
-                        DataType::TYPE_STRING);
-                    $sheet->setCellValueExplicit([5, $rowNum], trim($member->firstName . ' ' . $member->lastName),
-                        DataType::TYPE_STRING);
-                    $sheet->setCellValueExplicit([6, $rowNum], $member->encodedFeeCategoryLabel ?? '',
-                        DataType::TYPE_STRING);
+                    $sheet->setCellValueExplicit(
+                        [4, $rowNum],
+                        HouseholdCategoryLabel::for($review->expectedCategory),
+                        DataType::TYPE_STRING
+                    );
+                    $sheet->setCellValueExplicit(
+                        [5, $rowNum],
+                        trim($member->firstName . ' ' . $member->lastName),
+                        DataType::TYPE_STRING
+                    );
+                    $sheet->setCellValueExplicit(
+                        [6, $rowNum],
+                        $member->encodedFeeCategoryLabel ?? '',
+                        DataType::TYPE_STRING
+                    );
                     $sheet->setCellValueExplicit([7, $rowNum], self::verdict($review, $member), DataType::TYPE_STRING);
                     if ($review->differenceCents !== null) {
-                        $sheet->setCellValueExplicit([8, $rowNum], (string) ($review->differenceCents / 100),
-                            DataType::TYPE_NUMERIC);
+                        $sheet->setCellValueExplicit(
+                            [8, $rowNum],
+                            (string) ($review->differenceCents / 100),
+                            DataType::TYPE_NUMERIC
+                        );
                     }
                     $sheet->setCellValueExplicit([9, $rowNum], self::trigger($review), DataType::TYPE_STRING);
                     $rowNum++;

--- a/modules/fees/src/Controller/InvoiceController.php
+++ b/modules/fees/src/Controller/InvoiceController.php
@@ -124,22 +124,31 @@ class InvoiceController extends AbstractController
 
         $file = $request->getFile('invoice');
         if ($file === null || (int) ($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
-            return $this->render('@fees/invoice_import.html.twig', $this->formContext([
-                'upload_error' => 'Aucun fichier fourni, ou une erreur est survenue pendant le téléversement.',
-            ]));
+            return $this->render(
+                '@fees/invoice_import.html.twig',
+                $this->formContext([
+                    'upload_error' => 'Aucun fichier fourni, ou une erreur est survenue pendant le téléversement.',
+                ])
+            );
         }
 
         if ((int) ($file['size'] ?? 0) > self::MAX_BYTES) {
-            return $this->render('@fees/invoice_import.html.twig', $this->formContext([
-                'upload_error' => 'Ce fichier dépasse la taille maximale autorisée (20 Mo).',
-            ]));
+            return $this->render(
+                '@fees/invoice_import.html.twig',
+                $this->formContext([
+                    'upload_error' => 'Ce fichier dépasse la taille maximale autorisée (20 Mo).',
+                ])
+            );
         }
 
         $content = @file_get_contents((string) ($file['tmp_name'] ?? ''));
         if ($content === false) {
-            return $this->render('@fees/invoice_import.html.twig', $this->formContext([
-                'upload_error' => "Le fichier envoyé n'a pas pu être lu.",
-            ]));
+            return $this->render(
+                '@fees/invoice_import.html.twig',
+                $this->formContext([
+                    'upload_error' => "Le fichier envoyé n'a pas pu être lu.",
+                ])
+            );
         }
 
         $year = $this->effectiveYear();
@@ -205,10 +214,13 @@ class InvoiceController extends AbstractController
                 AuthSession::getUserAccountId()
             );
         } catch (\Throwable $e) {
-            FlashMessage::set('warning', UserFacingMessage::from(
-                $e,
-                "La facture a bien été importée, mais le PDF n'a pas pu être conservé dans Finances."
-            ));
+            FlashMessage::set(
+                'warning',
+                UserFacingMessage::from(
+                    $e,
+                    "La facture a bien été importée, mais le PDF n'a pas pu être conservé dans Finances."
+                )
+            );
         }
     }
 

--- a/modules/fees/src/Repository/HouseholdDetailRepository.php
+++ b/modules/fees/src/Repository/HouseholdDetailRepository.php
@@ -168,8 +168,10 @@ class HouseholdDetailRepository
                 number: $this->nullIfEmpty($this->decrypt($row['number_encrypted'], 'member_addresses.number')),
                 box: $this->nullIfEmpty($this->decrypt($row['box_encrypted'], 'member_addresses.box')),
                 complement: null,
-                postalCode: $this->nullIfEmpty($this->decrypt($row['postal_code_encrypted'],
-                    'member_addresses.postal_code')),
+                postalCode: $this->nullIfEmpty($this->decrypt(
+                    $row['postal_code_encrypted'],
+                    'member_addresses.postal_code'
+                )),
                 city: $this->nullIfEmpty($this->decrypt($row['city_encrypted'], 'member_addresses.city')),
                 country: null,
             );

--- a/modules/fees/src/Service/FeeAccuracyService.php
+++ b/modules/fees/src/Service/FeeAccuracyService.php
@@ -90,8 +90,14 @@ class FeeAccuracyService
                 $ignoredEntry = null;
             }
 
-            $review = $this->review($household, $blindIndex, $memberRows, $addressLabels, $feeCategoryLabels,
-                $ignoredEntry);
+            $review = $this->review(
+                $household,
+                $blindIndex,
+                $memberRows,
+                $addressLabels,
+                $feeCategoryLabels,
+                $ignoredEntry
+            );
 
             if ($ignoredEntry !== null) {
                 $setAside[] = $review;

--- a/modules/fees/src/Service/InvoiceVerificationService.php
+++ b/modules/fees/src/Service/InvoiceVerificationService.php
@@ -64,8 +64,11 @@ class InvoiceVerificationService
         $sectionLabels = $this->sectionLabels();
 
         return array_map(
-            fn(StoredInvoiceLine $line): ReconstitutedLine => $this->reconstitute($line, $snapshotMembers,
-                $sectionLabels),
+            fn(StoredInvoiceLine $line): ReconstitutedLine => $this->reconstitute(
+                $line,
+                $snapshotMembers,
+                $sectionLabels
+            ),
             $this->invoices->findLines($invoice->id)
         );
     }

--- a/modules/fees/src/Value/InvoiceImportOutcome.php
+++ b/modules/fees/src/Value/InvoiceImportOutcome.php
@@ -69,8 +69,16 @@ final class InvoiceImportOutcome
         ?string $issueDate,
         int $totalCents
     ): self {
-        return new self(self::STALE_ROSTER, null, [], $unknownSectionCodes, $ignoredRowCount, $documentNumber,
-            $issueDate, $totalCents);
+        return new self(
+            self::STALE_ROSTER,
+            null,
+            [],
+            $unknownSectionCodes,
+            $ignoredRowCount,
+            $documentNumber,
+            $issueDate,
+            $totalCents
+        );
     }
 
     public static function alreadyImported(int $invoiceId, string $documentNumber): self

--- a/modules/finance/src/Controller/CampaignController.php
+++ b/modules/finance/src/Controller/CampaignController.php
@@ -150,12 +150,15 @@ class CampaignController extends AbstractController
         $filter = CampaignOverviewService::normalizeFilter($request->getQuery('filter'));
         $detail = $this->overviewService->detail($campaign, $filter);
 
-        return $this->render('@finance/campaigns/detail.html.twig', $detail + [
-            'filter' => $filter,
-            'reminder_available' => $this->reminderService->isAvailable(),
-            'scout_year' => $this->scoutYearLabel($campaign->scoutYearId),
-            'account' => $this->financeService->getAccount($campaign->accountId),
-        ]);
+        return $this->render(
+            '@finance/campaigns/detail.html.twig',
+            $detail + [
+                'filter' => $filter,
+                'reminder_available' => $this->reminderService->isAvailable(),
+                'scout_year' => $this->scoutYearLabel($campaign->scoutYearId),
+                'account' => $this->financeService->getAccount($campaign->accountId),
+            ]
+        );
     }
 
     /**
@@ -379,11 +382,14 @@ class CampaignController extends AbstractController
         } catch (\Throwable $e) {
             // The mail-merge module's own refusal survives, its internals
             // do not (AGENTS.md § Exception messages that reach a visitor).
-            FlashMessage::set('error', \Core\Exception\UserFacingMessage::from(
-                $e,
-                "Le brouillon de rappel n'a pas pu être créé. Vérifiez que le publipostage est configuré pour votre "
-                    . "section."
-            ));
+            FlashMessage::set(
+                'error',
+                \Core\Exception\UserFacingMessage::from(
+                    $e,
+                    "Le brouillon de rappel n'a pas pu être créé. Vérifiez que le publipostage est configuré "
+                    . "pour votre section."
+                )
+            );
 
             return $this->redirect($redirect);
         }
@@ -427,16 +433,19 @@ class CampaignController extends AbstractController
             // messages to the families who did get one.
             $notified = $this->notificationService->notifyFamilies($campaign, $actorAccountId);
 
-            FlashMessage::set('success', $notified > 0
-                ? 'Les familles sont prévenues — '
-                    . $notified
-                    . ' compte'
-                    . ($notified > 1 ? 's' : '')
-                    . ' notifié'
-                    . ($notified > 1 ? 's' : '')
-                    . '.'
-                : "La campagne est marquée comme notifiée. Aucun compte n'a reçu de notification : soit tout est "
-                    . "réglé, soit aucune famille n'a de compte sur le site.");
+            FlashMessage::set(
+                'success',
+                $notified > 0
+                    ? 'Les familles sont prévenues — '
+                        . $notified
+                        . ' compte'
+                        . ($notified > 1 ? 's' : '')
+                        . ' notifié'
+                        . ($notified > 1 ? 's' : '')
+                        . '.'
+                    : "La campagne est marquée comme notifiée. Aucun compte n'a reçu de notification : soit tout est "
+                        . "réglé, soit aucune famille n'a de compte sur le site."
+            );
         } catch (FinanceException $e) {
             FlashMessage::set('error', $e->getMessage());
         }
@@ -453,11 +462,14 @@ class CampaignController extends AbstractController
         $years = $this->scoutYears->getAll();
         $current = $this->scoutYears->getCurrentYear();
 
-        return $this->render('@finance/campaigns/new.html.twig', $context + [
-            'accounts' => $this->financeService->getAccountsForUser($role),
-            'scout_years' => array_reverse($years),
-            'current_scout_year_id' => $current['id'],
-        ]);
+        return $this->render(
+            '@finance/campaigns/new.html.twig',
+            $context + [
+                'accounts' => $this->financeService->getAccountsForUser($role),
+                'scout_years' => array_reverse($years),
+                'current_scout_year_id' => $current['id'],
+            ]
+        );
     }
 
     /**

--- a/modules/finance/src/Controller/ConfigAccountController.php
+++ b/modules/finance/src/Controller/ConfigAccountController.php
@@ -82,8 +82,14 @@ class ConfigAccountController extends AbstractController
                         !empty($data['holder_name']) ? (string) $data['holder_name'] : null,
                         (string) ($data['role_min_view'] ?? 'intendant')
                     );
-                    $this->journalService->log('finance', 'account_created', 'info', "Compte « {$account->name} » créé",
-                        ['account_id' => $account->id], AuthSession::getUserAccountId());
+                    $this->journalService->log(
+                        'finance',
+                        'account_created',
+                        'info',
+                        "Compte « {$account->name} » créé",
+                        ['account_id' => $account->id],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true, 'account_id' => $account->id]);
 
                 case 'update':
@@ -98,23 +104,40 @@ class ConfigAccountController extends AbstractController
                         (string) ($data['role_min_view'] ?? 'intendant')
                     );
                     $this->syncReceiptFilesRoleMin($account->id, $account->roleMinView);
-                    $this->journalService->log('finance', 'account_updated', 'info',
-                        "Compte « {$account->name} » modifié", ['account_id' => $account->id],
-                        AuthSession::getUserAccountId());
+                    $this->journalService->log(
+                        'finance',
+                        'account_updated',
+                        'info',
+                        "Compte « {$account->name} » modifié",
+                        ['account_id' => $account->id],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true]);
 
                 case 'activate':
                     $id = (int) ($data['id'] ?? 0);
                     $this->financeService->setAccountActive($id, true);
-                    $this->journalService->log('finance', 'account_activated', 'info', 'Compte activé',
-                        ['account_id' => $id], AuthSession::getUserAccountId());
+                    $this->journalService->log(
+                        'finance',
+                        'account_activated',
+                        'info',
+                        'Compte activé',
+                        ['account_id' => $id],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true]);
 
                 case 'deactivate':
                     $id = (int) ($data['id'] ?? 0);
                     $this->financeService->setAccountActive($id, false);
-                    $this->journalService->log('finance', 'account_deactivated', 'info', 'Compte désactivé',
-                        ['account_id' => $id], AuthSession::getUserAccountId());
+                    $this->journalService->log(
+                        'finance',
+                        'account_deactivated',
+                        'info',
+                        'Compte désactivé',
+                        ['account_id' => $id],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true]);
 
                 default:

--- a/modules/finance/src/Controller/ConfigCategoryController.php
+++ b/modules/finance/src/Controller/ConfigCategoryController.php
@@ -93,10 +93,19 @@ class ConfigCategoryController extends AbstractController
 
                 case 'update':
                     $id = (int) ($data['id'] ?? 0);
-                    $this->financeService->updateCategory($id, (string) ($data['name'] ?? ''),
-                        (string) ($data['description'] ?? ''));
-                    $this->journalService->log('finance', 'category_updated', 'info', 'Catégorie modifiée',
-                        ['category_id' => $id], AuthSession::getUserAccountId());
+                    $this->financeService->updateCategory(
+                        $id,
+                        (string) ($data['name'] ?? ''),
+                        (string) ($data['description'] ?? '')
+                    );
+                    $this->journalService->log(
+                        'finance',
+                        'category_updated',
+                        'info',
+                        'Catégorie modifiée',
+                        ['category_id' => $id],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true]);
 
                 case 'activate':
@@ -112,14 +121,26 @@ class ConfigCategoryController extends AbstractController
                 case 'delete':
                     $id = (int) ($data['id'] ?? 0);
                     $this->financeService->deleteCategory($id);
-                    $this->journalService->log('finance', 'category_deleted', 'info', 'Catégorie supprimée',
-                        ['category_id' => $id], AuthSession::getUserAccountId());
+                    $this->journalService->log(
+                        'finance',
+                        'category_deleted',
+                        'info',
+                        'Catégorie supprimée',
+                        ['category_id' => $id],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true]);
 
                 case 'reset_defaults':
                     $this->financeService->resetDefaultCategories();
-                    $this->journalService->log('finance', 'categories_reset_to_defaults', 'info',
-                        'Catégories par défaut réinitialisées', [], AuthSession::getUserAccountId());
+                    $this->journalService->log(
+                        'finance',
+                        'categories_reset_to_defaults',
+                        'info',
+                        'Catégories par défaut réinitialisées',
+                        [],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true]);
 
                 default:

--- a/modules/finance/src/Controller/ConfigController.php
+++ b/modules/finance/src/Controller/ConfigController.php
@@ -104,8 +104,11 @@ class ConfigController extends AbstractController
      */
     private function ensureCampaignFilePurgeScheduled(): void
     {
-        $existing = $this->schedulerService->find('finance', PurgeCampaignFilesHandler::TASK_KEY,
-            PurgeCampaignFilesHandler::REFERENCE);
+        $existing = $this->schedulerService->find(
+            'finance',
+            PurgeCampaignFilesHandler::TASK_KEY,
+            PurgeCampaignFilesHandler::REFERENCE
+        );
         if ($existing !== null && $existing['status'] === 'pending' && strtotime($existing['run_at']) > time()) {
             return;
         }

--- a/modules/finance/src/Controller/ConfigRuleController.php
+++ b/modules/finance/src/Controller/ConfigRuleController.php
@@ -67,10 +67,21 @@ class ConfigRuleController extends AbstractController
                     return $this->json(['success' => false, 'error' => 'Catégorie invalide.'], 400);
                 }
                 $priority = count($this->ruleRepository->findAllOrderedByPriority());
-                $id = $this->ruleRepository->create($categoryId, $priority, $keywordPattern,
-                    $counterpartyAccountPattern, $amountRange);
-                $this->journalService->log('finance', 'rule_created', 'info', 'Règle de catégorisation créée',
-                    ['rule_id' => $id], AuthSession::getUserAccountId());
+                $id = $this->ruleRepository->create(
+                    $categoryId,
+                    $priority,
+                    $keywordPattern,
+                    $counterpartyAccountPattern,
+                    $amountRange
+                );
+                $this->journalService->log(
+                    'finance',
+                    'rule_created',
+                    'info',
+                    'Règle de catégorisation créée',
+                    ['rule_id' => $id],
+                    AuthSession::getUserAccountId()
+                );
                 return $this->json(['success' => true, 'rule_id' => $id]);
             }
 
@@ -98,10 +109,21 @@ class ConfigRuleController extends AbstractController
                     return $this->json(['success' => false, 'error' => 'Catégorie invalide.'], 400);
                 }
 
-                $this->ruleRepository->update($ruleId, $categoryId, $keywordPattern, $counterpartyAccountPattern,
-                    $amountRange);
-                $this->journalService->log('finance', 'rule_updated', 'info', 'Règle de catégorisation modifiée',
-                    ['rule_id' => $ruleId], AuthSession::getUserAccountId());
+                $this->ruleRepository->update(
+                    $ruleId,
+                    $categoryId,
+                    $keywordPattern,
+                    $counterpartyAccountPattern,
+                    $amountRange
+                );
+                $this->journalService->log(
+                    'finance',
+                    'rule_updated',
+                    'info',
+                    'Règle de catégorisation modifiée',
+                    ['rule_id' => $ruleId],
+                    AuthSession::getUserAccountId()
+                );
                 return $this->json(['success' => true]);
             }
 
@@ -132,8 +154,14 @@ class ConfigRuleController extends AbstractController
                     return $blocked;
                 }
                 $this->ruleRepository->delete($ruleId);
-                $this->journalService->log('finance', 'rule_deleted', 'info', 'Règle de catégorisation supprimée',
-                    ['rule_id' => $ruleId], AuthSession::getUserAccountId());
+                $this->journalService->log(
+                    'finance',
+                    'rule_deleted',
+                    'info',
+                    'Règle de catégorisation supprimée',
+                    ['rule_id' => $ruleId],
+                    AuthSession::getUserAccountId()
+                );
                 return $this->json(['success' => true]);
             }
 
@@ -156,8 +184,14 @@ class ConfigRuleController extends AbstractController
 
             case 'reset_defaults':
                 $this->financeService->resetDefaultCategoryRules();
-                $this->journalService->log('finance', 'rules_reset_to_defaults', 'info',
-                    'Règles de catégorisation par défaut réinitialisées', [], AuthSession::getUserAccountId());
+                $this->journalService->log(
+                    'finance',
+                    'rules_reset_to_defaults',
+                    'info',
+                    'Règles de catégorisation par défaut réinitialisées',
+                    [],
+                    AuthSession::getUserAccountId()
+                );
                 return $this->json(['success' => true]);
 
             case 'set_ai_enabled':
@@ -174,9 +208,12 @@ class ConfigRuleController extends AbstractController
                     return $this->json(['success' => false, 'error' => 'Une exécution est déjà en cours.'], 400);
                 }
                 $this->journalService->log(
-                    'finance', 'rules_run_on_uncategorized_started', 'info',
+                    'finance',
+                    'rules_run_on_uncategorized_started',
+                    'info',
                     'Exécution des règles de catégorisation sur les mouvements non catégorisés lancée en arrière-plan',
-                    [], AuthSession::getUserAccountId()
+                    [],
+                    AuthSession::getUserAccountId()
                 );
                 return $this->json(['success' => true]);
             }
@@ -244,8 +281,10 @@ class ConfigRuleController extends AbstractController
 
         if ($keywordPattern !== null) {
             if (!CategoryRuleEngine::isValidKeywordPattern($keywordPattern)) {
-                return $this->json(['success' => false, 'error' => 'Expression régulière invalide pour le mot-clé.'],
-                    400);
+                return $this->json(
+                    ['success' => false, 'error' => 'Expression régulière invalide pour le mot-clé.'],
+                    400
+                );
             }
             $keywordPattern = mb_strtolower($keywordPattern);
         }
@@ -256,8 +295,10 @@ class ConfigRuleController extends AbstractController
                 IbanNormalizer::looksLikeFullIban($counterpartyAccountPattern)
                 && !IbanNormalizer::isValidFullIban($counterpartyAccountPattern)
             ) {
-                return $this->json(['success' => false, 'error' => "Le compte contrepartie n'est pas un IBAN valide."],
-                    400);
+                return $this->json(
+                    ['success' => false, 'error' => "Le compte contrepartie n'est pas un IBAN valide."],
+                    400
+                );
             }
         }
 

--- a/modules/finance/src/Controller/DashboardController.php
+++ b/modules/finance/src/Controller/DashboardController.php
@@ -124,8 +124,13 @@ class DashboardController extends AbstractController
             $balanceEvolution = $this->financeService->getBalanceEvolution($account->id, $fiscalYear->id);
             $recentMovements = array_slice(
                 $isFiltered
-                    ? $this->findMatchingMovements($account->id, $fiscalYear->id, $categoryId, $uncategorizedOnly,
-                        $search)
+                    ? $this->findMatchingMovements(
+                        $account->id,
+                        $fiscalYear->id,
+                        $categoryId,
+                        $uncategorizedOnly,
+                        $search
+                    )
                     : $this->findActionNeededMovements($account->id, $fiscalYear->id),
                 0,
                 self::RECENT_MOVEMENTS_LIMIT
@@ -142,8 +147,11 @@ class DashboardController extends AbstractController
         );
         $recentMovementRows = array_map(fn(Transaction $movement) => [
             'movement' => $movement,
-            'counterparty' => MovementPresenter::counterparty($movement,
-                $firstReceiptsByMovementId[$movement->id] ?? null, $account->name),
+            'counterparty' => MovementPresenter::counterparty(
+                $movement,
+                $firstReceiptsByMovementId[$movement->id] ?? null,
+                $account->name
+            ),
             'description' => MovementPresenter::description(
                 $movement,
                 $firstReceiptsByMovementId[$movement->id] ?? null
@@ -240,8 +248,13 @@ class DashboardController extends AbstractController
         bool $uncategorizedOnly,
         string $search
     ): array {
-        $movements = $this->transactionRepository->findFiltered([$accountId], $fiscalYearId, $categoryId, null,
-            $uncategorizedOnly);
+        $movements = $this->transactionRepository->findFiltered(
+            [$accountId],
+            $fiscalYearId,
+            $categoryId,
+            null,
+            $uncategorizedOnly
+        );
 
         if ($search === '') {
             return $movements;

--- a/modules/finance/src/Controller/ImportController.php
+++ b/modules/finance/src/Controller/ImportController.php
@@ -115,10 +115,13 @@ class ImportController extends AbstractController
      */
     private function renderResult(array $context): Response
     {
-        return $this->render('@finance/import/result.html.twig', $context + [
-            'breadcrumb_trail' => [
-                ['label' => 'Importer', 'url' => '/finance/import'],
-            ],
-        ]);
+        return $this->render(
+            '@finance/import/result.html.twig',
+            $context + [
+                'breadcrumb_trail' => [
+                    ['label' => 'Importer', 'url' => '/finance/import'],
+                ],
+            ]
+        );
     }
 }

--- a/modules/finance/src/Controller/MovementController.php
+++ b/modules/finance/src/Controller/MovementController.php
@@ -93,13 +93,20 @@ class MovementController extends AbstractController
             // cannot happen in SQL (same split as the receipts list,
             // AttachmentRepository::findFilteredForAccount()).
             $totalCount = $this->transactionRepository->countFiltered(
-                $account->id, $fiscalYearId, $categoryId, $uncategorizedOnly
+                $account->id,
+                $fiscalYearId,
+                $categoryId,
+                $uncategorizedOnly
             );
             $totalPages = max(1, (int) ceil($totalCount / self::PER_PAGE));
             $page = min($page, $totalPages);
             $movements = $this->transactionRepository->findFilteredPage(
-                $account->id, $fiscalYearId, $categoryId, $uncategorizedOnly,
-                self::PER_PAGE, ($page - 1) * self::PER_PAGE
+                $account->id,
+                $fiscalYearId,
+                $categoryId,
+                $uncategorizedOnly,
+                self::PER_PAGE,
+                ($page - 1) * self::PER_PAGE
             );
         } else {
             $allMatches = $this->transactionRepository->findFiltered(
@@ -216,8 +223,12 @@ class MovementController extends AbstractController
         );
 
         $this->journalService->log(
-            'finance', 'movements_exported', 'info', 'Export des mouvements en XLSX',
-            ['account_id' => $account->id, 'count' => count($movements)], (int) AuthSession::getUserAccountId()
+            'finance',
+            'movements_exported',
+            'info',
+            'Export des mouvements en XLSX',
+            ['account_id' => $account->id, 'count' => count($movements)],
+            (int) AuthSession::getUserAccountId()
         );
 
         return \Core\Http\SpreadsheetResponse::download($spreadsheet, 'mouvements.xlsx');
@@ -255,8 +266,11 @@ class MovementController extends AbstractController
             // into a live formula in the treasurer's export.
             $sheet->setCellValueExplicit([1, $rowNum], $movement->transactionDate, DataType::TYPE_STRING);
             $sheet->setCellValueExplicit([2, $rowNum], $movement->label, DataType::TYPE_STRING);
-            $sheet->setCellValueExplicit([3, $rowNum],
-                MovementPresenter::counterparty($movement, $firstReceipt, $accountName), DataType::TYPE_STRING);
+            $sheet->setCellValueExplicit(
+                [3, $rowNum],
+                MovementPresenter::counterparty($movement, $firstReceipt, $accountName),
+                DataType::TYPE_STRING
+            );
             $sheet->setCellValueExplicit([4, $rowNum], (string) $movement->amount, DataType::TYPE_NUMERIC);
             $sheet->setCellValueExplicit([5, $rowNum], $category?->name ?? '', DataType::TYPE_STRING);
             $sheet->setCellValueExplicit([6, $rowNum], $movement->comment ?? '', DataType::TYPE_STRING);
@@ -414,8 +428,10 @@ class MovementController extends AbstractController
 
         $files = $request->getFiles('receipt');
         if ($files === []) {
-            return $this->json(['success' => false, 'error' => 'Aucun fichier fourni ou erreur lors du téléversement.'],
-                400);
+            return $this->json(
+                ['success' => false, 'error' => 'Aucun fichier fourni ou erreur lors du téléversement.'],
+                400
+            );
         }
         $file = $files[0];
         if ($file['error'] !== UPLOAD_ERR_OK) {
@@ -438,8 +454,15 @@ class MovementController extends AbstractController
         $mimeType = $detected !== false ? $detected : 'application/octet-stream';
 
         try {
-            $attachment = $this->receiptService->upload($content, $mimeType, $file['name'], $account->id, null, null,
-                AuthSession::getUserAccountId());
+            $attachment = $this->receiptService->upload(
+                $content,
+                $mimeType,
+                $file['name'],
+                $account->id,
+                null,
+                null,
+                AuthSession::getUserAccountId()
+            );
             $this->receiptService->associate($attachment->id, [$id]);
         } catch (FinanceException $e) {
             return $this->json(['success' => false, 'error' => $e->getMessage()], 400);
@@ -447,8 +470,12 @@ class MovementController extends AbstractController
 
         // Queued by Service\ReceiptService::store() itself — see there.
         $this->journalService->log(
-            'finance', 'receipt_uploaded', 'info', 'Reçu ajouté et associé depuis la page des mouvements',
-            ['attachment_id' => $attachment->id, 'transaction_id' => $id], AuthSession::getUserAccountId()
+            'finance',
+            'receipt_uploaded',
+            'info',
+            'Reçu ajouté et associé depuis la page des mouvements',
+            ['attachment_id' => $attachment->id, 'transaction_id' => $id],
+            AuthSession::getUserAccountId()
         );
 
         return $this->json(['success' => true, 'attachment_id' => $attachment->id]);
@@ -519,9 +546,11 @@ class MovementController extends AbstractController
                 'label' => $transaction->label,
                 'amount' => $transaction->amount,
                 'counterparty' => MovementPresenter::counterparty(
-                    $transaction, $firstReceipts[
+                    $transaction,
+                    $firstReceipts[
                         $transaction->id
-                    ] ?? null, $accountNamesById[$transaction->accountId] ?? ''
+                    ] ?? null,
+                    $accountNamesById[$transaction->accountId] ?? ''
                 ),
                 'description' => MovementPresenter::description($transaction, $firstReceipts[$transaction->id] ?? null),
             ], $matches),

--- a/modules/finance/src/Controller/ReceiptController.php
+++ b/modules/finance/src/Controller/ReceiptController.php
@@ -174,8 +174,13 @@ class ReceiptController extends AbstractController
         $consumerId = \Modules\Finance\Mail\FinanceMessageConsumer::CONSUMER_ID;
 
         $done = $confirm
-            ? $this->inboundMail->confirmCandidate($consumerId, $references, $messageId, $candidateId,
-                AuthSession::getUserAccountId())
+            ? $this->inboundMail->confirmCandidate(
+                $consumerId,
+                $references,
+                $messageId,
+                $candidateId,
+                AuthSession::getUserAccountId()
+            )
             : $this->inboundMail->dismissCandidate($consumerId, $references, $messageId, $candidateId);
 
         FlashMessage::set(
@@ -215,8 +220,11 @@ class ReceiptController extends AbstractController
         $page = max(1, (int) $request->getQuery('page', 1));
 
         $totalPages = max(1, (int) ceil(
-            $this->attachmentRepository->countFilteredForAccount($accountId, $pendingOnly,
-                $search !== '' ? $search : null) / self::PER_PAGE
+            $this->attachmentRepository->countFilteredForAccount(
+                $accountId,
+                $pendingOnly,
+                $search !== '' ? $search : null
+            ) / self::PER_PAGE
         ));
         $page = min($page, $totalPages);
 
@@ -296,8 +304,11 @@ class ReceiptController extends AbstractController
         $search = trim((string) $request->getQuery('q', ''));
         $page = max(1, (int) $request->getQuery('page', 1));
 
-        $total = $this->attachmentRepository->countFilteredForAccount($accountId, $pendingOnly,
-            $search !== '' ? $search : null);
+        $total = $this->attachmentRepository->countFilteredForAccount(
+            $accountId,
+            $pendingOnly,
+            $search !== '' ? $search : null
+        );
         $totalPages = max(1, (int) ceil($total / self::PER_PAGE));
         $page = min($page, $totalPages);
 
@@ -372,7 +383,11 @@ class ReceiptController extends AbstractController
     private function buildRows(?int $accountId, bool $pendingOnly, string $search, int $page): array
     {
         $results = $this->attachmentRepository->findFilteredForAccount(
-            $accountId, $pendingOnly, $search !== '' ? $search : null, self::PER_PAGE, ($page - 1) * self::PER_PAGE
+            $accountId,
+            $pendingOnly,
+            $search !== '' ? $search : null,
+            self::PER_PAGE,
+            ($page - 1) * self::PER_PAGE
         );
 
         return array_map(fn(array $row) => [
@@ -424,8 +439,10 @@ class ReceiptController extends AbstractController
 
         $files = $request->getFiles('receipts');
         if ($files === []) {
-            return $this->render('@finance/receipts/form.html.twig',
-                ['error' => 'Aucun fichier fourni ou erreur lors du téléversement.']);
+            return $this->render(
+                '@finance/receipts/form.html.twig',
+                ['error' => 'Aucun fichier fourni ou erreur lors du téléversement.']
+            );
         }
         if (count($files) > self::MAX_FILES_PER_UPLOAD) {
             return $this->render('@finance/receipts/form.html.twig', [
@@ -483,8 +500,15 @@ class ReceiptController extends AbstractController
         $mimeType = $detected !== false ? $detected : 'application/octet-stream';
 
         try {
-            $attachment = $this->receiptService->upload($content, $mimeType, $file['name'], $accountId, null, null,
-                AuthSession::getUserAccountId());
+            $attachment = $this->receiptService->upload(
+                $content,
+                $mimeType,
+                $file['name'],
+                $accountId,
+                null,
+                null,
+                AuthSession::getUserAccountId()
+            );
         } catch (FinanceException $e) {
             return $e->getMessage();
         }
@@ -492,8 +516,14 @@ class ReceiptController extends AbstractController
         // The extraction is queued by Service\ReceiptService::store()
         // itself, so that every way in gets it — including the one with
         // no controller at all, a receipt arriving by e-mail.
-        $this->journalService->log('finance', 'receipt_uploaded', 'info', 'Reçu ajouté',
-            ['attachment_id' => $attachment->id, 'account_id' => $accountId], AuthSession::getUserAccountId());
+        $this->journalService->log(
+            'finance',
+            'receipt_uploaded',
+            'info',
+            'Reçu ajouté',
+            ['attachment_id' => $attachment->id, 'account_id' => $accountId],
+            AuthSession::getUserAccountId()
+        );
 
         return null;
     }
@@ -594,8 +624,14 @@ class ReceiptController extends AbstractController
             return $this->json(['success' => false, 'error' => $e->getMessage()], 400);
         }
 
-        $this->journalService->log('finance', 'receipt_deleted', 'info', 'Reçu supprimé (archivé)',
-            ['attachment_id' => $id], AuthSession::getUserAccountId());
+        $this->journalService->log(
+            'finance',
+            'receipt_deleted',
+            'info',
+            'Reçu supprimé (archivé)',
+            ['attachment_id' => $id],
+            AuthSession::getUserAccountId()
+        );
 
         return $this->json(['success' => true]);
     }
@@ -608,30 +644,40 @@ class ReceiptController extends AbstractController
         $id = (int) ($params['id'] ?? 0);
 
         if (!CsrfGuard::validateToken((string) $request->getBody('_csrf_token', ''))) {
-            return $this->render('@finance/receipts/form.html.twig',
-                ['error' => self::SESSION_EXPIRED_MESSAGE, 'replace_id' => $id]);
+            return $this->render(
+                '@finance/receipts/form.html.twig',
+                ['error' => self::SESSION_EXPIRED_MESSAGE, 'replace_id' => $id]
+            );
         }
 
         $attachment = $this->requireVisibleAttachment($id);
         if ($attachment instanceof Response) {
-            return $this->render('@finance/receipts/form.html.twig',
-                ['error' => 'Reçu introuvable ou inaccessible.', 'replace_id' => $id]);
+            return $this->render(
+                '@finance/receipts/form.html.twig',
+                ['error' => 'Reçu introuvable ou inaccessible.', 'replace_id' => $id]
+            );
         }
 
         $file = $request->getFile('receipt');
         if ($file === null || (int) ($file['error'] ?? UPLOAD_ERR_NO_FILE) !== UPLOAD_ERR_OK) {
-            return $this->render('@finance/receipts/form.html.twig',
-                ['error' => 'Aucun fichier fourni ou erreur lors du téléversement.', 'replace_id' => $id]);
+            return $this->render(
+                '@finance/receipts/form.html.twig',
+                ['error' => 'Aucun fichier fourni ou erreur lors du téléversement.', 'replace_id' => $id]
+            );
         }
         if ((int) ($file['size'] ?? 0) > self::MAX_SIZE_BYTES) {
-            return $this->render('@finance/receipts/form.html.twig',
-                ['error' => 'Le fichier dépasse la taille maximale autorisée (15 Mo).', 'replace_id' => $id]);
+            return $this->render(
+                '@finance/receipts/form.html.twig',
+                ['error' => 'Le fichier dépasse la taille maximale autorisée (15 Mo).', 'replace_id' => $id]
+            );
         }
 
         $content = file_get_contents((string) $file['tmp_name']);
         if ($content === false) {
-            return $this->render('@finance/receipts/form.html.twig',
-                ['error' => 'Impossible de lire le fichier envoyé.', 'replace_id' => $id]);
+            return $this->render(
+                '@finance/receipts/form.html.twig',
+                ['error' => 'Impossible de lire le fichier envoyé.', 'replace_id' => $id]
+            );
         }
 
         // Detection is the sole source of truth — no client-declared fallback
@@ -641,8 +687,13 @@ class ReceiptController extends AbstractController
         $mimeType = $detected !== false ? $detected : 'application/octet-stream';
 
         try {
-            $newAttachment = $this->receiptService->replace($id, $content, $mimeType, (string) $file['name'],
-                AuthSession::getUserAccountId());
+            $newAttachment = $this->receiptService->replace(
+                $id,
+                $content,
+                $mimeType,
+                (string) $file['name'],
+                AuthSession::getUserAccountId()
+            );
         } catch (FinanceException $e) {
             return $this->render(
                 '@finance/receipts/form.html.twig',
@@ -650,8 +701,14 @@ class ReceiptController extends AbstractController
             );
         }
 
-        $this->journalService->log('finance', 'receipt_replaced', 'info', 'Reçu remplacé',
-            ['old_attachment_id' => $id, 'new_attachment_id' => $newAttachment->id], AuthSession::getUserAccountId());
+        $this->journalService->log(
+            'finance',
+            'receipt_replaced',
+            'info',
+            'Reçu remplacé',
+            ['old_attachment_id' => $id, 'new_attachment_id' => $newAttachment->id],
+            AuthSession::getUserAccountId()
+        );
 
         return $this->redirect(
             '/finance/receipts' . ($newAttachment->accountId !== null ? '?account_id=' . $newAttachment->accountId : '')
@@ -685,8 +742,14 @@ class ReceiptController extends AbstractController
             return $this->json(['success' => false, 'error' => $e->getMessage()], 400);
         }
 
-        $this->journalService->log('finance', 'receipt_associated', 'info', 'Reçu associé à des mouvements',
-            ['attachment_id' => $id, 'transaction_ids' => $transactionIds], AuthSession::getUserAccountId());
+        $this->journalService->log(
+            'finance',
+            'receipt_associated',
+            'info',
+            'Reçu associé à des mouvements',
+            ['attachment_id' => $id, 'transaction_ids' => $transactionIds],
+            AuthSession::getUserAccountId()
+        );
 
         return $this->json(['success' => true]);
     }

--- a/modules/finance/src/Controller/ToolsController.php
+++ b/modules/finance/src/Controller/ToolsController.php
@@ -235,13 +235,16 @@ class ToolsController extends AbstractController
      */
     private function renderTools(array $context = []): Response
     {
-        return $this->render('@finance/tools.html.twig', $context + [
-            // The page picker in @finance/_nav.html.twig wants these; the
-            // account picker is suppressed because neither tool works on
-            // an account — the QR takes an arbitrary IBAN, and the checker
-            // searches every receivable the caller may see.
-            'accounts' => [],
-            'hide_account_picker' => true,
-        ]);
+        return $this->render(
+            '@finance/tools.html.twig',
+            $context + [
+                // The page picker in @finance/_nav.html.twig wants these; the
+                // account picker is suppressed because neither tool works on
+                // an account — the QR takes an arbitrary IBAN, and the checker
+                // searches every receivable the caller may see.
+                'accounts' => [],
+                'hide_account_picker' => true,
+            ]
+        );
     }
 }

--- a/modules/finance/src/Repository/CampaignRowRepository.php
+++ b/modules/finance/src/Repository/CampaignRowRepository.php
@@ -167,8 +167,10 @@ class CampaignRowRepository
     {
         $mergeData = [];
         if (($row['merge_data'] ?? null) !== null) {
-            $decoded = json_decode($this->encryption->decrypt($row['merge_data'], 'finance_campaign_rows.merge_data'),
-                true);
+            $decoded = json_decode(
+                $this->encryption->decrypt($row['merge_data'], 'finance_campaign_rows.merge_data'),
+                true
+            );
             if (is_array($decoded)) {
                 foreach ($decoded as $header => $value) {
                     $mergeData[(string) $header] = (string) $value;

--- a/modules/finance/src/Repository/MemberLookupRepository.php
+++ b/modules/finance/src/Repository/MemberLookupRepository.php
@@ -41,8 +41,10 @@ class MemberLookupRepository
      */
     public function resolveIds(array $memberIds): array
     {
-        $ids = array_values(array_unique(array_filter(array_map('intval', $memberIds),
-            static fn(int $id): bool => $id > 0)));
+        $ids = array_values(array_unique(array_filter(
+            array_map('intval', $memberIds),
+            static fn(int $id): bool => $id > 0
+        )));
         if ($ids === []) {
             return [];
         }

--- a/modules/finance/src/Repository/TransactionRepository.php
+++ b/modules/finance/src/Repository/TransactionRepository.php
@@ -265,13 +265,16 @@ class TransactionRepository
         );
         $stmt->execute([$accountId, $fiscalYearId]);
 
-        return array_map(fn(array $row) => [
-            'category_id' => $row['category_id'] !== null ? (int) $row['category_id'] : null,
-            'category_name' => $row['category_name'] !== null ? (string) $row['category_name'] : null,
-            'income' => (float) $row['income'],
-            'expense' => (float) $row['expense'],
-            'total' => (float) $row['total'],
-        ], $stmt->fetchAll(\PDO::FETCH_ASSOC));
+        return array_map(
+            fn(array $row) => [
+                'category_id' => $row['category_id'] !== null ? (int) $row['category_id'] : null,
+                'category_name' => $row['category_name'] !== null ? (string) $row['category_name'] : null,
+                'income' => (float) $row['income'],
+                'expense' => (float) $row['expense'],
+                'total' => (float) $row['total'],
+            ],
+            $stmt->fetchAll(\PDO::FETCH_ASSOC)
+        );
     }
 
     /**

--- a/modules/finance/src/Service/AiCategorizationService.php
+++ b/modules/finance/src/Service/AiCategorizationService.php
@@ -112,8 +112,12 @@ class AiCategorizationService
             ));
         } catch (LlmException $e) {
             $this->journalService->log(
-                'finance', 'ai_categorization_failed', 'info',
-                "Catégorisation IA échouée : {$e->getMessage()}", ['transaction_id' => $transaction->id], null
+                'finance',
+                'ai_categorization_failed',
+                'info',
+                "Catégorisation IA échouée : {$e->getMessage()}",
+                ['transaction_id' => $transaction->id],
+                null
             );
             return null;
         }

--- a/modules/finance/src/Service/BulkCategorizationService.php
+++ b/modules/finance/src/Service/BulkCategorizationService.php
@@ -76,9 +76,17 @@ class BulkCategorizationService
 
     public function setAiRuleEnabled(bool $enabled): void
     {
-        $this->settingService->register(self::AI_ENABLED_SETTING_KEY, '0', 'boolean',
-            'Règle de catégorisation IA activée', 'Indicateur interne — ne pas modifier.', 'finance', null, null, false
-            );
+        $this->settingService->register(
+            self::AI_ENABLED_SETTING_KEY,
+            '0',
+            'boolean',
+            'Règle de catégorisation IA activée',
+            'Indicateur interne — ne pas modifier.',
+            'finance',
+            null,
+            null,
+            false
+        );
         $this->settingService->setInternal(self::AI_ENABLED_SETTING_KEY, $enabled ? '1' : '0', 'finance');
     }
 
@@ -145,9 +153,17 @@ class BulkCategorizationService
 
     private function registerRunningSetting(): void
     {
-        $this->settingService->register(self::RUNNING_SETTING_KEY, '0', 'number',
-            'Exécution des règles en cours depuis', 'Indicateur interne — ne pas modifier.', 'finance', null, null,
-            false);
+        $this->settingService->register(
+            self::RUNNING_SETTING_KEY,
+            '0',
+            'number',
+            'Exécution des règles en cours depuis',
+            'Indicateur interne — ne pas modifier.',
+            'finance',
+            null,
+            null,
+            false
+        );
     }
 
     /**

--- a/modules/finance/src/Service/CampaignExportService.php
+++ b/modules/finance/src/Service/CampaignExportService.php
@@ -107,8 +107,11 @@ class CampaignExportService
                 DataType::TYPE_NUMERIC
             );
             $sheet->setCellValueExplicit([8, $line], self::euros($row['amount_overpaid'] ?? 0), DataType::TYPE_NUMERIC);
-            $sheet->setCellValueExplicit([9, $line], self::STATUS_LABELS[$row['status'] ?? ''] ?? '',
-                DataType::TYPE_STRING);
+            $sheet->setCellValueExplicit(
+                [9, $line],
+                self::STATUS_LABELS[$row['status'] ?? ''] ?? '',
+                DataType::TYPE_STRING
+            );
             $sheet->setCellValueExplicit([10, $line], (string) ($row['note'] ?? ''), DataType::TYPE_STRING);
             $sheet->setCellValueExplicit([11, $line], (string) ($row['note_author'] ?? ''), DataType::TYPE_STRING);
             $sheet->setCellValueExplicit([12, $line], (string) ($row['note_updated_at'] ?? ''), DataType::TYPE_STRING);

--- a/modules/finance/src/Service/CampaignImportService.php
+++ b/modules/finance/src/Service/CampaignImportService.php
@@ -114,8 +114,14 @@ class CampaignImportService
         $seenMemberIds = [];
 
         foreach ($dataRows as $row) {
-            $memberId = $this->resolveMember($row['data'], $memberIdColumn, $deskIdColumn, $resolvedIds,
-                $resolvedDeskIds, $problem);
+            $memberId = $this->resolveMember(
+                $row['data'],
+                $memberIdColumn,
+                $deskIdColumn,
+                $resolvedIds,
+                $resolvedDeskIds,
+                $problem
+            );
             if ($memberId === null) {
                 $problems[] = [
                     'line' => $row['line'],

--- a/modules/finance/src/Service/CampaignOverviewService.php
+++ b/modules/finance/src/Service/CampaignOverviewService.php
@@ -73,8 +73,10 @@ class CampaignOverviewService
         $summaries = [];
 
         foreach ($this->campaigns->findByScoutYear($scoutYearId) as $campaign) {
-            if (!$this->accountVisibility->isVisibleTo($this->accountRepository->findById($campaign->accountId),
-                $viewerRole)) {
+            if (!$this->accountVisibility->isVisibleTo(
+                $this->accountRepository->findById($campaign->accountId),
+                $viewerRole
+            )) {
                 continue;
             }
 

--- a/modules/finance/src/Service/CampaignReminderService.php
+++ b/modules/finance/src/Service/CampaignReminderService.php
@@ -109,8 +109,12 @@ class CampaignReminderService
         foreach ($recipients as $email => $recipient) {
             $rows[] = [
                 'email' => (string) $email,
-                'values' => $this->valuesFor($recipient, $maxBlocks, $account->holderName ?? $account->name,
-                    IbanNormalizer::format(IbanNormalizer::normalize($account->iban))),
+                'values' => $this->valuesFor(
+                    $recipient,
+                    $maxBlocks,
+                    $account->holderName ?? $account->name,
+                    IbanNormalizer::format(IbanNormalizer::normalize($account->iban))
+                ),
             ];
         }
 

--- a/modules/finance/src/Service/ExpectedReceivableService.php
+++ b/modules/finance/src/Service/ExpectedReceivableService.php
@@ -63,8 +63,15 @@ class ExpectedReceivableService implements ExpectedReceivableInterface
             throw new FinanceException('La communication doit contenir au moins un chiffre.');
         }
 
-        $id = $this->repository->create($sourceModule, $sourceReferenceId, $accountId, $amountCents, $communication,
-            $label, $memberId);
+        $id = $this->repository->create(
+            $sourceModule,
+            $sourceReferenceId,
+            $accountId,
+            $amountCents,
+            $communication,
+            $label,
+            $memberId
+        );
 
         // The payment can predate the receivable — a rental's security
         // deposit routinely arrives before the booking is confirmed — and

--- a/modules/finance/src/Service/FinanceAccountService.php
+++ b/modules/finance/src/Service/FinanceAccountService.php
@@ -25,13 +25,16 @@ class FinanceAccountService implements FinanceAccountInterface
             fn(Account $account) => $account->status === Account::STATUS_ACTIVE
         );
 
-        return array_values(array_map(fn(Account $account) => [
-            'id' => $account->id,
-            'name' => $account->name,
-            'iban' => $account->iban,
-            'holder_name' => $account->holderName,
-            'section_id' => $account->sectionId,
-        ], $accounts));
+        return array_values(array_map(
+            fn(Account $account) => [
+                'id' => $account->id,
+                'name' => $account->name,
+                'iban' => $account->iban,
+                'holder_name' => $account->holderName,
+                'section_id' => $account->sectionId,
+            ],
+            $accounts
+        ));
     }
 
     public function getDefaultAccountForSection(int $sectionId): ?int

--- a/modules/finance/src/Service/FinanceService.php
+++ b/modules/finance/src/Service/FinanceService.php
@@ -299,9 +299,17 @@ class FinanceService
             // finds them by name and seeds rules for them, exactly once.
             $this->seedDefaultCategoryRules();
 
-            $this->settingService->register(self::SEEDED_SETTING_KEY, '0', 'boolean',
-                'Catégories par défaut initialisées', 'Indicateur interne — ne pas modifier.', 'finance', null, null,
-                false);
+            $this->settingService->register(
+                self::SEEDED_SETTING_KEY,
+                '0',
+                'boolean',
+                'Catégories par défaut initialisées',
+                'Indicateur interne — ne pas modifier.',
+                'finance',
+                null,
+                null,
+                false
+            );
             $this->settingService->setInternal(self::SEEDED_SETTING_KEY, '1', 'finance');
         }
 
@@ -365,8 +373,10 @@ class FinanceService
             fn(CategoryRule $rule) => !$rule->isSystem
         ));
 
-        usort($nonSystemRules,
-            fn(CategoryRule $a, CategoryRule $b) => ($b->isDefault ? 1 : 0) <=> ($a->isDefault ? 1 : 0));
+        usort(
+            $nonSystemRules,
+            fn(CategoryRule $a, CategoryRule $b) => ($b->isDefault ? 1 : 0) <=> ($a->isDefault ? 1 : 0)
+        );
 
         $this->categoryRuleRepository->reorder(array_map(fn(CategoryRule $rule) => $rule->id, $nonSystemRules));
     }
@@ -385,8 +395,10 @@ class FinanceService
      */
     public function resetDefaultCategories(): void
     {
-        $existingNames = array_map(fn(Category $category) => $category->name,
-            $this->categoryRepository->findAllOrdered());
+        $existingNames = array_map(
+            fn(Category $category) => $category->name,
+            $this->categoryRepository->findAllOrdered()
+        );
 
         $recreatedNames = [];
         foreach (self::DEFAULT_CATEGORY_DESCRIPTIONS as $name => $description) {
@@ -425,8 +437,15 @@ class FinanceService
 
             foreach ($patterns as $pattern) {
                 $priority = count($this->categoryRuleRepository->findAllOrderedByPriority());
-                $this->categoryRuleRepository->create($category->id, $priority, $pattern, null, null, isSystem: false,
-                    isDefault: true);
+                $this->categoryRuleRepository->create(
+                    $category->id,
+                    $priority,
+                    $pattern,
+                    null,
+                    null,
+                    isSystem: false,
+                    isDefault: true
+                );
             }
         }
     }

--- a/modules/finance/src/Service/ImportService.php
+++ b/modules/finance/src/Service/ImportService.php
@@ -138,8 +138,12 @@ class ImportService
                         }
                     }
 
-                    $this->checkpointRepository->create($account->id, $checkpointDate, $balance,
-                        BalanceCheckpoint::SOURCE_IMPORT);
+                    $this->checkpointRepository->create(
+                        $account->id,
+                        $checkpointDate,
+                        $balance,
+                        BalanceCheckpoint::SOURCE_IMPORT
+                    );
                 }
 
                 $statementImportId = $this->statementImportRepository->create(

--- a/modules/finance/src/Service/ReceiptMatchingService.php
+++ b/modules/finance/src/Service/ReceiptMatchingService.php
@@ -120,8 +120,12 @@ class ReceiptMatchingService
 
         $match = $this->findRuleBasedMatch($receipt, $candidates);
         if ($match !== null) {
-            $this->associate($receipt, $match, 'receipt_auto_matched',
-                'Reçu associé automatiquement à un mouvement (règles, sans IA)');
+            $this->associate(
+                $receipt,
+                $match,
+                'receipt_auto_matched',
+                'Reçu associé automatiquement à un mouvement (règles, sans IA)'
+            );
             return;
         }
 

--- a/modules/finance/src/Service/ReceiptService.php
+++ b/modules/finance/src/Service/ReceiptService.php
@@ -159,8 +159,16 @@ class ReceiptService
             throw new FinanceException('Compte introuvable.');
         }
 
-        return $this->store($account, $content, $mimeType, $originalFilename, $suggestedAmount, $suggestedDate,
-            $uploadedBy, $reuseIdentical);
+        return $this->store(
+            $account,
+            $content,
+            $mimeType,
+            $originalFilename,
+            $suggestedAmount,
+            $suggestedDate,
+            $uploadedBy,
+            $reuseIdentical
+        );
     }
 
     /**
@@ -258,7 +266,13 @@ class ReceiptService
         // already perform.
         try {
             $id = $this->attachmentRepository->create(
-                $account?->id, $fileId, $mimeType, $originalFilename, $suggestedAmount, $suggestedDate, null,
+                $account?->id,
+                $fileId,
+                $mimeType,
+                $originalFilename,
+                $suggestedAmount,
+                $suggestedDate,
+                null,
                 $uploadedBy,
                 $suggestedSource,
                 $contentHash
@@ -416,7 +430,14 @@ class ReceiptService
         $transferred = false;
         try {
             $newId = $this->attachmentRepository->create(
-                $old->accountId, $fileId, $mimeType, $originalFilename, null, null, $attachmentId, $uploadedBy
+                $old->accountId,
+                $fileId,
+                $mimeType,
+                $originalFilename,
+                null,
+                null,
+                $attachmentId,
+                $uploadedBy
             );
 
             $this->transactionAttachmentRepository->transferAttachment($attachmentId, $newId);

--- a/modules/finance/src/Service/ReceivableAllocationService.php
+++ b/modules/finance/src/Service/ReceivableAllocationService.php
@@ -330,8 +330,12 @@ class ReceivableAllocationService
         }
 
         if ($existing !== null) {
-            $this->allocationRepository->update($existing->id, $amountCents, ReceivableAllocation::SOURCE_MANUAL,
-                $actorUserAccountId);
+            $this->allocationRepository->update(
+                $existing->id,
+                $amountCents,
+                ReceivableAllocation::SOURCE_MANUAL,
+                $actorUserAccountId
+            );
             return;
         }
 
@@ -408,8 +412,12 @@ class ReceivableAllocationService
 
         $existing = $this->allocationRepository->findPair($transactionId, $receivableId);
         if ($existing !== null) {
-            $this->allocationRepository->update($existing->id, -$amountCents, ReceivableAllocation::SOURCE_MANUAL,
-                $actorUserAccountId);
+            $this->allocationRepository->update(
+                $existing->id,
+                -$amountCents,
+                ReceivableAllocation::SOURCE_MANUAL,
+                $actorUserAccountId
+            );
             return;
         }
 
@@ -805,8 +813,10 @@ class ReceivableAllocationService
         // Same predicate as every other finance page (Service\
         // AccountVisibility): section treasurers are partitioned here as
         // everywhere else, or the partition leaks through this door.
-        if (!$this->accountVisibility->isVisibleTo($this->accountRepository->findById($receivable->accountId),
-            $viewerRole)) {
+        if (!$this->accountVisibility->isVisibleTo(
+            $this->accountRepository->findById($receivable->accountId),
+            $viewerRole
+        )) {
             throw new FinanceException("Cette créance n'existe pas.");
         }
 

--- a/modules/finance/src/Service/ReceivableSearchService.php
+++ b/modules/finance/src/Service/ReceivableSearchService.php
@@ -108,8 +108,11 @@ class ReceivableSearchService
         if ($needle !== '') {
             $rows = array_values(array_filter($rows, static fn(array $row): bool => self::matches($row, $needle)));
         } elseif ($nearAmountCents !== null) {
-            usort($rows, static fn(array $a, array $b): int => abs($a['remaining_cents'] - $nearAmountCents)
-                <=> abs($b['remaining_cents'] - $nearAmountCents));
+            usort(
+                $rows,
+                static fn(array $a, array $b): int => abs($a['remaining_cents'] - $nearAmountCents)
+                    <=> abs($b['remaining_cents'] - $nearAmountCents)
+            );
 
             return array_slice($rows, 0, self::LIMIT);
         }

--- a/modules/finance/src/Service/ReceivablesOverviewService.php
+++ b/modules/finance/src/Service/ReceivablesOverviewService.php
@@ -343,8 +343,11 @@ class ReceivablesOverviewService
 
     private function instanceLabel(string $sourceModule, int $referenceId): string
     {
-        $named = $this->describe($sourceModule, static fn(ReceivableSourceDescriberInterface $d): ?string
-            => $d->describeInstance($referenceId));
+        $named = $this->describe(
+            $sourceModule,
+            static fn(ReceivableSourceDescriberInterface $d): ?string
+                => $d->describeInstance($referenceId)
+        );
 
         if ($named !== null && $named !== '') {
             return $named;
@@ -363,8 +366,11 @@ class ReceivablesOverviewService
      */
     private function sourceLabel(string $sourceModule): string
     {
-        $named = $this->describe($sourceModule, static fn(ReceivableSourceDescriberInterface $d): string
-            => $d->sourceLabel());
+        $named = $this->describe(
+            $sourceModule,
+            static fn(ReceivableSourceDescriberInterface $d): string
+                => $d->sourceLabel()
+        );
 
         return $named !== null && $named !== '' ? $named : ucfirst($sourceModule);
     }

--- a/modules/finance/src/Service/ReconciliationService.php
+++ b/modules/finance/src/Service/ReconciliationService.php
@@ -165,8 +165,15 @@ class ReconciliationService
                 continue;
             }
 
-            $proposal = $this->splitProposal($credit, $remainder, $allocatedReceivableIds, $receivables, $settlements,
-                $householdByMemberId, $identities);
+            $proposal = $this->splitProposal(
+                $credit,
+                $remainder,
+                $allocatedReceivableIds,
+                $receivables,
+                $settlements,
+                $householdByMemberId,
+                $identities
+            );
             if ($proposal !== null) {
                 $split[] = $proposal;
             }
@@ -178,12 +185,24 @@ class ReconciliationService
             if ($settlement === null || $settlement->amountOverpaidCents <= 0) {
                 continue;
             }
-            $overpaid[] = $this->overpaidRow($receivable, $settlement, $identities, $householdByMemberId, $receivables,
-                $settlements);
+            $overpaid[] = $this->overpaidRow(
+                $receivable,
+                $settlement,
+                $identities,
+                $householdByMemberId,
+                $receivables,
+                $settlements
+            );
         }
 
-        $crossAccount = $this->crossAccount($account, $receivables, $settlements, $credits, $allocationsByTransaction,
-            $identities);
+        $crossAccount = $this->crossAccount(
+            $account,
+            $receivables,
+            $settlements,
+            $credits,
+            $allocationsByTransaction,
+            $identities
+        );
 
         return [
             'account' => $account,

--- a/modules/finance/src/Task/ExtractReceiptDataHandler.php
+++ b/modules/finance/src/Task/ExtractReceiptDataHandler.php
@@ -109,8 +109,11 @@ class ExtractReceiptDataHandler implements TaskHandlerInterface
             return;
         }
 
-        $fileStorage = new EncryptedFileStorageService(new FileRepository($pdo), $context->encryption,
-            $context->storagePath);
+        $fileStorage = new EncryptedFileStorageService(
+            new FileRepository($pdo),
+            $context->encryption,
+            $context->storagePath
+        );
 
         try {
             $content = $fileStorage->retrieve($attachment->fileId);
@@ -125,8 +128,11 @@ class ExtractReceiptDataHandler implements TaskHandlerInterface
 
         $parsed = null;
         if ($request === null) {
-            $this->logFailure($context, $attachmentId,
-                "PDF sans texte exploitable et impossible à convertir en image pour l'analyse.");
+            $this->logFailure(
+                $context,
+                $attachmentId,
+                "PDF sans texte exploitable et impossible à convertir en image pour l'analyse."
+            );
         } else {
             try {
                 $parsed = $llmConnector->complete($request)->parsed;
@@ -231,8 +237,11 @@ class ExtractReceiptDataHandler implements TaskHandlerInterface
             return new LlmRequest(
                 tier: LlmTier::CHEAP,
                 prompt: self::PROMPT . $this->filenameHint($originalFilename)
-                    . "\n\nVoici le texte extrait du document :\n\n" . mb_substr($text, 0,
-                        self::MAX_EXTRACTED_TEXT_CHARS),
+                    . "\n\nVoici le texte extrait du document :\n\n" . mb_substr(
+                        $text,
+                        0,
+                        self::MAX_EXTRACTED_TEXT_CHARS
+                    ),
                 responseSchema: self::RESPONSE_SCHEMA
             );
         }

--- a/modules/finance/src/Task/PurgeCampaignFilesHandler.php
+++ b/modules/finance/src/Task/PurgeCampaignFilesHandler.php
@@ -77,8 +77,11 @@ class PurgeCampaignFilesHandler implements TaskHandlerInterface
 
             $campaigns = new CampaignRepository($pdo);
             $rows = new CampaignRowRepository($pdo, $context->encryption);
-            $storage = new EncryptedFileStorageService(new FileRepository($pdo), $context->encryption,
-                $context->storagePath);
+            $storage = new EncryptedFileStorageService(
+                new FileRepository($pdo),
+                $context->encryption,
+                $context->storagePath
+            );
 
             $forgotten = 0;
             foreach ($expiredYears as $scoutYearId) {

--- a/modules/finance/src/Task/PurgeOldMovementsHandler.php
+++ b/modules/finance/src/Task/PurgeOldMovementsHandler.php
@@ -63,8 +63,11 @@ class PurgeOldMovementsHandler implements TaskHandlerInterface
         $attachmentRepository = new AttachmentRepository($pdo, $context->encryption);
         $checkpointRepository = new BalanceCheckpointRepository($pdo);
         $balanceService = new BalanceService($checkpointRepository, $transactionRepository);
-        $fileStorage = new EncryptedFileStorageService(new FileRepository($pdo), $context->encryption,
-            $context->storagePath);
+        $fileStorage = new EncryptedFileStorageService(
+            new FileRepository($pdo),
+            $context->encryption,
+            $context->storagePath
+        );
 
         $retentionYears = (int) $context->settings->get(self::SETTING_KEY, 'finance', '5');
         $cutoffDate = (new \DateTimeImmutable())->modify("-{$retentionYears} years")->format('Y-m-d');
@@ -131,8 +134,12 @@ class PurgeOldMovementsHandler implements TaskHandlerInterface
 
             $checkpointRepository->deleteBeforeOrAt($account->id, $fiscalYear->endDate);
             if ($consolidatedBalance !== null) {
-                $checkpointRepository->create($account->id, $fiscalYear->endDate, $consolidatedBalance,
-                    BalanceCheckpoint::SOURCE_MANUAL);
+                $checkpointRepository->create(
+                    $account->id,
+                    $fiscalYear->endDate,
+                    $consolidatedBalance,
+                    BalanceCheckpoint::SOURCE_MANUAL
+                );
             }
 
             $pdo->commit();

--- a/modules/finance/src/Task/RunCategorizationRulesHandler.php
+++ b/modules/finance/src/Task/RunCategorizationRulesHandler.php
@@ -74,7 +74,9 @@ class RunCategorizationRulesHandler implements TaskHandlerInterface
         );
 
         $bulkCategorizationService = new BulkCategorizationService(
-            $transactionRepository, $ruleEngine, $aiCategorizationService,
+            $transactionRepository,
+            $ruleEngine,
+            $aiCategorizationService,
             new SettingService(new SettingRepository($pdo)),
             new SchedulerService(new SchedulerRepository($pdo))
         );

--- a/modules/gallery/src/Controller/GalleryChiefController.php
+++ b/modules/gallery/src/Controller/GalleryChiefController.php
@@ -88,15 +88,18 @@ class GalleryChiefController extends AbstractController
             ? $this->albumService->findAllForManage()
             : $this->albumService->findForManageByScoutYears($this->recentScoutYearIds());
 
-        $albums = array_map(fn(Album $a) => [
-            'album' => $a,
-            'can_edit' => $this->accessService->canManageAlbum($role, $a->sectionId, $email),
-            // The list used to render a hardcoded "Section spécifique" for
-            // every scoped album, so it never told a chief WHICH section.
-            'section_label' => $a->sectionId !== null
-                ? ($sectionLabels[$a->sectionId] ?? 'Section inconnue')
-                : null,
-        ], $albumRows);
+        $albums = array_map(
+            fn(Album $a) => [
+                'album' => $a,
+                'can_edit' => $this->accessService->canManageAlbum($role, $a->sectionId, $email),
+                // The list used to render a hardcoded "Section spécifique" for
+                // every scoped album, so it never told a chief WHICH section.
+                'section_label' => $a->sectionId !== null
+                    ? ($sectionLabels[$a->sectionId] ?? 'Section inconnue')
+                    : null,
+            ],
+            $albumRows
+        );
 
         $this->storageLocationService->ensureLegacyLocationBackfilled();
 
@@ -550,10 +553,13 @@ class GalleryChiefController extends AbstractController
             'max_media_per_album' => (int) $this->settingService->get('gallery_max_media_per_album', 'gallery', 200),
             'locations' => $locations,
             'default_location_id' => $defaultLocation?->id,
-            'media' => $album !== null ? array_map(fn(Media $m) => [
-                'media' => $m,
-                'thumb_url' => $this->mediaService->resolveUrl($m, $album, 'thumb'),
-            ], $media) : [],
+            'media' => $album !== null ? array_map(
+                fn(Media $m) => [
+                    'media' => $m,
+                    'thumb_url' => $this->mediaService->resolveUrl($m, $album, 'thumb'),
+                ],
+                $media
+            ) : [],
             'csrf_token' => CsrfGuard::generateToken(),
         ];
     }

--- a/modules/gallery/src/Controller/GalleryConfigController.php
+++ b/modules/gallery/src/Controller/GalleryConfigController.php
@@ -135,9 +135,13 @@ class GalleryConfigController extends AbstractController
             // SettingException naming a key. The journal keeps it; the page
             // gets a sentence somebody wrote for it.
             $this->journalService->log(
-                'gallery', 'config_update_failed', 'info', 'Échec de l\'enregistrement de la configuration de la '
+                'gallery',
+                'config_update_failed',
+                'info',
+                'Échec de l\'enregistrement de la configuration de la '
                     . 'galerie',
-                ['error' => $e->getMessage()], (int) AuthSession::getUserAccountId()
+                ['error' => $e->getMessage()],
+                (int) AuthSession::getUserAccountId()
             );
 
             return $this->saveError(UserFacingMessage::from(
@@ -147,8 +151,12 @@ class GalleryConfigController extends AbstractController
         }
 
         $this->journalService->log(
-            'gallery', 'config_updated', 'info', 'Configuration de la galerie modifiée',
-            [], (int) AuthSession::getUserAccountId()
+            'gallery',
+            'config_updated',
+            'info',
+            'Configuration de la galerie modifiée',
+            [],
+            (int) AuthSession::getUserAccountId()
         );
 
         return $this->redirect('/config/gallery');
@@ -228,7 +236,10 @@ class GalleryConfigController extends AbstractController
         // has any use for them. They never reach the page.
         $summary = 'Connexion impossible : ' . $error;
         $this->journalService->log(
-            'gallery', 's3_test_connection_failed', 'info', 'Échec du test de connexion à un stockage S3',
+            'gallery',
+            's3_test_connection_failed',
+            'info',
+            'Échec du test de connexion à un stockage S3',
             ['bucket' => (string) ($data['bucket'] ?? ''), 'sdk_error' => $backend->lastTechnicalError()],
             (int) AuthSession::getUserAccountId()
         );
@@ -303,8 +314,12 @@ class GalleryConfigController extends AbstractController
         $email = AuthSession::getEmail() ?? '';
 
         try {
-            $this->albumService->startMigration((int) $params['id'], (int) ($data['target_location_id'] ?? 0), $role,
-                $email);
+            $this->albumService->startMigration(
+                (int) $params['id'],
+                (int) ($data['target_location_id'] ?? 0),
+                $role,
+                $email
+            );
         } catch (GalleryException $e) {
             return $this->json(['success' => false, 'error' => $e->getMessage()], 422);
         }
@@ -326,8 +341,10 @@ class GalleryConfigController extends AbstractController
             'ffmpeg_available' => $this->ffmpegAvailability->check(),
             'gallery_s3_ai_available' => $this->s3ErrorExplainerService->isAvailable(),
             'locations' => $locations,
-            'local_albums' => array_values(array_filter($this->albumService->findAllForManage(),
-                fn(Album $a) => $a->isLocal())),
+            'local_albums' => array_values(array_filter(
+                $this->albumService->findAllForManage(),
+                fn(Album $a) => $a->isLocal()
+            )),
             // Albums another module owns. Listed HERE and nowhere else in
             // gallery: what they hold and who may see them belong to their
             // owner, but they take real space on a real location and moving
@@ -348,8 +365,10 @@ class GalleryConfigController extends AbstractController
             ),
             'location_album_counts' => array_combine(
                 array_map(fn(StorageLocation $l) => $l->id, $locations),
-                array_map(fn(StorageLocation $l) => $this->storageLocationRepository->countAlbumsUsing($l->id),
-                    $locations)
+                array_map(
+                    fn(StorageLocation $l) => $this->storageLocationRepository->countAlbumsUsing($l->id),
+                    $locations
+                )
             ),
             // Room left on the volume behind each local location. Null for
             // an S3 location and null on a host that will not answer — the
@@ -360,19 +379,37 @@ class GalleryConfigController extends AbstractController
                 array_map(fn(StorageLocation $l) => $this->storageLocationService->diskSpaceFor($l), $locations)
             ),
             'gallery_allow_external' => (bool) $this->settingService->get('gallery_allow_external', 'gallery', true),
-            'gallery_max_media_per_album' => (int) $this->settingService->get('gallery_max_media_per_album', 'gallery',
-                200),
-            'gallery_max_photo_upload_mb' => (int) $this->settingService->get('gallery_max_photo_upload_mb', 'gallery',
-                30),
-            'gallery_photo_max_dimension' => (int) $this->settingService->get('gallery_photo_max_dimension', 'gallery',
-                3000),
+            'gallery_max_media_per_album' => (int) $this->settingService->get(
+                'gallery_max_media_per_album',
+                'gallery',
+                200
+            ),
+            'gallery_max_photo_upload_mb' => (int) $this->settingService->get(
+                'gallery_max_photo_upload_mb',
+                'gallery',
+                30
+            ),
+            'gallery_photo_max_dimension' => (int) $this->settingService->get(
+                'gallery_photo_max_dimension',
+                'gallery',
+                3000
+            ),
             'gallery_allow_video' => (bool) $this->settingService->get('gallery_allow_video', 'gallery', true),
-            'gallery_max_video_upload_mb' => (int) $this->settingService->get('gallery_max_video_upload_mb', 'gallery',
-                2048),
-            'gallery_max_video_duration_sec' => (int) $this->settingService->get('gallery_max_video_duration_sec',
-                'gallery', 1800),
-            'gallery_keep_original_video' => (bool) $this->settingService->get('gallery_keep_original_video', 'gallery',
-                false),
+            'gallery_max_video_upload_mb' => (int) $this->settingService->get(
+                'gallery_max_video_upload_mb',
+                'gallery',
+                2048
+            ),
+            'gallery_max_video_duration_sec' => (int) $this->settingService->get(
+                'gallery_max_video_duration_sec',
+                'gallery',
+                1800
+            ),
+            'gallery_keep_original_video' => (bool) $this->settingService->get(
+                'gallery_keep_original_video',
+                'gallery',
+                false
+            ),
             'csrf_token' => CsrfGuard::generateToken(),
         ];
     }

--- a/modules/gallery/src/Controller/GalleryController.php
+++ b/modules/gallery/src/Controller/GalleryController.php
@@ -146,8 +146,10 @@ class GalleryController extends AbstractController
             'album' => $album,
             'breadcrumb_current' => $album->title,
             'media' => $media,
-            'has_downloadable_media' => !$unavailable && count(array_filter($mediaRows,
-                fn(Media $m) => $m->processingStatus === Media::STATUS_DONE)) > 0,
+            'has_downloadable_media' => !$unavailable && count(array_filter(
+                $mediaRows,
+                fn(Media $m) => $m->processingStatus === Media::STATUS_DONE
+            )) > 0,
             'storage_unavailable' => $unavailable,
             'storage_unavailable_reason' => $unavailableReason,
         ]);
@@ -308,8 +310,12 @@ class GalleryController extends AbstractController
         if ($album->isDelegated()) {
             \assert($album->ownerType !== null && $album->ownerId !== null);
             $role = Role::fromString(AuthSession::getRole());
-            if (!$this->delegatedAlbumAccessRegistry->isAllowed($album->ownerType, $album->ownerId, $role,
-                $this->linkedMemberIds)) {
+            if (!$this->delegatedAlbumAccessRegistry->isAllowed(
+                $album->ownerType,
+                $album->ownerId,
+                $role,
+                $this->linkedMemberIds
+            )) {
                 return new Response('Not Found', 404);
             }
         } elseif (!$this->isVisible($album)) {
@@ -584,8 +590,12 @@ class GalleryController extends AbstractController
         \assert($album->ownerType !== null && $album->ownerId !== null);
 
         $role = Role::fromString(AuthSession::getRole());
-        if (!$this->delegatedAlbumAccessRegistry->isAllowed($album->ownerType, $album->ownerId, $role,
-            $this->linkedMemberIds)) {
+        if (!$this->delegatedAlbumAccessRegistry->isAllowed(
+            $album->ownerType,
+            $album->ownerId,
+            $role,
+            $this->linkedMemberIds
+        )) {
             return new Response('Not Found', 404);
         }
 

--- a/modules/gallery/src/Controller/GalleryStorageLocationController.php
+++ b/modules/gallery/src/Controller/GalleryStorageLocationController.php
@@ -89,7 +89,13 @@ class GalleryStorageLocationController extends AbstractController
                     StorageLocation::TYPE_LOCAL,
                     $label,
                     $this->normalizeSubdir($request->getBody('subdir')),
-                    null, null, null, null, null, null, null
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
                 );
             }
         } catch (GalleryException $e) {
@@ -104,8 +110,12 @@ class GalleryStorageLocationController extends AbstractController
         }
 
         $this->journalService->log(
-            'gallery', 'storage_location_created', 'info', "Emplacement de stockage « {$label} » créé",
-            [], (int) AuthSession::getUserAccountId()
+            'gallery',
+            'storage_location_created',
+            'info',
+            "Emplacement de stockage « {$label} » créé",
+            [],
+            (int) AuthSession::getUserAccountId()
         );
 
         return $this->redirect('/config/gallery');
@@ -176,8 +186,16 @@ class GalleryStorageLocationController extends AbstractController
                 );
             } else {
                 $this->storageLocationRepository->update(
-                    $location->id, $label, $this->normalizeSubdir($request->getBody('subdir')),
-                    null, null, null, null, null, null, null
+                    $location->id,
+                    $label,
+                    $this->normalizeSubdir($request->getBody('subdir')),
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
                 );
             }
         } catch (GalleryException $e) {
@@ -192,8 +210,12 @@ class GalleryStorageLocationController extends AbstractController
         }
 
         $this->journalService->log(
-            'gallery', 'storage_location_updated', 'info', "Emplacement de stockage « {$label} » modifié",
-            [], (int) AuthSession::getUserAccountId()
+            'gallery',
+            'storage_location_updated',
+            'info',
+            "Emplacement de stockage « {$label} » modifié",
+            [],
+            (int) AuthSession::getUserAccountId()
         );
 
         return $this->redirect('/config/gallery');
@@ -224,8 +246,12 @@ class GalleryStorageLocationController extends AbstractController
         }
 
         $this->journalService->log(
-            'gallery', 'storage_location_deleted', 'info', "Emplacement de stockage « {$location->label} » supprimé",
-            [], (int) AuthSession::getUserAccountId()
+            'gallery',
+            'storage_location_deleted',
+            'info',
+            "Emplacement de stockage « {$location->label} » supprimé",
+            [],
+            (int) AuthSession::getUserAccountId()
         );
 
         return $this->json(['success' => true]);
@@ -252,9 +278,13 @@ class GalleryStorageLocationController extends AbstractController
         $this->storageLocationRepository->setDefault($location->id);
 
         $this->journalService->log(
-            'gallery', 'storage_location_default_changed', 'info', "Emplacement de stockage « {$location->label} » "
+            'gallery',
+            'storage_location_default_changed',
+            'info',
+            "Emplacement de stockage « {$location->label} » "
                 . "défini par défaut",
-            [], (int) AuthSession::getUserAccountId()
+            [],
+            (int) AuthSession::getUserAccountId()
         );
 
         return $this->json(['success' => true]);

--- a/modules/gallery/src/Service/AlbumService.php
+++ b/modules/gallery/src/Service/AlbumService.php
@@ -180,8 +180,17 @@ class AlbumService
         $this->assertValidLength($title, self::MAX_TITLE_LENGTH, 'Le titre');
 
         $scoutYearId = $this->resolveScoutYearId($albumDate, $effectiveScoutYearId);
-        $id = $this->albumRepository->create($type, $title, $subtitle, $albumDate, $sectionId, $scoutYearId,
-            $externalUrl, $storageLocationId, $createdBy);
+        $id = $this->albumRepository->create(
+            $type,
+            $title,
+            $subtitle,
+            $albumDate,
+            $sectionId,
+            $scoutYearId,
+            $externalUrl,
+            $storageLocationId,
+            $createdBy
+        );
 
         if ($ogTags !== null) {
             $ogImageFileId = $this->cacheOgImage($id, $ogTags['image'], $createdBy);
@@ -485,8 +494,13 @@ class AlbumService
         }
 
         $this->albumRepository->startMigration($albumId, $target->id);
-        $this->schedulerService->scheduleAfter('gallery', 'migrate_album_storage', 0, ['album_id' => $albumId],
-            'album_migration_' . $albumId);
+        $this->schedulerService->scheduleAfter(
+            'gallery',
+            'migrate_album_storage',
+            0,
+            ['album_id' => $albumId],
+            'album_migration_' . $albumId
+        );
     }
 
     /**
@@ -534,8 +548,12 @@ class AlbumService
             file_put_contents($tmpPath, $bytes);
             return $this->uploadHandler->handle(
                 ['tmp_name' => $tmpPath, 'size' => strlen($bytes), 'error' => UPLOAD_ERR_OK, 'name' => 'og_image'],
-                "gallery/{$albumId}/og", self::OG_IMAGE_ALLOWED_MIMES, self::OG_IMAGE_MAX_BYTES, 'identified',
-                'gallery', $createdBy
+                "gallery/{$albumId}/og",
+                self::OG_IMAGE_ALLOWED_MIMES,
+                self::OG_IMAGE_MAX_BYTES,
+                'identified',
+                'gallery',
+                $createdBy
             );
         } catch (UploadException) {
             // Best-effort — an unsupported/oversized image just leaves the

--- a/modules/gallery/src/Service/DelegatedAlbumService.php
+++ b/modules/gallery/src/Service/DelegatedAlbumService.php
@@ -87,8 +87,17 @@ class DelegatedAlbumService implements DelegatedAlbumManager
 
         try {
             $albumId = $this->albumRepository->create(
-                Album::TYPE_LOCAL, $title, null, $albumDate, null, $scoutYearId, null, $location->id, $createdBy,
-                $ownerType, $ownerId
+                Album::TYPE_LOCAL,
+                $title,
+                null,
+                $albumDate,
+                null,
+                $scoutYearId,
+                null,
+                $location->id,
+                $createdBy,
+                $ownerType,
+                $ownerId
             );
         } catch (\PDOException $e) {
             // Two callers racing to create the first album for the same

--- a/modules/gallery/src/Service/GalleryMemberQueryService.php
+++ b/modules/gallery/src/Service/GalleryMemberQueryService.php
@@ -47,13 +47,16 @@ class GalleryMemberQueryService implements GalleryAlbumProvider
             $limit
         );
 
-        return array_map(fn(Album $album) => [
-            'id' => $album->id,
-            'title' => $album->displayTitle(),
-            'album_date' => $album->albumDate,
-            'cover_url' => $this->coverUrl($album),
-            'url' => $album->isLocal() ? '/gallery/' . $album->id : (string) $album->externalUrl,
-        ], $albums);
+        return array_map(
+            fn(Album $album) => [
+                'id' => $album->id,
+                'title' => $album->displayTitle(),
+                'album_date' => $album->albumDate,
+                'cover_url' => $this->coverUrl($album),
+                'url' => $album->isLocal() ? '/gallery/' . $album->id : (string) $album->externalUrl,
+            ],
+            $albums
+        );
     }
 
     private function coverUrl(Album $album): ?string

--- a/modules/gallery/src/Service/MediaService.php
+++ b/modules/gallery/src/Service/MediaService.php
@@ -152,9 +152,15 @@ class MediaService
             // the exact same ownership check as /gallery/media/{id}/{size},
             // instead of stopping at the flat 'identified' floor below.
             $fileId = $this->uploadHandler->handle(
-                $uploadedFile, "gallery/{$album->id}/orig", $allowedMimes, $maxBytes, 'identified', 'gallery',
+                $uploadedFile,
+                "gallery/{$album->id}/orig",
+                $allowedMimes,
+                $maxBytes,
+                'identified',
+                'gallery',
                 $accountId,
-                $album->ownerType, $album->ownerId
+                $album->ownerType,
+                $album->ownerId
             );
         } catch (UploadException $e) {
             // Core\File\UploadException is a Core\Exception\UserFacingException
@@ -177,7 +183,11 @@ class MediaService
         $sortOrder = $this->mediaRepository->nextSortOrder($album->id);
         $originalFilename = isset($uploadedFile['name']) ? (string) $uploadedFile['name'] : null;
         $mediaId = $this->mediaRepository->create(
-            $album->id, $isVideo ? Media::TYPE_VIDEO : Media::TYPE_PHOTO, $fileId, $sortOrder, $originalFilename
+            $album->id,
+            $isVideo ? Media::TYPE_VIDEO : Media::TYPE_PHOTO,
+            $fileId,
+            $sortOrder,
+            $originalFilename
         );
 
         // First upload becomes the album cover automatically (module spec:

--- a/modules/gallery/src/Service/StorageLocationService.php
+++ b/modules/gallery/src/Service/StorageLocationService.php
@@ -169,13 +169,19 @@ class StorageLocationService
             $subdir = $location->subdir !== null && $location->subdir !== '' ? $location->subdir : 'gallery';
             $dir = $this->localStoragePath($subdir);
             if (!is_dir($dir) && !@mkdir($dir, 0755, true)) {
-                $this->storageLocationRepository->recordCheckResult($location->id, false,
-                    "Le dossier de stockage local ({$dir}) n'existe pas et n'a pas pu être créé.");
+                $this->storageLocationRepository->recordCheckResult(
+                    $location->id,
+                    false,
+                    "Le dossier de stockage local ({$dir}) n'existe pas et n'a pas pu être créé."
+                );
                 return;
             }
             if (!is_writable($dir)) {
-                $this->storageLocationRepository->recordCheckResult($location->id, false,
-                    "Le dossier de stockage local ({$dir}) n'est pas accessible en écriture.");
+                $this->storageLocationRepository->recordCheckResult(
+                    $location->id,
+                    false,
+                    "Le dossier de stockage local ({$dir}) n'est pas accessible en écriture."
+                );
                 return;
             }
             $this->storageLocationRepository->recordCheckResult($location->id, true, null);

--- a/modules/gallery/src/Task/MigrateAlbumStorageHandler.php
+++ b/modules/gallery/src/Task/MigrateAlbumStorageHandler.php
@@ -64,8 +64,10 @@ class MigrateAlbumStorageHandler implements TaskHandlerInterface
         $albumRepository = new AlbumRepository($pdo);
         $mediaRepository = new MediaRepository($pdo);
         $storageLocationRepository = new StorageLocationRepository($pdo, $context->encryption);
-        $storageBackendFactory = $this->storageBackendFactory ?? new StorageBackendFactory($storageLocationRepository,
-            $context->storagePath);
+        $storageBackendFactory = $this->storageBackendFactory ?? new StorageBackendFactory(
+            $storageLocationRepository,
+            $context->storagePath
+        );
 
         $album = $albumRepository->findById($albumId);
         if (
@@ -134,7 +136,9 @@ class MigrateAlbumStorageHandler implements TaskHandlerInterface
         $albumRepository->completeMigration($albumId, $targetLocation->id);
 
         $context->journal->log(
-            'gallery', 'album_storage_migrated', 'info',
+            'gallery',
+            'album_storage_migrated',
+            'info',
             "Album #{$albumId} migré de « {$sourceLocation->label} » vers « {$targetLocation->label} »",
             ['album_id' => $albumId, 'from_location_id' => $sourceLocation->id, 'to_location_id' => $targetLocation->id]
         );

--- a/modules/gallery/src/Task/ProcessPhotoHandler.php
+++ b/modules/gallery/src/Task/ProcessPhotoHandler.php
@@ -51,13 +51,21 @@ class ProcessPhotoHandler implements TaskHandlerInterface
         // Never write renditions into a location a migration is in the middle
         // of moving away from — see Task\MediaProcessingGate.
         if ($album !== null && $album->isMigrating()) {
-            if ((new MediaProcessingGate())->deferWhileMigrating('process_photo', $mediaId, $album->id, $payload,
-                $context)) {
+            if ((new MediaProcessingGate())->deferWhileMigrating(
+                'process_photo',
+                $mediaId,
+                $album->id,
+                $payload,
+                $context
+            )) {
                 return;
             }
             $mediaRepository->markFailed($mediaId);
             $context->journal->log(
-                'gallery', 'photo_processing_failed', 'info', 'Échec du traitement d\'une photo',
+                'gallery',
+                'photo_processing_failed',
+                'info',
+                'Échec du traitement d\'une photo',
                 ['media_id' => $mediaId, 'album_id' => $media->albumId, 'error' => 'Migration de stockage toujours en '
                     . 'cours.']
             );
@@ -87,7 +95,10 @@ class ProcessPhotoHandler implements TaskHandlerInterface
             $storageLocationRepository = new StorageLocationRepository($pdo, $context->encryption);
             $storageBackendFactory = new StorageBackendFactory($storageLocationRepository, $context->storagePath);
             $storageLocationService = $this->storageLocationService(
-                $context, $storageLocationRepository, $albumRepository, $storageBackendFactory
+                $context,
+                $storageLocationRepository,
+                $albumRepository,
+                $storageBackendFactory
             );
             $location = $storageLocationService->resolveLocationForAlbum($album);
             if ($location === null) {
@@ -102,8 +113,14 @@ class ProcessPhotoHandler implements TaskHandlerInterface
             $storage->put($mediumKey, $result['medium'], 'image/jpeg');
             $storage->put($largeKey, $result['large'], 'image/jpeg');
 
-            $mediaRepository->markPhotoDone($mediaId, $thumbKey, $mediumKey, $largeKey, $result['width'],
-                $result['height']);
+            $mediaRepository->markPhotoDone(
+                $mediaId,
+                $thumbKey,
+                $mediumKey,
+                $largeKey,
+                $result['width'],
+                $result['height']
+            );
 
             // Disk savings (module spec) — the derived sizes above are the
             // only ones ever served for a photo; the files-table metadata
@@ -113,7 +130,10 @@ class ProcessPhotoHandler implements TaskHandlerInterface
         } catch (\Throwable $e) {
             $mediaRepository->markFailed($mediaId);
             $context->journal->log(
-                'gallery', 'photo_processing_failed', 'info', 'Échec du traitement d\'une photo',
+                'gallery',
+                'photo_processing_failed',
+                'info',
+                'Échec du traitement d\'une photo',
                 ['media_id' => $mediaId, 'album_id' => $media->albumId, 'error' => $e->getMessage()]
             );
         }

--- a/modules/gallery/src/Task/ProcessVideoHandler.php
+++ b/modules/gallery/src/Task/ProcessVideoHandler.php
@@ -53,13 +53,21 @@ class ProcessVideoHandler implements TaskHandlerInterface
         // Never write renditions into a location a migration is in the middle
         // of moving away from — see Task\MediaProcessingGate.
         if ($album !== null && $album->isMigrating()) {
-            if ((new MediaProcessingGate())->deferWhileMigrating('process_video', $mediaId, $album->id, $payload,
-                $context)) {
+            if ((new MediaProcessingGate())->deferWhileMigrating(
+                'process_video',
+                $mediaId,
+                $album->id,
+                $payload,
+                $context
+            )) {
                 return;
             }
             $mediaRepository->markFailed($mediaId);
             $context->journal->log(
-                'gallery', 'video_processing_failed', 'info', 'Échec du traitement d\'une vidéo',
+                'gallery',
+                'video_processing_failed',
+                'info',
+                'Échec du traitement d\'une vidéo',
                 ['media_id' => $mediaId, 'album_id' => $media->albumId, 'error' => 'Migration de stockage toujours en '
                     . 'cours.']
             );
@@ -144,9 +152,16 @@ class ProcessVideoHandler implements TaskHandlerInterface
             }
 
             $mediaRepository->markVideoDone(
-                $mediaId, $thumbKey, $mediumKey, $largeKey, $originalKey, $probe[
+                $mediaId,
+                $thumbKey,
+                $mediumKey,
+                $largeKey,
+                $originalKey,
+                $probe[
                     'width'
-                ], $probe['height'], $probe['durationSeconds']
+                ],
+                $probe['height'],
+                $probe['durationSeconds']
             );
 
             // Module spec: drop the staging original's bytes once processed,
@@ -157,7 +172,10 @@ class ProcessVideoHandler implements TaskHandlerInterface
         } catch (\Throwable $e) {
             $mediaRepository->markFailed($mediaId);
             $context->journal->log(
-                'gallery', 'video_processing_failed', 'info', 'Échec du traitement d\'une vidéo',
+                'gallery',
+                'video_processing_failed',
+                'info',
+                'Échec du traitement d\'une vidéo',
                 ['media_id' => $mediaId, 'album_id' => $media->albumId, 'error' => $e->getMessage()]
             );
         } finally {

--- a/modules/groups/src/Controller/GroupController.php
+++ b/modules/groups/src/Controller/GroupController.php
@@ -729,8 +729,10 @@ class GroupController extends AbstractController
             GroupSessionContext $context
         ): Response {
             $this->membershipService?->close($group, $context->userAccountId);
-            FlashMessage::set('success',
-                'Le groupe est clôturé : il reste consultable, mais n\'accepte plus de nouvelle publication.');
+            FlashMessage::set(
+                'success',
+                'Le groupe est clôturé : il reste consultable, mais n\'accepte plus de nouvelle publication.'
+            );
 
             return $this->redirect('/groups/' . $group->id);
         });

--- a/modules/groups/src/Controller/GroupMemberController.php
+++ b/modules/groups/src/Controller/GroupMemberController.php
@@ -180,10 +180,13 @@ class GroupMemberController extends AbstractController
         $shown = array_slice($matches, 0, 10);
         $accountLabels = $this->accountLabels($shown, $scoutYearId);
 
-        return $this->json(array_map(fn(MemberProfile $p) => [
-            'id' => $p->memberId,
-            'label' => $this->searchLabel($p, $accountLabels[$p->memberId] ?? ''),
-        ], $shown));
+        return $this->json(array_map(
+            fn(MemberProfile $p) => [
+                'id' => $p->memberId,
+                'label' => $this->searchLabel($p, $accountLabels[$p->memberId] ?? ''),
+            ],
+            $shown
+        ));
     }
 
     /**
@@ -274,8 +277,11 @@ class GroupMemberController extends AbstractController
                 // group must keep a moderator of its own, and revoking the
                 // last one is refused rather than performed.
                 if (!$done) {
-                    FlashMessage::set('error', 'Ce compte est le dernier modérateur de ce groupe : désignez '
-                        . 'd\'abord un autre modérateur avant de lui retirer la modération.');
+                    FlashMessage::set(
+                        'error',
+                        'Ce compte est le dernier modérateur de ce groupe : désignez '
+                            . 'd\'abord un autre modérateur avant de lui retirer la modération.'
+                    );
                 }
             }
 
@@ -290,18 +296,25 @@ class GroupMemberController extends AbstractController
      */
     public function removeMember(Request $request, array $params): Response
     {
-        return $this->moderatorAction($request, $params, function (DiscussionGroup $group) use ($request) {
-            $memberId = (int) $request->getBody('member_id', 0);
-            if ($memberId > 0 && !$this->groupService->removeMember($group, $memberId)) {
-                // Same protection as a voluntary departure: the last
-                // moderator cannot be removed either, or the group would
-                // be left with nobody of its own in charge.
-                FlashMessage::set('error', 'Ce membre est le dernier modérateur de ce groupe : désignez '
-                    . 'd\'abord un autre modérateur avant de le retirer.');
+        return $this->moderatorAction(
+            $request,
+            $params,
+            function (DiscussionGroup $group) use ($request) {
+                $memberId = (int) $request->getBody('member_id', 0);
+                if ($memberId > 0 && !$this->groupService->removeMember($group, $memberId)) {
+                    // Same protection as a voluntary departure: the last
+                    // moderator cannot be removed either, or the group would
+                    // be left with nobody of its own in charge.
+                    FlashMessage::set(
+                        'error',
+                        'Ce membre est le dernier modérateur de ce groupe : désignez '
+                            . 'd\'abord un autre modérateur avant de le retirer.'
+                    );
+                }
+    
+                return $this->redirect('/groups/' . $group->id . '/members');
             }
-
-            return $this->redirect('/groups/' . $group->id . '/members');
-        });
+        );
     }
 
     /**
@@ -454,10 +467,13 @@ class GroupMemberController extends AbstractController
                     // Labelled here rather than in the template so the
                     // plain dropdown and the search box that replaces it
                     // can never word the same person differently.
-                    'members' => array_map(fn(MemberProfile $p) => [
-                        'id' => $p->memberId,
-                        'label' => $this->searchLabel($p, $accountLabels[$p->memberId] ?? ''),
-                    ], $candidates),
+                    'members' => array_map(
+                        fn(MemberProfile $p) => [
+                            'id' => $p->memberId,
+                            'label' => $this->searchLabel($p, $accountLabels[$p->memberId] ?? ''),
+                        ],
+                        $candidates
+                    ),
                 ];
             }
         }

--- a/modules/groups/src/Controller/PostController.php
+++ b/modules/groups/src/Controller/PostController.php
@@ -469,8 +469,14 @@ class PostController extends AbstractController
 
                 $edited = $this->postRepository->findById($post->id);
                 if ($edited !== null) {
-                    $this->notifyMentions($group, $edited->id, $edited->body, $edited->isHidden(), $context,
-                        $alreadyMentioned);
+                    $this->notifyMentions(
+                        $group,
+                        $edited->id,
+                        $edited->body,
+                        $edited->isHidden(),
+                        $context,
+                        $alreadyMentioned
+                    );
                 }
             }
 

--- a/modules/groups/src/Controller/ReactionController.php
+++ b/modules/groups/src/Controller/ReactionController.php
@@ -213,8 +213,10 @@ class ReactionController extends AbstractController
                 return null;
             }
 
-            return $this->reactorListService?->forReply($reply->id,
-                $group->scoutYearId ?? $context->effectiveScoutYearId) ?? [];
+            return $this->reactorListService?->forReply(
+                $reply->id,
+                $group->scoutYearId ?? $context->effectiveScoutYearId
+            ) ?? [];
         });
     }
 

--- a/modules/groups/src/Controller/ReplyController.php
+++ b/modules/groups/src/Controller/ReplyController.php
@@ -199,8 +199,14 @@ class ReplyController extends AbstractController
         }
 
         try {
-            $replyId = $this->replyService->create($group, $post->id, $context->userAccountId, $authorMemberId, $body,
-                $mediaId);
+            $replyId = $this->replyService->create(
+                $group,
+                $post->id,
+                $context->userAccountId,
+                $authorMemberId,
+                $body,
+                $mediaId
+            );
         } catch (GroupsException $e) {
             // The image was uploaded before the reply row existed, so a
             // refusal here has to take it back out again — otherwise a

--- a/modules/groups/src/Controller/ReportController.php
+++ b/modules/groups/src/Controller/ReportController.php
@@ -342,9 +342,12 @@ class ReportController extends AbstractController
      */
     private function hideAction(Request $request, array $params, string $idKey, callable $hide): Response
     {
-        if (($guard = $this->guardCsrf($request, $request->getBody('return_to') === 'reports'
-            ? '/groups/' . (int) ($params['id'] ?? 0) . '/reports'
-            : '/groups/' . (int) ($params['id'] ?? 0))) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            $request->getBody('return_to') === 'reports'
+                ? '/groups/' . (int) ($params['id'] ?? 0) . '/reports'
+                : '/groups/' . (int) ($params['id'] ?? 0)
+        )) !== null) {
             return $guard;
         }
 

--- a/modules/groups/src/Service/GroupNotificationService.php
+++ b/modules/groups/src/Service/GroupNotificationService.php
@@ -116,8 +116,12 @@ class GroupNotificationService
 
         $this->send(
             self::TYPE_REPLY_RECEIVED,
-            fn(): array => $this->recipientsForAuthorOf($post, $group, $reply->authorUserAccountId,
-                $effectiveScoutYearId),
+            fn(): array => $this->recipientsForAuthorOf(
+                $post,
+                $group,
+                $reply->authorUserAccountId,
+                $effectiveScoutYearId
+            ),
             [
                 'title' => 'Réponse à votre message — ' . $group->name,
                 // The REPLY's text, and only if the reply itself is
@@ -281,8 +285,10 @@ class GroupNotificationService
         ?int $reporterAccountId,
         ?ReportedAuthor $author = null
     ): void {
-        $escalated = $author !== null && $this->recipientResolver->isExplicitModeratorAccount($group,
-            $author->userAccountId);
+        $escalated = $author !== null && $this->recipientResolver->isExplicitModeratorAccount(
+            $group,
+            $author->userAccountId
+        );
 
         $this->send(
             self::TYPE_ITEM_REPORTED,

--- a/modules/groups/src/Service/PostService.php
+++ b/modules/groups/src/Service/PostService.php
@@ -59,8 +59,13 @@ class PostService
         $this->assertAcceptable($body);
 
         $now = Timestamps::now();
-        $postId = $this->postRepository->create($group->id, $userAccountId, $authorMemberId, $this->normalize($body),
-            $now);
+        $postId = $this->postRepository->create(
+            $group->id,
+            $userAccountId,
+            $authorMemberId,
+            $this->normalize($body),
+            $now
+        );
         $this->activityService->bump($group->id, $postId, $now);
 
         return $postId;

--- a/modules/groups/src/Service/ReportService.php
+++ b/modules/groups/src/Service/ReportService.php
@@ -67,8 +67,11 @@ class ReportService
         ], $actorAccountId);
 
         $post = $this->postRepository->findById($postId);
-        if ($post !== null && $this->shouldHide($post->hiddenAt, $post->moderationCleared,
-            $this->postReports->countFor($postId))) {
+        if ($post !== null && $this->shouldHide(
+            $post->hiddenAt,
+            $post->moderationCleared,
+            $this->postReports->countFor($postId)
+        )) {
             $this->postRepository->setHiddenAt($postId, Timestamps::now());
             $this->journal('group_post_auto_hidden', 'Message de groupe masqué automatiquement', [
                 'group_id' => $groupId,
@@ -95,8 +98,11 @@ class ReportService
         ], $actorAccountId);
 
         $reply = $this->replyRepository->findById($replyId);
-        if ($reply !== null && $this->shouldHide($reply->hiddenAt, $reply->moderationCleared,
-            $this->replyReports->countFor($replyId))) {
+        if ($reply !== null && $this->shouldHide(
+            $reply->hiddenAt,
+            $reply->moderationCleared,
+            $this->replyReports->countFor($replyId)
+        )) {
             $this->replyRepository->setHiddenAt($replyId, Timestamps::now());
             $this->journal('group_reply_auto_hidden', 'Réponse de groupe masquée automatiquement', [
                 'group_id' => $groupId,

--- a/modules/inbound_mail/src/Controller/InboundMailConfigController.php
+++ b/modules/inbound_mail/src/Controller/InboundMailConfigController.php
@@ -326,8 +326,17 @@ class InboundMailConfigController extends AbstractController
         }
 
         if ($id > 0) {
-            $this->adminService->update($id, $name, $host, $port, $encryption, $username, $password, $folders,
-                $isEnabled);
+            $this->adminService->update(
+                $id,
+                $name,
+                $host,
+                $port,
+                $encryption,
+                $username,
+                $password,
+                $folders,
+                $isEnabled
+            );
             $this->journalService->log(
                 'inbound_mail',
                 'inbound_mailbox_updated',
@@ -346,8 +355,16 @@ class InboundMailConfigController extends AbstractController
             return $this->redirect('/config/courrier-entrant');
         }
 
-        $newId = $this->adminService->create($name, $host, $port, $encryption, $username, $password, $folders,
-            $isEnabled);
+        $newId = $this->adminService->create(
+            $name,
+            $host,
+            $port,
+            $encryption,
+            $username,
+            $password,
+            $folders,
+            $isEnabled
+        );
         $this->journalService->log(
             'inbound_mail',
             'inbound_mailbox_created',

--- a/modules/inbound_mail/src/Repository/InboundMessageRepository.php
+++ b/modules/inbound_mail/src/Repository/InboundMessageRepository.php
@@ -2029,10 +2029,13 @@ class InboundMessageRepository
     ): InboundMessage {
         $toEmails = [];
         if ($row['to_emails_encrypted'] !== null) {
-            $toEmails = array_values(array_filter(explode(
-                "\n",
-                $this->encryption->decrypt((string) $row['to_emails_encrypted'], 'inbound_messages.to_emails')
-            ), static fn(string $email) => $email !== ''));
+            $toEmails = array_values(array_filter(
+                explode(
+                    "\n",
+                    $this->encryption->decrypt((string) $row['to_emails_encrypted'], 'inbound_messages.to_emails')
+                ),
+                static fn(string $email) => $email !== ''
+            ));
         }
 
         return new InboundMessage(

--- a/modules/inbound_mail/src/Service/GeneralMailboxService.php
+++ b/modules/inbound_mail/src/Service/GeneralMailboxService.php
@@ -258,13 +258,16 @@ class GeneralMailboxService
             // did not, so a consumer that files something « only ever by a
             // person » (Finance's receipts) saw nobody and took the
             // unattended route on every confirmation made here.
-            $consumer->onLinked($message, new \Modules\InboundMail\Api\MessageLink(
-                $candidate->consumerId,
-                $candidate->businessReference,
-                LinkOrigin::MANUAL,
-                $candidate->attachmentId,
-                $userAccountId
-            ));
+            $consumer->onLinked(
+                $message,
+                new \Modules\InboundMail\Api\MessageLink(
+                    $candidate->consumerId,
+                    $candidate->businessReference,
+                    LinkOrigin::MANUAL,
+                    $candidate->attachmentId,
+                    $userAccountId
+                )
+            );
         } catch (\Throwable) {
             // The association is already written. One module's bookkeeping
             // throwing must not undo a decision a person just made, nor

--- a/modules/inbound_mail/src/Service/InboundMailService.php
+++ b/modules/inbound_mail/src/Service/InboundMailService.php
@@ -133,13 +133,16 @@ class InboundMailService implements InboundMailInterface
 
         $stored = $this->messageRepository->findOneForReference($consumerId, $businessReference, $messageId);
         if ($stored !== null) {
-            $this->notifyLinked($stored, new MessageLink(
-                $consumerId,
-                $businessReference,
-                LinkOrigin::MANUAL,
-                0,
-                $userAccountId
-            ));
+            $this->notifyLinked(
+                $stored,
+                new MessageLink(
+                    $consumerId,
+                    $businessReference,
+                    LinkOrigin::MANUAL,
+                    0,
+                    $userAccountId
+                )
+            );
         }
 
         return true;
@@ -257,13 +260,16 @@ class InboundMailService implements InboundMailInterface
             // The author travels with the link. Finance files a receipt
             // « only ever by a person », and the person was being dropped
             // right here — the row named them, the callback did not.
-            $this->notifyLinked($stored, new MessageLink(
-                $consumerId,
-                $candidate->businessReference,
-                LinkOrigin::MANUAL,
-                $candidate->attachmentId,
-                $userAccountId
-            ));
+            $this->notifyLinked(
+                $stored,
+                new MessageLink(
+                    $consumerId,
+                    $candidate->businessReference,
+                    LinkOrigin::MANUAL,
+                    $candidate->attachmentId,
+                    $userAccountId
+                )
+            );
         }
 
         return true;

--- a/modules/inbound_mail/src/Service/MailboxScopeService.php
+++ b/modules/inbound_mail/src/Service/MailboxScopeService.php
@@ -129,11 +129,14 @@ class MailboxScopeService
             $id = $consumer->consumerId();
             $answer = $answers[$id] ?? ['analyze' => false, 'read' => ReadMode::NONE->value];
 
-            $this->mailboxRepository->saveScope($mailboxId, new MailboxScope(
-                $id,
-                $answer['analyze'],
-                ReadMode::fromString($answer['read'])
-            ));
+            $this->mailboxRepository->saveScope(
+                $mailboxId,
+                new MailboxScope(
+                    $id,
+                    $answer['analyze'],
+                    ReadMode::fromString($answer['read'])
+                )
+            );
         }
     }
 

--- a/modules/inbound_mail/src/Service/MailboxSyncService.php
+++ b/modules/inbound_mail/src/Service/MailboxSyncService.php
@@ -293,8 +293,11 @@ class MailboxSyncService
                 => isset($results[$consumer->consumerId()])
         ));
         $keepBody = self::anyWants($claimants, static fn(MessageRetentionPreference $p): bool => $p->wantsBody(), true);
-        $keepHeaders = self::anyWants($claimants,
-            static fn(MessageRetentionPreference $p): bool => $p->wantsRawHeaders(), false);
+        $keepHeaders = self::anyWants(
+            $claimants,
+            static fn(MessageRetentionPreference $p): bool => $p->wantsRawHeaders(),
+            false
+        );
 
         $storedId = $this->messageRepository->create(
             mailboxId: $mailbox->id,

--- a/modules/leadership/src/Controller/LeadershipController.php
+++ b/modules/leadership/src/Controller/LeadershipController.php
@@ -83,12 +83,18 @@ class LeadershipController extends AbstractController
             $context['today']
         );
 
-        return $this->render('@leadership/index.html.twig', $this->withFooter($context, [
-            'training_count' => count($toConvince) + count($toFinish),
-            'obligations_count' => count($birthdays) + count($candidates),
-            'stewards_count' => count($stewards),
-            'summer_regime' => $this->stewardService->isSummerRegime($context['today']),
-        ]));
+        return $this->render(
+            '@leadership/index.html.twig',
+            $this->withFooter(
+                $context,
+                [
+                    'training_count' => count($toConvince) + count($toFinish),
+                    'obligations_count' => count($birthdays) + count($candidates),
+                    'stewards_count' => count($stewards),
+                    'summer_regime' => $this->stewardService->isSummerRegime($context['today']),
+                ]
+            )
+        );
     }
 
     /**
@@ -101,53 +107,59 @@ class LeadershipController extends AbstractController
     {
         $context = $this->context();
 
-        return $this->render('@leadership/training.html.twig', $this->withFooter($context, [
-            // FormationMappingController sends the visitor back here with
-            // this flag: a fragment cannot open a collapsed block, because
-            // a fragment never reaches the server.
-            'mapping_open' => $request->getQuery('mapping') === '1',
-            'unit_note_key' => self::UNIT_NOTE_KEY,
-            'unit_note' => $this->editableContentService->get(self::UNIT_NOTE_KEY),
-            'to_convince' => $this->trainingService->toConvince(
-                $context['staff'],
-                $context['scout_year_id'],
-                $context['scout_year_label'],
-                $context['previous_scout_year_id'],
-                // So somebody who arrives with a T1 already behind them is
-                // on "à terminer" and not on "à convaincre de commencer".
-                $context['resolver']
-            ),
-            // With a single imported year there is nothing to compare
-            // against, so the first-year half of the list cannot be
-            // computed at all. An empty list would read as "nobody to
-            // convince", which is a different and wrong statement.
-            'history_too_short' => $context['previous_scout_year_id'] === null,
-            'to_finish' => $this->trainingService->toFinish($context['staff'], $context['resolver']),
-            'section_situations' => $this->trainingService->sectionSituations(
-                $context['staff'],
-                $context['scout_year_id'],
-                $context['resolver']
-            ),
-            // Above the ratio rather than beside it: the number these
-            // people stopped counting towards is the one a chief reads
-            // first (roadmap IT-20).
-            'unspecified_brevets' => $this->trainingService->unspecifiedBrevetCount(
-                $context['staff'],
-                $context['resolver']
-            ),
-            'unresolved_levels' => $this->trainingService->unresolvedLevels(
-                $context['scout_year_id'],
-                $context['resolver']
-            ),
-            'decided_levels' => $this->trainingService->decidedLevels(
-                $this->mappingRepository->findAllRows(),
-                $context['scout_year_id']
-            ),
-            'assignable_steps' => array_map(
-                static fn (FormationStep $step): array => ['value' => $step->value, 'label' => $step->label()],
-                FormationStep::assignable()
-            ),
-        ]));
+        return $this->render(
+            '@leadership/training.html.twig',
+            $this->withFooter(
+                $context,
+                [
+                    // FormationMappingController sends the visitor back here with
+                    // this flag: a fragment cannot open a collapsed block, because
+                    // a fragment never reaches the server.
+                    'mapping_open' => $request->getQuery('mapping') === '1',
+                    'unit_note_key' => self::UNIT_NOTE_KEY,
+                    'unit_note' => $this->editableContentService->get(self::UNIT_NOTE_KEY),
+                    'to_convince' => $this->trainingService->toConvince(
+                        $context['staff'],
+                        $context['scout_year_id'],
+                        $context['scout_year_label'],
+                        $context['previous_scout_year_id'],
+                        // So somebody who arrives with a T1 already behind them is
+                        // on "à terminer" and not on "à convaincre de commencer".
+                        $context['resolver']
+                    ),
+                    // With a single imported year there is nothing to compare
+                    // against, so the first-year half of the list cannot be
+                    // computed at all. An empty list would read as "nobody to
+                    // convince", which is a different and wrong statement.
+                    'history_too_short' => $context['previous_scout_year_id'] === null,
+                    'to_finish' => $this->trainingService->toFinish($context['staff'], $context['resolver']),
+                    'section_situations' => $this->trainingService->sectionSituations(
+                        $context['staff'],
+                        $context['scout_year_id'],
+                        $context['resolver']
+                    ),
+                    // Above the ratio rather than beside it: the number these
+                    // people stopped counting towards is the one a chief reads
+                    // first (roadmap IT-20).
+                    'unspecified_brevets' => $this->trainingService->unspecifiedBrevetCount(
+                        $context['staff'],
+                        $context['resolver']
+                    ),
+                    'unresolved_levels' => $this->trainingService->unresolvedLevels(
+                        $context['scout_year_id'],
+                        $context['resolver']
+                    ),
+                    'decided_levels' => $this->trainingService->decidedLevels(
+                        $this->mappingRepository->findAllRows(),
+                        $context['scout_year_id']
+                    ),
+                    'assignable_steps' => array_map(
+                        static fn (FormationStep $step): array => ['value' => $step->value, 'label' => $step->label()],
+                        FormationStep::assignable()
+                    ),
+                ]
+            )
+        );
     }
 
     /**
@@ -160,16 +172,23 @@ class LeadershipController extends AbstractController
     {
         $context = $this->context();
 
-        return $this->render('@leadership/obligations.html.twig', $this->withFooter($context, [
-            'birthdays' => $this->obligationsService->upcomingAdultBirthdays($context['staff'], $context['today']),
-            'candidates' => $this->obligationsService->candidates($context['staff'], $context['today']),
-            // An empty birthday block means "nobody turns 20 soon" only
-            // when every birth date is known; this is how many people it
-            // could say nothing about.
-            'without_birth_date' => $this->obligationsService->countWithoutBirthDate($context['staff']),
-            'alert_weeks' => LeadershipRules::ADULT_AGE_ALERT_WEEKS,
-            'adult_age' => LeadershipRules::ADULT_AGE,
-        ]));
+        return $this->render(
+            '@leadership/obligations.html.twig',
+            $this->withFooter(
+                $context,
+                [
+                    'birthdays' => $this->obligationsService
+                        ->upcomingAdultBirthdays($context['staff'], $context['today']),
+                    'candidates' => $this->obligationsService->candidates($context['staff'], $context['today']),
+                    // An empty birthday block means "nobody turns 20 soon" only
+                    // when every birth date is known; this is how many people it
+                    // could say nothing about.
+                    'without_birth_date' => $this->obligationsService->countWithoutBirthDate($context['staff']),
+                    'alert_weeks' => LeadershipRules::ADULT_AGE_ALERT_WEEKS,
+                    'adult_age' => LeadershipRules::ADULT_AGE,
+                ]
+            )
+        );
     }
 
     /**
@@ -183,19 +202,25 @@ class LeadershipController extends AbstractController
         $context = $this->context();
         $summer = $this->stewardService->isSummerRegime($context['today']);
 
-        return $this->render('@leadership/stewards.html.twig', $this->withFooter($context, [
-            'summer_regime' => $summer,
-            'registrations' => $this->stewardService->registrations(
-                $context['staff'],
-                $context['scout_year_id'],
-                $context['today']
-            ),
-            'under_age' => $this->stewardService->underAgeStewards($context['staff'], $context['today']),
-            'free_days' => LeadershipRules::STEWARD_FREE_DAYS,
-            'warning_days' => LeadershipRules::STEWARD_WARNING_DAYS,
-            'critical_days' => LeadershipRules::STEWARD_CRITICAL_DAYS,
-            'min_age' => LeadershipRules::STEWARD_MIN_AGE,
-        ]));
+        return $this->render(
+            '@leadership/stewards.html.twig',
+            $this->withFooter(
+                $context,
+                [
+                    'summer_regime' => $summer,
+                    'registrations' => $this->stewardService->registrations(
+                        $context['staff'],
+                        $context['scout_year_id'],
+                        $context['today']
+                    ),
+                    'under_age' => $this->stewardService->underAgeStewards($context['staff'], $context['today']),
+                    'free_days' => LeadershipRules::STEWARD_FREE_DAYS,
+                    'warning_days' => LeadershipRules::STEWARD_WARNING_DAYS,
+                    'critical_days' => LeadershipRules::STEWARD_CRITICAL_DAYS,
+                    'min_age' => LeadershipRules::STEWARD_MIN_AGE,
+                ]
+            )
+        );
     }
 
     /**

--- a/modules/mass_mail/src/Controller/MassMailController.php
+++ b/modules/mass_mail/src/Controller/MassMailController.php
@@ -144,8 +144,10 @@ class MassMailController extends AbstractController
             return $this->notFound();
         }
 
-        return $this->render('@mass_mail/compose.html.twig',
-            $this->buildComposeContext($email, $this->formFromEmail($email), null));
+        return $this->render(
+            '@mass_mail/compose.html.twig',
+            $this->buildComposeContext($email, $this->formFromEmail($email), null)
+        );
     }
 
     /**
@@ -719,8 +721,11 @@ class MassMailController extends AbstractController
         $audienceId = $form['audience_id'] !== null ? (int) $form['audience_id'] : null;
         if ($audienceId !== null) {
             try {
-                $summary = $this->massMailService->getAudienceSummary($audienceId, AuthSession::getUserAccountId(),
-                    $authorization);
+                $summary = $this->massMailService->getAudienceSummary(
+                    $audienceId,
+                    AuthSession::getUserAccountId(),
+                    $authorization
+                );
                 $audience = $summary['audience'];
                 $audienceSample = $summary['sample'];
             } catch (MassMailException) {
@@ -742,8 +747,10 @@ class MassMailController extends AbstractController
             'forced_section_id' => $authorization->forcedSenderSectionId,
             'list_options' => $this->buildListOptions($authorization, (string) $form['list']),
             'scout_years' => $this->buildScoutYearOptions(),
-            'previous_year_cutoff' => (string) ($this->settingService->get(self::SETTING_PREVIOUS_YEAR_CUTOFF,
-                'mass_mail') ?: self::DEFAULT_PREVIOUS_YEAR_CUTOFF),
+            'previous_year_cutoff' => (string) ($this->settingService->get(
+                self::SETTING_PREVIOUS_YEAR_CUTOFF,
+                'mass_mail'
+            ) ?: self::DEFAULT_PREVIOUS_YEAR_CUTOFF),
             'audience' => $audience,
             'audience_sample' => $audienceSample,
             'attachments' => $attachments,
@@ -1078,8 +1085,11 @@ class MassMailController extends AbstractController
 
         $userSectionIds = $this->massMailAccessService->getUserSectionIds($email, $currentYearId);
         $linkedMembers = $this->memberService->getLinkedMembers($email, $currentYearId);
-        $forcedSectionId = SectionPickerHelper::resolveDefault(null, $linkedMembers,
-            $this->sectionService->getAllWithBranches());
+        $forcedSectionId = SectionPickerHelper::resolveDefault(
+            null,
+            $linkedMembers,
+            $this->sectionService->getAllWithBranches()
+        );
 
         return new SenderAuthorization(false, $userSectionIds, $forcedSectionId);
     }

--- a/modules/mass_mail/src/Repository/EmailRepository.php
+++ b/modules/mass_mail/src/Repository/EmailRepository.php
@@ -225,8 +225,10 @@ class EmailRepository
         $scoutYearsByEmailId = $this->getScoutYearIdsForEmails($emailIds);
 
         return [
-            'emails' => array_map(fn(array $row) => $this->hydrate($row, $scoutYearsByEmailId[(int) $row['id']] ?? []),
-                $rows),
+            'emails' => array_map(
+                fn(array $row) => $this->hydrate($row, $scoutYearsByEmailId[(int) $row['id']] ?? []),
+                $rows
+            ),
             'total' => $total,
         ];
     }

--- a/modules/mass_mail/src/Repository/RecipientRepository.php
+++ b/modules/mass_mail/src/Repository/RecipientRepository.php
@@ -250,18 +250,21 @@ class RecipientRepository
         );
         $stmt->execute([$memberId]);
 
-        return array_map(fn(array $row) => [
-            'id' => (int) $row['id'],
-            'subject' => (string) $row['subject'],
-            'sent_at' => (string) $row['sent_at'],
-            'section_name' => (string) $row['section_name'],
-            // The stored subject is the TEMPLATE — `{{Prenom}}` and all —
-            // for a publipostage. These two say which line's values put it
-            // back the way this member read it; Service\MassMailQueryService
-            // does that, since substitution is not a repository's job.
-            'list_type' => (string) $row['list_type'],
-            'audience_row_id' => $row['audience_row_id'] !== null ? (int) $row['audience_row_id'] : null,
-        ], $stmt->fetchAll(\PDO::FETCH_ASSOC));
+        return array_map(
+            fn(array $row) => [
+                'id' => (int) $row['id'],
+                'subject' => (string) $row['subject'],
+                'sent_at' => (string) $row['sent_at'],
+                'section_name' => (string) $row['section_name'],
+                // The stored subject is the TEMPLATE — `{{Prenom}}` and all —
+                // for a publipostage. These two say which line's values put it
+                // back the way this member read it; Service\MassMailQueryService
+                // does that, since substitution is not a repository's job.
+                'list_type' => (string) $row['list_type'],
+                'audience_row_id' => $row['audience_row_id'] !== null ? (int) $row['audience_row_id'] : null,
+            ],
+            $stmt->fetchAll(\PDO::FETCH_ASSOC)
+        );
     }
 
     /**

--- a/modules/mass_mail/src/Service/AudienceImportService.php
+++ b/modules/mass_mail/src/Service/AudienceImportService.php
@@ -88,8 +88,10 @@ class AudienceImportService
 
         $memberIdsByDeskId = $tiersColumn !== null
             ? $this->memberResolutionRepository->findMemberIdsByDeskIds(
-                array_values(array_filter(array_map(fn(array $r) => trim($r['data'][$tiersColumn] ?? ''), $dataRows),
-                    fn(string $v) => $v !== ''))
+                array_values(array_filter(
+                    array_map(fn(array $r) => trim($r['data'][$tiersColumn] ?? ''), $dataRows),
+                    fn(string $v) => $v !== ''
+                ))
             )
             : [];
 
@@ -120,8 +122,10 @@ class AudienceImportService
             }
 
             $addresses = $this->splitAddresses($emailValue);
-            $invalid = array_values(array_filter($addresses,
-                fn(string $a) => filter_var($a, FILTER_VALIDATE_EMAIL) === false));
+            $invalid = array_values(array_filter(
+                $addresses,
+                fn(string $a) => filter_var($a, FILTER_VALIDATE_EMAIL) === false
+            ));
             if ($invalid !== []) {
                 $errors[] = "Ligne {$lineNo} — la valeur « {$invalid[0]} » de la colonne Email n'est pas une adresse "
                     . "valide.";
@@ -140,20 +144,34 @@ class AudienceImportService
             throw new AudienceImportException($errors);
         }
 
-        $audienceId = $this->audienceRepository->createAudience($originalFilename, $sheetName, $columns,
-            count($resolved), $createdBy);
+        $audienceId = $this->audienceRepository->createAudience(
+            $originalFilename,
+            $sheetName,
+            $columns,
+            count($resolved),
+            $createdBy
+        );
         foreach ($resolved as $row) {
-            $this->audienceRepository->createRow($audienceId, $row['line'], $row['member_id'], $row['email'],
-                $row['data']);
+            $this->audienceRepository->createRow(
+                $audienceId,
+                $row['line'],
+                $row['member_id'],
+                $row['email'],
+                $row['data']
+            );
         }
 
         $this->journalService->log(
-            'mass_mail', 'audience_imported', 'info', 'Audience de publipostage importée depuis un fichier Excel',
+            'mass_mail',
+            'audience_imported',
+            'info',
+            'Audience de publipostage importée depuis un fichier Excel',
             [
                 'audience_id' => $audienceId,
                 'row_count' => count($resolved),
                 'column_count' => count($columns)
-            ], $createdBy
+            ],
+            $createdBy
         );
 
         $audience = $this->audienceRepository->findById($audienceId);
@@ -279,8 +297,10 @@ class AudienceImportService
      */
     private function splitAddresses(string $value): array
     {
-        return array_values(array_filter(array_map('trim', (array) preg_split('/[;,]/', $value)),
-            fn(string $a) => $a !== ''));
+        return array_values(array_filter(
+            array_map('trim', (array) preg_split('/[;,]/', $value)),
+            fn(string $a) => $a !== ''
+        ));
     }
 
     /**
@@ -309,16 +329,20 @@ class AudienceImportService
 
         $duplicateMemberGroups = array_values(array_filter($memberLines, fn(array $lines) => count($lines) > 1));
         if ($duplicateMemberGroups !== []) {
-            $linesList = implode(' ; ',
-                array_map(fn(array $lines) => 'lignes ' . implode(', ', $lines), $duplicateMemberGroups));
+            $linesList = implode(
+                ' ; ',
+                array_map(fn(array $lines) => 'lignes ' . implode(', ', $lines), $duplicateMemberGroups)
+            );
             $warnings[] = "Un même Tiers apparaît sur plusieurs lignes ({$linesList}) : chaque ligne enverra son "
                 . "propre email.";
         }
 
         $duplicateAddressGroups = array_values(array_filter($addressLines, fn(array $lines) => count($lines) > 1));
         if ($duplicateAddressGroups !== []) {
-            $linesList = implode(' ; ',
-                array_map(fn(array $lines) => 'lignes ' . implode(', ', $lines), $duplicateAddressGroups));
+            $linesList = implode(
+                ' ; ',
+                array_map(fn(array $lines) => 'lignes ' . implode(', ', $lines), $duplicateAddressGroups)
+            );
             $warnings[] = "Une même adresse email apparaît sur plusieurs lignes ({$linesList}) : chaque ligne "
                 . "enverra son propre email.";
         }

--- a/modules/mass_mail/src/Service/MassMailService.php
+++ b/modules/mass_mail/src/Service/MassMailService.php
@@ -294,8 +294,15 @@ class MassMailService
             }
         }
 
-        $result = $this->emailRepository->findFiltered($search, $status, $sectionId, $matchedDefaultListTypes,
-            $page, $visibleSectionIds, $ownAccountId);
+        $result = $this->emailRepository->findFiltered(
+            $search,
+            $status,
+            $sectionId,
+            $matchedDefaultListTypes,
+            $page,
+            $visibleSectionIds,
+            $ownAccountId
+        );
 
         return ['emails' => $result['emails'], 'total' => $result['total'], 'per_page' => EmailRepository::perPage()];
     }
@@ -368,12 +375,25 @@ class MassMailService
             $this->assertScoutYearsSelectable($scoutYearIds);
         }
 
-        $id = $this->emailRepository->create($subject, $bodyHtml, $sectionId, $listType, $listId, $listSectionId,
-            $scoutYearIds, $createdBy, $audienceId);
+        $id = $this->emailRepository->create(
+            $subject,
+            $bodyHtml,
+            $sectionId,
+            $listType,
+            $listId,
+            $listSectionId,
+            $scoutYearIds,
+            $createdBy,
+            $audienceId
+        );
 
         $this->journalService->log(
-            'mass_mail', 'email_created', 'info', 'Nouvel email de masse créé (brouillon)',
-            ['email_id' => $id], $createdBy
+            'mass_mail',
+            'email_created',
+            'info',
+            'Nouvel email de masse créé (brouillon)',
+            ['email_id' => $id],
+            $createdBy
         );
 
         $email = $this->emailRepository->findById($id);
@@ -439,8 +459,17 @@ class MassMailService
             }
         }
 
-        $this->emailRepository->update($id, $subject, $bodyHtml, $sectionId, $listType, $listId, $listSectionId,
-            $scoutYearIds, $audienceId);
+        $this->emailRepository->update(
+            $id,
+            $subject,
+            $bodyHtml,
+            $sectionId,
+            $listType,
+            $listId,
+            $listSectionId,
+            $scoutYearIds,
+            $audienceId
+        );
 
         $updated = $this->emailRepository->findById($id);
         \assert($updated !== null);
@@ -462,8 +491,12 @@ class MassMailService
         $this->emailRepository->updateStatus($id, Email::STATUS_TEST);
 
         $this->journalService->log(
-            'mass_mail', 'email_status_changed', 'info', 'Email de masse passé en mode test',
-            ['email_id' => $id, 'from' => Email::STATUS_DRAFT, 'to' => Email::STATUS_TEST], $actorId
+            'mass_mail',
+            'email_status_changed',
+            'info',
+            'Email de masse passé en mode test',
+            ['email_id' => $id, 'from' => Email::STATUS_DRAFT, 'to' => Email::STATUS_TEST],
+            $actorId
         );
 
         return $this->requireEmail($id);
@@ -484,8 +517,12 @@ class MassMailService
         $this->emailRepository->updateStatus($id, Email::STATUS_DRAFT);
 
         $this->journalService->log(
-            'mass_mail', 'email_status_changed', 'info', 'Email de masse revenu en brouillon',
-            ['email_id' => $id, 'from' => Email::STATUS_TEST, 'to' => Email::STATUS_DRAFT], $actorId
+            'mass_mail',
+            'email_status_changed',
+            'info',
+            'Email de masse revenu en brouillon',
+            ['email_id' => $id, 'from' => Email::STATUS_TEST, 'to' => Email::STATUS_DRAFT],
+            $actorId
         );
 
         return $this->requireEmail($id);
@@ -746,7 +783,10 @@ class MassMailService
     private function freezeListRecipients(Email $email): array
     {
         $members = $this->mailingListService->resolveMembersForYears(
-            $email->listType, $email->listId, $email->listSectionId, $this->orderYearsMostRecentFirst(
+            $email->listType,
+            $email->listId,
+            $email->listSectionId,
+            $this->orderYearsMostRecentFirst(
                 $email->scoutYearIds
             )
         );
@@ -802,8 +842,13 @@ class MassMailService
 
             foreach ($addresses as $memberEmail) {
                 $this->recipientRepository->create(
-                    $email->id, $member['member_id'], $member['scout_year_id'], $memberEmail->email,
-                    Recipient::STATUS_PENDING, null, $memberEmail->id
+                    $email->id,
+                    $member['member_id'],
+                    $member['scout_year_id'],
+                    $memberEmail->email,
+                    Recipient::STATUS_PENDING,
+                    null,
+                    $memberEmail->id
                 );
                 $writtenAddresses[mb_strtolower(trim($memberEmail->email))] = true;
                 $validCount++;
@@ -853,7 +898,12 @@ class MassMailService
     ): array {
         if (filter_var($address, FILTER_VALIDATE_EMAIL) === false) {
             $recipientId = $this->recipientRepository->create(
-                $email->id, null, null, $address, Recipient::STATUS_ERROR, 'Adresse invalide'
+                $email->id,
+                null,
+                null,
+                $address,
+                Recipient::STATUS_ERROR,
+                'Adresse invalide'
             );
             $this->journalRecipientNotSendable($email->id, $recipientId, null, 'Adresse invalide');
             return [$validCount, $invalidCount + 1];
@@ -861,8 +911,12 @@ class MassMailService
 
         if ($this->suppressedAddressRepository->isSuppressed($address)) {
             $recipientId = $this->recipientRepository->create(
-                $email->id, null, null, $address,
-                Recipient::STATUS_ERROR, 'Adresse désinscrite des emails groupés'
+                $email->id,
+                null,
+                null,
+                $address,
+                Recipient::STATUS_ERROR,
+                'Adresse désinscrite des emails groupés'
             );
             $this->journalRecipientNotSendable(
                 $email->id,
@@ -912,16 +966,24 @@ class MassMailService
         foreach ($rows as $row) {
             if ($row->memberId !== null) {
                 $profile = $mergeMembers[$row->memberId] ?? null;
-                $deskEmail = $profile !== null && $profile['email'] !== null && filter_var($profile['email'],
-                    FILTER_VALIDATE_EMAIL) !== false
+                $deskEmail = $profile !== null && $profile['email'] !== null && filter_var(
+                    $profile['email'],
+                    FILTER_VALIDATE_EMAIL
+                ) !== false
                     ? $profile['email']
                     : null;
                 $addresses = $this->memberEmailService->resolveValidAddressesForMassMail($row->memberId, $deskEmail);
 
                 if ($addresses === []) {
                     $recipientId = $this->recipientRepository->create(
-                        $email->id, $row->memberId, $profile['scout_year_id'] ?? null, null,
-                        Recipient::STATUS_ERROR, 'Adresse invalide', null, $row->id
+                        $email->id,
+                        $row->memberId,
+                        $profile['scout_year_id'] ?? null,
+                        null,
+                        Recipient::STATUS_ERROR,
+                        'Adresse invalide',
+                        null,
+                        $row->id
                     );
                     $this->journalRecipientNotSendable(
                         $email->id,
@@ -935,8 +997,14 @@ class MassMailService
 
                 foreach ($addresses as $memberEmail) {
                     $this->recipientRepository->create(
-                        $email->id, $row->memberId, $profile['scout_year_id'] ?? null, $memberEmail->email,
-                        Recipient::STATUS_PENDING, null, $memberEmail->id, $row->id
+                        $email->id,
+                        $row->memberId,
+                        $profile['scout_year_id'] ?? null,
+                        $memberEmail->email,
+                        Recipient::STATUS_PENDING,
+                        null,
+                        $memberEmail->id,
+                        $row->id
                     );
                     $validCount++;
                 }
@@ -946,8 +1014,14 @@ class MassMailService
             foreach ($this->splitRowAddresses($row) as $address) {
                 if ($this->suppressedAddressRepository->isSuppressed($address)) {
                     $recipientId = $this->recipientRepository->create(
-                        $email->id, null, null, $address,
-                        Recipient::STATUS_ERROR, 'Adresse désinscrite des emails groupés', null, $row->id
+                        $email->id,
+                        null,
+                        null,
+                        $address,
+                        Recipient::STATUS_ERROR,
+                        'Adresse désinscrite des emails groupés',
+                        null,
+                        $row->id
                     );
                     $this->journalRecipientNotSendable(
                         $email->id,
@@ -959,8 +1033,14 @@ class MassMailService
                     continue;
                 }
                 $this->recipientRepository->create(
-                    $email->id, null, null, $address,
-                    Recipient::STATUS_PENDING, null, null, $row->id
+                    $email->id,
+                    null,
+                    null,
+                    $address,
+                    Recipient::STATUS_PENDING,
+                    null,
+                    null,
+                    $row->id
                 );
                 $validCount++;
             }
@@ -1175,8 +1255,11 @@ class MassMailService
             return;
         }
 
-        $this->schedulerService->scheduleAfter(self::SCHEDULER_MODULE_ID, self::SCHEDULER_TASK_KEY,
-            $runImmediately ? 0 : 60);
+        $this->schedulerService->scheduleAfter(
+            self::SCHEDULER_MODULE_ID,
+            self::SCHEDULER_TASK_KEY,
+            $runImmediately ? 0 : 60
+        );
     }
 
     /**
@@ -1294,8 +1377,12 @@ class MassMailService
         SenderAuthorization $authorization
     ): void
     {
-        if (!MassMailAccessService::canUseList($authorization->isChefDUniteOrAbove,
-            $authorization->allowedListSectionIds, $listType, $listSectionId)) {
+        if (!MassMailAccessService::canUseList(
+            $authorization->isChefDUniteOrAbove,
+            $authorization->allowedListSectionIds,
+            $listType,
+            $listSectionId
+        )) {
             throw new MassMailException("Vous ne pouvez envoyer qu'à la liste de votre section ou à la liste des "
                 . "chefs — seul un chef d'unité peut cibler une autre liste.");
         }

--- a/modules/mass_mail/src/Task/SendBatchHandler.php
+++ b/modules/mass_mail/src/Task/SendBatchHandler.php
@@ -56,8 +56,11 @@ class SendBatchHandler implements TaskHandlerInterface
         $mergeRenderer = new MergeRenderer();
         $massMailService = $this->buildMassMailService($context);
 
-        $batchSize = (int) $context->settings->get(self::SETTING_BATCH_SIZE, 'mass_mail',
-            (string) self::DEFAULT_BATCH_SIZE);
+        $batchSize = (int) $context->settings->get(
+            self::SETTING_BATCH_SIZE,
+            'mass_mail',
+            (string) self::DEFAULT_BATCH_SIZE
+        );
         if ($batchSize <= 0) {
             $batchSize = self::DEFAULT_BATCH_SIZE;
         }
@@ -227,8 +230,12 @@ class SendBatchHandler implements TaskHandlerInterface
 
         if ($batch !== []) {
             $context->journal->log(
-                'mass_mail', 'batch_sent', 'info', 'Lot d\'emails de masse envoyé',
-                ['sent' => $sentCount, 'errors' => $errorCount, 'batch_size' => $batchSize], null
+                'mass_mail',
+                'batch_sent',
+                'info',
+                'Lot d\'emails de masse envoyé',
+                ['sent' => $sentCount, 'errors' => $errorCount, 'batch_size' => $batchSize],
+                null
             );
         }
 
@@ -272,8 +279,10 @@ class SendBatchHandler implements TaskHandlerInterface
         }
 
         $pdo = $context->connection->getPdo();
-        $memberYear = (new MemberYearRepository($pdo))->findByMemberAndYear($recipient->memberId,
-            $recipient->scoutYearId);
+        $memberYear = (new MemberYearRepository($pdo))->findByMemberAndYear(
+            $recipient->memberId,
+            $recipient->scoutYearId
+        );
         $url = $memberYear !== null ? '/members/' . $memberYear['id'] . '/emails/' . $recipient->id : null;
 
         $context->notifications->dispatch('mass_mail.email_received', [
@@ -331,7 +340,9 @@ class SendBatchHandler implements TaskHandlerInterface
         }
 
         $intervalMinutes = (int) $context->settings->get(
-            self::SETTING_BATCH_INTERVAL_MINUTES, 'mass_mail', (string) self::DEFAULT_BATCH_INTERVAL_MINUTES
+            self::SETTING_BATCH_INTERVAL_MINUTES,
+            'mass_mail',
+            (string) self::DEFAULT_BATCH_INTERVAL_MINUTES
         );
         if ($intervalMinutes <= 0) {
             $intervalMinutes = self::DEFAULT_BATCH_INTERVAL_MINUTES;
@@ -352,8 +363,11 @@ class SendBatchHandler implements TaskHandlerInterface
             new \Core\Badge\MemberBadgeRepository($pdo)
         );
 
-        $memberService = new \Core\Member\MemberService(new \Core\Import\MemberYearRepository($pdo),
-            $context->encryption, $context->connection);
+        $memberService = new \Core\Member\MemberService(
+            new \Core\Import\MemberYearRepository($pdo),
+            $context->encryption,
+            $context->connection
+        );
         $scoutYearService = new \Core\Config\ScoutYearService($pdo);
 
         // No module namespace needed — Core\Member\MemberEmailService only

--- a/modules/member_stats/src/Service/MemberStatsService.php
+++ b/modules/member_stats/src/Service/MemberStatsService.php
@@ -62,8 +62,11 @@ class MemberStatsService
         $rows = $this->repository->getMemberBranchData($scoutYearId);
         foreach ($rows as $row) {
             $birthYear = MemberYearService::extractBirthYear($row['birth_date']);
-            $effectiveAge = $this->memberYearService->getEffectiveAge($birthYear, $row['scout_year_offset'],
-                $referenceYear);
+            $effectiveAge = $this->memberYearService->getEffectiveAge(
+                $birthYear,
+                $row['scout_year_offset'],
+                $referenceYear
+            );
 
             if (!$effectiveAge->isInKnownBranch()) {
                 continue; // no usable birth year, or effective age outside the four animés branches

--- a/modules/news/src/Controller/FormController.php
+++ b/modules/news/src/Controller/FormController.php
@@ -186,25 +186,48 @@ class FormController extends AbstractController
             (string) $request->getServer('REMOTE_ADDR', '')
         );
         if ($humanCheckResult !== null && !$humanCheckResult->accepted) {
-            return $this->rerenderFormWithError($request, $article, $form, $fields, $email, $scoutYearId,
-                'Une erreur est survenue. Veuillez réessayer.');
+            return $this->rerenderFormWithError(
+                $request,
+                $article,
+                $form,
+                $fields,
+                $email,
+                $scoutYearId,
+                'Une erreur est survenue. Veuillez réessayer.'
+            );
         }
 
         try {
             $response = $this->responseService->submit(
-                $article, $form, $fields, $accountId, $email, $scoutYearId,
+                $article,
+                $form,
+                $fields,
+                $accountId,
+                $email,
+                $scoutYearId,
                 (string) $request->getBody('contact_email', ''),
                 $this->extractAnswers($request, $fields),
                 $memberYearId
             );
         } catch (NewsException $e) {
-            return $this->rerenderFormWithError($request, $article, $form, $fields, $email, $scoutYearId,
-                $e->getMessage());
+            return $this->rerenderFormWithError(
+                $request,
+                $article,
+                $form,
+                $fields,
+                $email,
+                $scoutYearId,
+                $e->getMessage()
+            );
         }
 
         $this->journalService->log(
-            'news', 'form_response_submitted', 'info', "Réponse soumise pour l'article « {$article->title} »",
-            ['article_id' => $article->id, 'form_id' => $form->id, 'response_id' => $response->id], $accountId
+            'news',
+            'form_response_submitted',
+            'info',
+            "Réponse soumise pour l'article « {$article->title} »",
+            ['article_id' => $article->id, 'form_id' => $form->id, 'response_id' => $response->id],
+            $accountId
         );
 
         // Post/Redirect/Get. This used to RENDER the confirmation, so the
@@ -567,8 +590,10 @@ class FormController extends AbstractController
         $responses = array_map(
             static fn (array $row) => $row['response'],
             self::applyAudience(
-                self::applyFilter($this->filterableRows($form),
-                    self::normalizeFilter((string) $request->getBody('filter', self::FILTER_ALL))),
+                self::applyFilter(
+                    $this->filterableRows($form),
+                    self::normalizeFilter((string) $request->getBody('filter', self::FILTER_ALL))
+                ),
                 $audience
             )
         );
@@ -710,13 +735,18 @@ class FormController extends AbstractController
         // the list above it would be worse than no filter at all.
         $responses = array_map(
             static fn (array $row) => $row['response'],
-            self::applyFilter($this->filterableRows($form),
-                self::normalizeFilter((string) $request->getQuery('filter', self::FILTER_ALL)))
+            self::applyFilter(
+                $this->filterableRows($form),
+                self::normalizeFilter((string) $request->getQuery('filter', self::FILTER_ALL))
+            )
         );
         $xlsx = $this->buildXlsx($fields, $responses, $form);
 
         $this->journalService->log(
-            'news', 'form_responses_exported', 'info', "Export des réponses de l'article « {$article->title} »",
+            'news',
+            'form_responses_exported',
+            'info',
+            "Export des réponses de l'article « {$article->title} »",
             ['article_id' => $article->id, 'form_id' => $form->id, 'response_count' => count($responses)],
             (int) AuthSession::getUserAccountId()
         );
@@ -776,9 +806,10 @@ class FormController extends AbstractController
      */
     public function updateResponse(Request $request, array $params): Response
     {
-        if (($guard = $this->guardCsrf($request,
+        if (($guard = $this->guardCsrf(
+            $request,
             '/news/' . (int) ($params['id'] ?? 0) . '/form/responses/' . (int) ($params['response_id'] ?? 0) . '/edit'
-            )) !== null) {
+        )) !== null) {
             return $guard;
         }
 
@@ -799,10 +830,13 @@ class FormController extends AbstractController
 
         try {
             $this->responseService->update(
-                $response, $form, $fields,
+                $response,
+                $form,
+                $fields,
                 (string) $request->getBody('contact_email', ''),
                 $this->extractAnswers($request, $fields),
-                AuthSession::getEmail(), $scoutYearId
+                AuthSession::getEmail(),
+                $scoutYearId
             );
         } catch (NewsException $e) {
             $memberOptions = $form->access === NewsForm::ACCESS_IDENTIFIED
@@ -821,8 +855,12 @@ class FormController extends AbstractController
         }
 
         $this->journalService->log(
-            'news', 'form_response_updated', 'info', "Réponse modifiée pour l'article « {$article->title} »",
-            ['article_id' => $article->id, 'form_id' => $form->id, 'response_id' => $response->id], $accountId
+            'news',
+            'form_response_updated',
+            'info',
+            "Réponse modifiée pour l'article « {$article->title} »",
+            ['article_id' => $article->id, 'form_id' => $form->id, 'response_id' => $response->id],
+            $accountId
         );
 
         return $this->redirect('/news/' . $article->id);
@@ -942,8 +980,10 @@ class FormController extends AbstractController
             if ($field->isNonInput()) {
                 continue;
             }
-            $answers[$field->id] = $request->getBody('field_' . $field->id,
-                $field->fieldType === FormField::TYPE_CHECKBOX ? [] : '');
+            $answers[$field->id] = $request->getBody(
+                'field_' . $field->id,
+                $field->fieldType === FormField::TYPE_CHECKBOX ? [] : ''
+            );
         }
         return $answers;
     }

--- a/modules/news/src/Controller/NewsController.php
+++ b/modules/news/src/Controller/NewsController.php
@@ -295,8 +295,11 @@ class NewsController extends AbstractController
             // The form is no longer optional (usability review: "only the
             // form, with by default a bloc de texte") — every article
             // always gets one, saved together in this same POST.
-            $this->formService->save($article->id, $this->extractFormSettings($request, $visibility),
-                $this->extractFields($request));
+            $this->formService->save(
+                $article->id,
+                $this->extractFormSettings($request, $visibility),
+                $this->extractFields($request)
+            );
         } catch (NewsException $e) {
             return $this->render(
                 '@news/editor.html.twig',
@@ -305,8 +308,12 @@ class NewsController extends AbstractController
         }
 
         $this->journalService->log(
-            'news', 'article_created', 'info', "Article « {$article->title} » créé",
-            ['article_id' => $article->id], $accountId
+            'news',
+            'article_created',
+            'info',
+            "Article « {$article->title} » créé",
+            ['article_id' => $article->id],
+            $accountId
         );
 
         return $this->redirect('/news/' . $article->id . '/gerer');
@@ -365,8 +372,10 @@ class NewsController extends AbstractController
         // form starts issuing tickets, and only that direction. Lowering
         // the switch needs nothing — the tickets already issued stay
         // valid and stay scannable.
-        $startsIssuingTickets = $this->formService->willStartIssuingTickets($article->id,
-            (bool) $formSettings['issues_ticket']);
+        $startsIssuingTickets = $this->formService->willStartIssuingTickets(
+            $article->id,
+            (bool) $formSettings['issues_ticket']
+        );
 
         try {
             $imageFileId = $this->resolveUploadedImageFileId($request, $visibility, $accountId);
@@ -384,13 +393,19 @@ class NewsController extends AbstractController
 
             $form = $this->formService->save($article->id, $formSettings, $this->extractFields($request));
         } catch (NewsException $e) {
-            return $this->render('@news/editor.html.twig',
-                $this->editorErrorContext($article, $request, $e->getMessage()))->setStatusCode(422);
+            return $this->render(
+                '@news/editor.html.twig',
+                $this->editorErrorContext($article, $request, $e->getMessage())
+            )->setStatusCode(422);
         }
 
         $this->journalService->log(
-            'news', 'article_updated', 'info', "Article « {$article->title} » modifié",
-            ['article_id' => $article->id], $accountId
+            'news',
+            'article_updated',
+            'info',
+            "Article « {$article->title} » modifié",
+            ['article_id' => $article->id],
+            $accountId
         );
 
         if ($startsIssuingTickets) {
@@ -426,8 +441,12 @@ class NewsController extends AbstractController
         $this->articleService->delete($article->id);
 
         $this->journalService->log(
-            'news', 'article_deleted', 'info', "Article « {$article->title} » supprimé",
-            ['article_id' => $article->id], $accountId
+            'news',
+            'article_deleted',
+            'info',
+            "Article « {$article->title} » supprimé",
+            ['article_id' => $article->id],
+            $accountId
         );
 
         return $this->json(['success' => true]);
@@ -462,7 +481,11 @@ class NewsController extends AbstractController
         // the list card and social-share description, and short enough
         // that Core\Pdf\PosterPdfService's own truncation never kicks in.
         $pdf = $this->posterPdfService->generate(
-            $article->title, (string) $article->summary, $qrUrl, $shortName, $this->buildImageDataUri(
+            $article->title,
+            (string) $article->summary,
+            $qrUrl,
+            $shortName,
+            $this->buildImageDataUri(
                 $article->imageFileId
             )
         );
@@ -512,8 +535,10 @@ class NewsController extends AbstractController
                 ? $this->responseService->resolveMemberOptions($email, $scoutYearId)
                 : [];
             if ($form->responseLimit === NewsForm::RESPONSE_LIMIT_ONE_PER_MEMBER) {
-                $alreadyResponded = $this->responseService->hasAlreadyRespondedForAllMembers($form,
-                    array_keys($memberOptions));
+                $alreadyResponded = $this->responseService->hasAlreadyRespondedForAllMembers(
+                    $form,
+                    array_keys($memberOptions)
+                );
             } else {
                 $alreadyResponded = $this->responseService->hasAlreadyResponded($form, $accountId, null);
             }
@@ -886,8 +911,16 @@ class NewsController extends AbstractController
         $legacyBodyHtml = $fields === [] && $article !== null ? $this->articleService->getBodyHtml($article->id) : '';
 
         $draft = new FormField(
-            id: 0, formId: 0, sortOrder: 0, fieldType: FormField::TYPE_TEXT, label: null, isRequired: false,
-            optionsSource: null, optionsManual: null, capacityMax: null, pricePerUnit: null,
+            id: 0,
+            formId: 0,
+            sortOrder: 0,
+            fieldType: FormField::TYPE_TEXT,
+            label: null,
+            isRequired: false,
+            optionsSource: null,
+            optionsManual: null,
+            capacityMax: null,
+            pricePerUnit: null,
             confirmationText: $legacyBodyHtml !== '' ? $legacyBodyHtml : null
         );
 
@@ -1010,7 +1043,9 @@ class NewsController extends AbstractController
         );
 
         $this->journalService->log(
-            'news', 'tickets_backfilled', 'info',
+            'news',
+            'tickets_backfilled',
+            'info',
             'Billets générés pour les réponses déjà enregistrées d\'un formulaire',
             ['form_id' => $form->id, 'count' => count($issued)],
             $accountId

--- a/modules/news/src/Controller/ScanController.php
+++ b/modules/news/src/Controller/ScanController.php
@@ -207,12 +207,15 @@ class ScanController extends AbstractController
         return $this->json([
             'success' => true,
             'verdict' => null,
-            'matches' => array_map(static fn (array $m) => [
-                'response_id' => $m['response']->id,
-                'label' => $m['label'],
-                'seat_total' => $m['seat_total'],
-                'used_at' => $m['used_at'],
-            ], $matches),
+            'matches' => array_map(
+                static fn (array $m) => [
+                    'response_id' => $m['response']->id,
+                    'label' => $m['label'],
+                    'seat_total' => $m['seat_total'],
+                    'used_at' => $m['used_at'],
+                ],
+                $matches
+            ),
         ]);
     }
 

--- a/modules/news/src/Repository/Article.php
+++ b/modules/news/src/Repository/Article.php
@@ -94,8 +94,11 @@ final class Article
      */
     public function isEffectivelyIndexed(?\DateTimeImmutable $now = null): bool
     {
-        if (!$this->isIndexed || in_array($this->visibility,
-            [self::VISIBILITY_DIRECT_LINK, self::VISIBILITY_IDENTIFIED], true)) {
+        if (!$this->isIndexed || in_array(
+            $this->visibility,
+            [self::VISIBILITY_DIRECT_LINK, self::VISIBILITY_IDENTIFIED],
+            true
+        )) {
             return false;
         }
 

--- a/modules/news/src/Service/ArticleService.php
+++ b/modules/news/src/Service/ArticleService.php
@@ -237,8 +237,16 @@ class ArticleService implements HomeNewsProvider
             $seoStopDate
         ] = $this->enforceSeoRules($visibility, $isIndexed, $seoKeywords, $seoStopDate);
 
-        $id = $this->articleRepository->create($title, $visibility, $isIndexed, $seoKeywords, $seoStopDate, $createdBy,
-            $summary, $imageFileId);
+        $id = $this->articleRepository->create(
+            $title,
+            $visibility,
+            $isIndexed,
+            $seoKeywords,
+            $seoStopDate,
+            $createdBy,
+            $summary,
+            $imageFileId
+        );
 
         $code = $this->shortUrlService->createShortUrl('/news/' . $id, $createdBy);
         $this->articleRepository->setShortUrlCode($id, $code);
@@ -274,8 +282,16 @@ class ArticleService implements HomeNewsProvider
             $seoStopDate
         ] = $this->enforceSeoRules($visibility, $isIndexed, $seoKeywords, $seoStopDate);
 
-        $this->articleRepository->update($id, $title, $visibility, $isIndexed, $seoKeywords, $seoStopDate, $summary,
-            $imageFileId);
+        $this->articleRepository->update(
+            $id,
+            $title,
+            $visibility,
+            $isIndexed,
+            $seoKeywords,
+            $seoStopDate,
+            $summary,
+            $imageFileId
+        );
 
         $updated = $this->articleRepository->findById($id);
         $this->syncCoverImageAccess($updated?->imageFileId, $visibility);

--- a/modules/news/src/Service/FormService.php
+++ b/modules/news/src/Service/FormService.php
@@ -135,18 +135,34 @@ class FormService
 
         if ($existing === null) {
             $formId = $this->formRepository->create(
-                $articleId, $access, $responseLimit, $settings['opens_at'], $settings['closes_at'],
-                $settings['is_force_closed'], $responseRoleMin, $settings['daily_digest_enabled'],
+                $articleId,
+                $access,
+                $responseLimit,
+                $settings['opens_at'],
+                $settings['closes_at'],
+                $settings['is_force_closed'],
+                $responseRoleMin,
+                $settings['daily_digest_enabled'],
                 $settings['finance_account_id'],
-                $issuesTicket, $eventDate, $eventLocation
+                $issuesTicket,
+                $eventDate,
+                $eventLocation
             );
         } else {
             $formId = $existing->id;
             $this->formRepository->update(
-                $formId, $access, $responseLimit, $settings['opens_at'], $settings['closes_at'],
-                $settings['is_force_closed'], $responseRoleMin, $settings['daily_digest_enabled'],
+                $formId,
+                $access,
+                $responseLimit,
+                $settings['opens_at'],
+                $settings['closes_at'],
+                $settings['is_force_closed'],
+                $responseRoleMin,
+                $settings['daily_digest_enabled'],
                 $settings['finance_account_id'],
-                $issuesTicket, $eventDate, $eventLocation
+                $issuesTicket,
+                $eventDate,
+                $eventLocation
             );
         }
 
@@ -277,14 +293,30 @@ class FormService
 
             if ($field['id'] !== null && in_array($field['id'], $existingIds, true)) {
                 $this->fieldRepository->update(
-                    $field['id'], $index, $field['field_type'], $label, $isRequired,
-                    $optionsSource, $optionsManual, $capacityMax, $pricePerUnit, $confirmationText
+                    $field['id'],
+                    $index,
+                    $field['field_type'],
+                    $label,
+                    $isRequired,
+                    $optionsSource,
+                    $optionsManual,
+                    $capacityMax,
+                    $pricePerUnit,
+                    $confirmationText
                 );
                 $incomingIds[] = $field['id'];
             } else {
                 $incomingIds[] = $this->fieldRepository->create(
-                    $formId, $index, $field['field_type'], $label, $isRequired,
-                    $optionsSource, $optionsManual, $capacityMax, $pricePerUnit, $confirmationText
+                    $formId,
+                    $index,
+                    $field['field_type'],
+                    $label,
+                    $isRequired,
+                    $optionsSource,
+                    $optionsManual,
+                    $capacityMax,
+                    $pricePerUnit,
+                    $confirmationText
                 );
             }
         }
@@ -296,10 +328,12 @@ class FormService
 
     private function normalizeResponseLimit(string $value): string
     {
-        return in_array($value,
+        return in_array(
+            $value,
             [NewsForm::RESPONSE_LIMIT_UNLIMITED, NewsForm::RESPONSE_LIMIT_ONE_PER_ACCOUNT,
                 NewsForm::RESPONSE_LIMIT_ONE_PER_MEMBER],
-            true)
+            true
+        )
             ? $value
             : NewsForm::RESPONSE_LIMIT_UNLIMITED;
     }

--- a/modules/news/src/Service/ResponseColumns.php
+++ b/modules/news/src/Service/ResponseColumns.php
@@ -85,8 +85,12 @@ class ResponseColumns
 
         if ($this->hasPayment($fields)) {
             $columns[] = new ResponseColumn(self::AMOUNT_DUE, 'amount_due', null, ResponseColumn::KIND_AMOUNT_DUE);
-            $columns[] = new ResponseColumn(self::AMOUNT_RECEIVED, 'amount_received', null,
-                ResponseColumn::KIND_AMOUNT_RECEIVED);
+            $columns[] = new ResponseColumn(
+                self::AMOUNT_RECEIVED,
+                'amount_received',
+                null,
+                ResponseColumn::KIND_AMOUNT_RECEIVED
+            );
             $columns[] = new ResponseColumn(self::STRUCTURED_COMMUNICATION, 'structured_communication');
             $columns[] = new ResponseColumn(self::PAYMENT_STATUS, 'payment_status');
         }

--- a/modules/news/src/Service/ResponseService.php
+++ b/modules/news/src/Service/ResponseService.php
@@ -132,8 +132,11 @@ class ResponseService
         }
 
         $qrPng = $this->sepaQrCode->generatePng(
-            $account['holder_name'] ?? $this->siteName, $account['iban'], null,
-            (int) round($total * 100), $response->structuredCommunication
+            $account['holder_name'] ?? $this->siteName,
+            $account['iban'],
+            null,
+            (int) round($total * 100),
+            $response->structuredCommunication
         );
 
         return [
@@ -373,14 +376,23 @@ class ResponseService
             if ($total > 0.0 && $form->financeAccountId !== null && $this->isPaymentAvailable()) {
                 $structuredCommunication = $this->structuredCommunication->generate();
                 $receivableId = $this->expectedReceivable->createReceivable(
-                    'news', $form->id, $form->financeAccountId, (int) round($total * 100),
-                    $structuredCommunication, $contactEmail
+                    'news',
+                    $form->id,
+                    $form->financeAccountId,
+                    (int) round($total * 100),
+                    $structuredCommunication,
+                    $contactEmail
                 );
             }
 
             $responseId = $this->responseRepository->create(
-                $form->id, $userAccountId, $memberYearId, $contactEmail,
-                $normalizedAnswers, $structuredCommunication, $receivableId
+                $form->id,
+                $userAccountId,
+                $memberYearId,
+                $contactEmail,
+                $normalizedAnswers,
+                $structuredCommunication,
+                $receivableId
             );
 
             foreach ($fields as $field) {
@@ -409,7 +421,9 @@ class ResponseService
                 $this->ticketService->issueFor($this->responseRepository->findById($responseId));
             } catch (NewsException $e) {
                 $this->journalService?->log(
-                    'news', 'ticket_reference_failed', 'info',
+                    'news',
+                    'ticket_reference_failed',
+                    'info',
                     'Échec de la génération de la référence de billet pour une réponse de formulaire',
                     ['article_id' => $article->id, 'form_id' => $form->id, 'response_id' => $responseId],
                     $userAccountId
@@ -431,7 +445,9 @@ class ResponseService
             $this->journalService?->log(
                 // 'warning' isn't a valid event_log.level (only 'info'/
                 // 'security' — see JournalService::log()'s docblock).
-                'news', 'confirmation_email_failed', 'info',
+                'news',
+                'confirmation_email_failed',
+                'info',
                 'Échec de l\'envoi de l\'email de confirmation pour une réponse de formulaire',
                 ['article_id' => $article->id, 'form_id' => $form->id, 'response_id' => $response->id],
                 $response->userAccountId
@@ -572,13 +588,17 @@ class ResponseService
             // submission, but the server is the only check that actually
             // matters (a JS-disabled or scripted client bypasses HTML5
             // validation entirely).
-            if ($field->fieldType === FormField::TYPE_EMAIL && $value !== '' && !filter_var($value,
-                FILTER_VALIDATE_EMAIL)) {
+            if ($field->fieldType === FormField::TYPE_EMAIL && $value !== '' && !filter_var(
+                $value,
+                FILTER_VALIDATE_EMAIL
+            )) {
                 throw new NewsException('Le champ "' . $field->label . '" doit être une adresse email valide.');
             }
 
-            if ($field->fieldType === FormField::TYPE_PHONE && $value !== '' && !preg_match('/^\+?[0-9 .\-()]{6,20}$/',
-                $value)) {
+            if ($field->fieldType === FormField::TYPE_PHONE && $value !== '' && !preg_match(
+                '/^\+?[0-9 .\-()]{6,20}$/',
+                $value
+            )) {
                 throw new NewsException('Le champ "' . $field->label . '" doit être un numéro de téléphone valide.');
             }
 
@@ -688,8 +708,12 @@ class ResponseService
         // the standalone ticket cannot disagree about it.
         if ($ticket !== null && $this->ticketMail !== null) {
             $this->ticketMail->sendWithIcs(
-                $article, $form, $response->contactEmail,
-                $email->subject, $email->bodyHtml, $email->bodyText
+                $article,
+                $form,
+                $response->contactEmail,
+                $email->subject,
+                $email->bodyHtml,
+                $email->bodyText
             );
 
             return;

--- a/modules/news/src/Service/TicketMailService.php
+++ b/modules/news/src/Service/TicketMailService.php
@@ -84,10 +84,13 @@ class TicketMailService
             return;
         }
 
-        $email = $this->emailTemplateRenderer->render('news.ticket', array_merge(
-            ['site_name' => $this->siteName, 'article_title' => $article->title],
-            $this->ticketVariables($form, (string) $response->ticketReference)
-        ));
+        $email = $this->emailTemplateRenderer->render(
+            'news.ticket',
+            array_merge(
+                ['site_name' => $this->siteName, 'article_title' => $article->title],
+                $this->ticketVariables($form, (string) $response->ticketReference)
+            )
+        );
 
         $this->sendWithIcs(
             $article,

--- a/modules/registration/src/Controller/DeparturesController.php
+++ b/modules/registration/src/Controller/DeparturesController.php
@@ -56,8 +56,11 @@ class DeparturesController extends AbstractController
         $email = AuthSession::getEmail() ?? '';
         $effectiveYear = $this->publicYear();
 
-        $staffedSections = $this->sectionStaffAuthorizationService->getStaffedSections($email, AuthSession::getRole(),
-            $effectiveYear->id);
+        $staffedSections = $this->sectionStaffAuthorizationService->getStaffedSections(
+            $email,
+            AuthSession::getRole(),
+            $effectiveYear->id
+        );
 
         if ($staffedSections === []) {
             return $this->render('@registration/departures.html.twig', [

--- a/modules/registration/src/Controller/PassageController.php
+++ b/modules/registration/src/Controller/PassageController.php
@@ -78,13 +78,18 @@ class PassageController extends AbstractController
         $referenceMonthDay = $this->slotService->referenceMonthDay();
 
         $newRegistrations = $this->passageService->getNewRegistrations(
-            (int) $targetYear['id'], (string) $targetYear['label'], $referenceMonthDay, (int) $publicYear['id']
+            (int) $targetYear['id'],
+            (string) $targetYear['label'],
+            $referenceMonthDay,
+            (int) $publicYear['id']
         );
         // Read-only: assigning the obvious single-option destinations is
         // Task\AutoAssignPassageHandler's job now. Doing it here meant a
         // plain GET wrote to the database on every display of the page.
         $branchChanges = $this->passageService->getBranchChanges(
-            (int) $publicYear['id'], (string) $publicYear['label'], (int) $targetYear['id']
+            (int) $publicYear['id'],
+            (string) $publicYear['label'],
+            (int) $targetYear['id']
         );
 
         // IT-17 — what the families answered, beside the decision each
@@ -226,8 +231,11 @@ class PassageController extends AbstractController
             ]);
         }
 
-        $allowedSectionIds = $this->arrivalSectionIdsForMember($memberId, (int) $publicYear['id'],
-            (string) $publicYear['label']);
+        $allowedSectionIds = $this->arrivalSectionIdsForMember(
+            $memberId,
+            (int) $publicYear['id'],
+            (string) $publicYear['label']
+        );
         if (!in_array($submittedSectionId, $allowedSectionIds, true)) {
             return $this->json(
                 ['success' => false, 'error' => "Cette section n'appartient pas à la branche d'arrivée de ce membre."],
@@ -281,8 +289,11 @@ class PassageController extends AbstractController
         $sectionId = (int) ($data['preferred_section_id'] ?? 0);
 
         if ($sectionId !== 0) {
-            $allowed = $this->arrivalSectionIdsForMember($memberId, (int) $publicYear['id'],
-                (string) $publicYear['label']);
+            $allowed = $this->arrivalSectionIdsForMember(
+                $memberId,
+                (int) $publicYear['id'],
+                (string) $publicYear['label']
+            );
             if (!in_array($sectionId, $allowed, true)) {
                 return $this->json(
                     ['success' => false, 'error' => "Cette section n'appartient pas à la branche d'arrivée de ce "

--- a/modules/registration/src/Controller/PublicRegistrationController.php
+++ b/modules/registration/src/Controller/PublicRegistrationController.php
@@ -135,8 +135,11 @@ class PublicRegistrationController extends AbstractController
         if (!$availability['form_available']) {
             return $this->render(
                 '@registration/public.html.twig',
-                $this->buildPageContext('Les inscriptions ne sont pas ouvertes pour le moment.', $request->getBodyAll(),
-                    null)
+                $this->buildPageContext(
+                    'Les inscriptions ne sont pas ouvertes pour le moment.',
+                    $request->getBodyAll(),
+                    null
+                )
             )->setStatusCode(422);
         }
 
@@ -336,8 +339,11 @@ class PublicRegistrationController extends AbstractController
         }
 
         return [
-            'parcours_image_file_id' => (int) $this->settingService->get('registration_parcours_image_file_id',
-                'registration', '0'),
+            'parcours_image_file_id' => (int) $this->settingService->get(
+                'registration_parcours_image_file_id',
+                'registration',
+                '0'
+            ),
             'target_year_label' => $targetLabel,
             'birth_years_by_branch' => $this->slotService->birthYearsByBranch($targetLabel),
             'waitlist_enabled' => $waitlistEnabled,

--- a/modules/registration/src/Controller/ReenrollmentConfigController.php
+++ b/modules/registration/src/Controller/ReenrollmentConfigController.php
@@ -66,10 +66,16 @@ class ReenrollmentConfigController extends AbstractController
 
         return $this->render('@registration/reenrollment_config.html.twig', [
             'is_open' => $this->campaign->isOpen(),
-            'open_at' => (string) $this->settingService->get(ReenrollmentCampaignService::SETTING_OPEN_AT,
-                'registration', ''),
-            'close_at' => (string) $this->settingService->get(ReenrollmentCampaignService::SETTING_CLOSE_AT,
-                'registration', ''),
+            'open_at' => (string) $this->settingService->get(
+                ReenrollmentCampaignService::SETTING_OPEN_AT,
+                'registration',
+                ''
+            ),
+            'close_at' => (string) $this->settingService->get(
+                ReenrollmentCampaignService::SETTING_CLOSE_AT,
+                'registration',
+                ''
+            ),
             'reminder_1_days' => (string) $this->settingService->get(
                 ReenrollmentCampaignService::SETTING_REMINDER_1_DAYS,
                 'registration',
@@ -206,8 +212,10 @@ class ReenrollmentConfigController extends AbstractController
             AuthSession::getUserAccountId()
         );
 
-        FlashMessage::set('success',
-            'Relance programmée : les familles sans réponse la recevront dans quelques minutes.');
+        FlashMessage::set(
+            'success',
+            'Relance programmée : les familles sans réponse la recevront dans quelques minutes.'
+        );
 
         return $this->redirect(self::PAGE_URL);
     }

--- a/modules/registration/src/Controller/RegistrationConfigController.php
+++ b/modules/registration/src/Controller/RegistrationConfigController.php
@@ -571,10 +571,16 @@ class RegistrationConfigController extends AbstractController
                 'registration',
                 '0'
             ) === '1',
-            'scheduled_open_at' => (string) $this->settingService->get('registration_scheduled_open_at', 'registration',
-                ''),
-            'scheduled_close_at' => (string) $this->settingService->get('registration_scheduled_close_at',
-                'registration', ''),
+            'scheduled_open_at' => (string) $this->settingService->get(
+                'registration_scheduled_open_at',
+                'registration',
+                ''
+            ),
+            'scheduled_close_at' => (string) $this->settingService->get(
+                'registration_scheduled_close_at',
+                'registration',
+                ''
+            ),
 
             // Waitlist management, surfaced inside the capacity box rather
             // than hidden away in Configuration > Réglages. When it is off,
@@ -586,10 +592,16 @@ class RegistrationConfigController extends AbstractController
                 'registration',
                 '1'
             ) === '1',
-            'threshold_available' => (string) $this->settingService->get(self::SETTING_THRESHOLD_AVAILABLE,
-                'registration', '0.5'),
-            'threshold_limited' => (string) $this->settingService->get(self::SETTING_THRESHOLD_LIMITED, 'registration',
-                '0.1'),
+            'threshold_available' => (string) $this->settingService->get(
+                self::SETTING_THRESHOLD_AVAILABLE,
+                'registration',
+                '0.5'
+            ),
+            'threshold_limited' => (string) $this->settingService->get(
+                self::SETTING_THRESHOLD_LIMITED,
+                'registration',
+                '0.1'
+            ),
             'default_capacity' => SlotService::DEFAULT_CAPACITY,
 
             'selectable_years' => $years['selectable'],

--- a/modules/registration/src/Controller/RegistrationRequestController.php
+++ b/modules/registration/src/Controller/RegistrationRequestController.php
@@ -378,8 +378,10 @@ class RegistrationRequestController extends AbstractController
         $linkedMemberYearId = null;
         if ($registrationRequest->linkedMemberId !== null) {
             $publicYear = $this->scoutYearResolver->getCurrentPublicYear();
-            $memberYear = $this->memberYearRepository->findByMemberAndYear($registrationRequest->linkedMemberId,
-                (int) $publicYear['id']);
+            $memberYear = $this->memberYearRepository->findByMemberAndYear(
+                $registrationRequest->linkedMemberId,
+                (int) $publicYear['id']
+            );
             $linkedMemberYearId = $memberYear['id'] ?? null;
         }
 

--- a/modules/registration/src/Repository/ReenrollmentRepository.php
+++ b/modules/registration/src/Repository/ReenrollmentRepository.php
@@ -300,8 +300,10 @@ class ReenrollmentRepository
             decision: (string) $row['decision'],
             preferredSectionId: $row['preferred_section_id'] !== null ? (int) $row['preferred_section_id'] : null,
             familyComment: $row['family_comment_encrypted'] !== null
-                ? $this->encryption->decrypt($row['family_comment_encrypted'],
-                    'registration_reenrollments.family_comment')
+                ? $this->encryption->decrypt(
+                    $row['family_comment_encrypted'],
+                    'registration_reenrollments.family_comment'
+                )
                 : null,
             answeredAt: DateInput::requireFromStorage((string) $row['answered_at'], 'answered_at'),
             answeredByUserAccountId: $row['answered_by_user_account_id'] !== null

--- a/modules/registration/src/Repository/RegistrationRequestRepository.php
+++ b/modules/registration/src/Repository/RegistrationRequestRepository.php
@@ -59,8 +59,12 @@ class RegistrationRequestRepository
             $fields['birth_date']
         ), 'registration_name_dob');
 
-        $addressNormalized = AddressNormalizer::normalize($fields['street'], $fields['number'], null,
-            $fields['postal_code']);
+        $addressNormalized = AddressNormalizer::normalize(
+            $fields['street'],
+            $fields['number'],
+            null,
+            $fields['postal_code']
+        );
         $addressBlind = $addressNormalized !== '' ? $this->encryption->blindIndex($addressNormalized, 'address') : null;
 
         // The request row and its sibling links are one single unit of work:
@@ -484,8 +488,10 @@ class RegistrationRequestRepository
     public function updateInternalNotes(int $id, ?string $notes): void
     {
         $stmt = $this->pdo->prepare('UPDATE registration_requests SET internal_notes_encrypted = ? WHERE id = ?');
-        $stmt->execute([$notes !== null && $notes !== '' ? $this->encryption->encrypt($notes,
-            'registration_requests.internal_notes') : null,
+        $stmt->execute([$notes !== null && $notes !== '' ? $this->encryption->encrypt(
+            $notes,
+            'registration_requests.internal_notes'
+        ) : null,
             $id]);
     }
 
@@ -613,10 +619,14 @@ class RegistrationRequestRepository
             id: (int) $row['id'],
             scoutYearId: (int) $row['scout_year_id'],
             parentName: $this->encryption->decrypt($row['parent_name_encrypted'], 'registration_requests.parent_name'),
-            childLastName: $this->encryption->decrypt($row['child_last_name_encrypted'],
-                'registration_requests.child_last_name'),
-            childFirstName: $this->encryption->decrypt($row['child_first_name_encrypted'],
-                'registration_requests.child_first_name'),
+            childLastName: $this->encryption->decrypt(
+                $row['child_last_name_encrypted'],
+                'registration_requests.child_last_name'
+            ),
+            childFirstName: $this->encryption->decrypt(
+                $row['child_first_name_encrypted'],
+                'registration_requests.child_first_name'
+            ),
             gender: $this->encryption->decrypt($row['gender_encrypted'], 'registration_requests.gender'),
             birthDate: $this->encryption->decrypt($row['birth_date_encrypted'], 'registration_requests.birth_date'),
             street: $this->encryption->decrypt($row['street_encrypted'], 'registration_requests.street'),

--- a/modules/registration/src/Repository/RegistrationSecondaryEmailRepository.php
+++ b/modules/registration/src/Repository/RegistrationSecondaryEmailRepository.php
@@ -75,8 +75,10 @@ class RegistrationSecondaryEmailRepository
 
     public function findByRequestAndEmail(int $registrationRequestId, string $email): ?RegistrationSecondaryEmail
     {
-        $blindIndex = $this->encryption->blindIndex(RegistrationRequestRepository::normalizeEmail($email),
-            'registration_email');
+        $blindIndex = $this->encryption->blindIndex(
+            RegistrationRequestRepository::normalizeEmail($email),
+            'registration_email'
+        );
         $stmt = $this->pdo->prepare(
             'SELECT * FROM registration_secondary_emails WHERE registration_request_id = ? AND email_blind_index = ?'
         );

--- a/modules/registration/src/Service/ForecastService.php
+++ b/modules/registration/src/Service/ForecastService.php
@@ -284,10 +284,16 @@ class ForecastService
                     ? $this->encryption->decrypt($row['birth_date_encrypted'], 'member_years.birth_date')
                     : null
             );
-            $currentAge = $this->memberYearService->getEffectiveAge($birthYear, (int) $row['scout_year_offset'],
-                $currentReferenceYear);
-            $projectedAge = $this->memberYearService->getEffectiveAge($birthYear, (int) $row['scout_year_offset'],
-                $targetReferenceYear);
+            $currentAge = $this->memberYearService->getEffectiveAge(
+                $birthYear,
+                (int) $row['scout_year_offset'],
+                $currentReferenceYear
+            );
+            $projectedAge = $this->memberYearService->getEffectiveAge(
+                $birthYear,
+                (int) $row['scout_year_offset'],
+                $targetReferenceYear
+            );
 
             // The decisive question is where they land NEXT year, never
             // where they sit today — a member held back by scout_year_offset
@@ -365,8 +371,12 @@ class ForecastService
         // section prévue (or "non attribués" when none is chosen). Never
         // 'encoded' requests (see class docblock) — the double-counting
         // guard is structural, not a runtime check.
-        $newRegistrations = $this->passageService->getNewRegistrations($targetYearId, $targetYearLabel,
-            $referenceMonthDay, $currentYearId);
+        $newRegistrations = $this->passageService->getNewRegistrations(
+            $targetYearId,
+            $targetYearLabel,
+            $referenceMonthDay,
+            $currentYearId
+        );
         foreach ($newRegistrations as $row) {
             $request = $row['request'];
 
@@ -471,8 +481,10 @@ class ForecastService
      */
     private function resolveBranchColorBySortOrder(int $sortOrder, array $allSections): string
     {
-        $branchSections = array_values(array_filter($allSections,
-            static fn(array $s) => $s['branch_sort_order'] === $sortOrder));
+        $branchSections = array_values(array_filter(
+            $allSections,
+            static fn(array $s) => $s['branch_sort_order'] === $sortOrder
+        ));
         if ($branchSections === []) {
             return MemberYearService::colorForBranchSortOrder($sortOrder);
         }
@@ -670,8 +682,11 @@ class ForecastService
             if ($row['birth_year'] !== null) {
                 $pyramid[$row['birth_year']] ??= ['male' => 0, 'female' => 0, 'other' => 0];
                 $pyramid[$row['birth_year']][$row['gender']]++;
-                $pyramidMax = max($pyramidMax, $pyramid[$row['birth_year']]['male'],
-                    $pyramid[$row['birth_year']]['female']);
+                $pyramidMax = max(
+                    $pyramidMax,
+                    $pyramid[$row['birth_year']]['male'],
+                    $pyramid[$row['birth_year']]['female']
+                );
             }
 
             // Every row that cannot land in a real section row is tallied

--- a/modules/registration/src/Service/PassageService.php
+++ b/modules/registration/src/Service/PassageService.php
@@ -93,8 +93,10 @@ class PassageService
             $siblings = $siblingsByRequest[$request->id] ?? [];
 
             $sectionsInBranch = $slot !== null
-                ? array_values(array_filter($sections,
-                    static fn(array $s) => $s['age_branch_id'] === $slot['age_branch_id']))
+                ? array_values(array_filter(
+                    $sections,
+                    static fn(array $s) => $s['age_branch_id'] === $slot['age_branch_id']
+                ))
                 : [];
 
             $rows[] = [
@@ -168,8 +170,11 @@ class PassageService
                     ? $this->encryption->decrypt($row['birth_date_encrypted'], 'member_years.birth_date')
                     : null
             );
-            $effectiveAge = $memberYearService->getEffectiveAge($birthYear, (int) $row['scout_year_offset'],
-                $referenceYear);
+            $effectiveAge = $memberYearService->getEffectiveAge(
+                $birthYear,
+                (int) $row['scout_year_offset'],
+                $referenceYear
+            );
 
             // Only the last rank of a branch changes branch at all (and a
             // last-year Pionnier "ne passe nulle part") — one single

--- a/modules/registration/src/Service/RegistrationMenuHookService.php
+++ b/modules/registration/src/Service/RegistrationMenuHookService.php
@@ -39,8 +39,10 @@ class RegistrationMenuHookService implements MenuEntryProvider
             return [];
         }
 
-        $retentionMonths = (int) ($this->settingService->get('registration_espace_animes_retention_months',
-            'registration') ?: 3);
+        $retentionMonths = (int) ($this->settingService->get(
+            'registration_espace_animes_retention_months',
+            'registration'
+        ) ?: 3);
         $now = new \DateTimeImmutable();
 
         $entries = [];
@@ -78,8 +80,11 @@ class RegistrationMenuHookService implements MenuEntryProvider
             return false;
         }
 
-        if (in_array($request->status, [RegistrationRequest::STATUS_REFUSED, RegistrationRequest::STATUS_WITHDRAWN],
-            true)
+        if (in_array(
+            $request->status,
+            [RegistrationRequest::STATUS_REFUSED, RegistrationRequest::STATUS_WITHDRAWN],
+            true
+        )
             && $request->finalAt !== null
         ) {
             return $now < $request->finalAt->modify("+{$retentionMonths} months");

--- a/modules/registration/src/Service/RequestEmailService.php
+++ b/modules/registration/src/Service/RequestEmailService.php
@@ -64,8 +64,11 @@ class RequestEmailService
         $this->repository->markAcceptedEmailSent($request->id);
 
         $this->journalService->log(
-            'registration', 'registration_accepted_email_sent', 'info',
-            "Email d'acceptation envoyé", ['request_id' => $request->id]
+            'registration',
+            'registration_accepted_email_sent',
+            'info',
+            "Email d'acceptation envoyé",
+            ['request_id' => $request->id]
         );
     }
 
@@ -82,8 +85,11 @@ class RequestEmailService
         $this->repository->markRefusedEmailSent($request->id);
 
         $this->journalService->log(
-            'registration', 'registration_refused_email_sent', 'info',
-            'Email de refus envoyé', ['request_id' => $request->id]
+            'registration',
+            'registration_refused_email_sent',
+            'info',
+            'Email de refus envoyé',
+            ['request_id' => $request->id]
         );
     }
 
@@ -124,8 +130,12 @@ class RequestEmailService
         ]);
 
         try {
-            $this->mailService->send(to: $request->email, subject: $subject, bodyHtml: $body,
-                bodyText: self::toPlainText($body));
+            $this->mailService->send(
+                to: $request->email,
+                subject: $subject,
+                bodyHtml: $body,
+                bodyText: self::toPlainText($body)
+            );
         } catch (MailException $e) {
             // Nothing was written: the previous tracking link still works and
             // *_email_sent_at is untouched, so retrying really is free. Worth

--- a/modules/registration/src/Service/SecondaryEmailService.php
+++ b/modules/registration/src/Service/SecondaryEmailService.php
@@ -77,7 +77,10 @@ class SecondaryEmailService
         $this->sendConfirmationEmail($created->id, $normalized, $rawToken);
 
         $this->journalService->log(
-            'registration', 'registration_secondary_email_added', 'info', 'Adresse email secondaire ajoutée',
+            'registration',
+            'registration_secondary_email_added',
+            'info',
+            'Adresse email secondaire ajoutée',
             ['request_id' => $requestId, 'secondary_email_id' => $created->id]
         );
 
@@ -93,7 +96,10 @@ class SecondaryEmailService
         $this->repository->delete($emailId);
 
         $this->journalService->log(
-            'registration', 'registration_secondary_email_removed', 'info', 'Adresse email secondaire supprimée',
+            'registration',
+            'registration_secondary_email_removed',
+            'info',
+            'Adresse email secondaire supprimée',
             ['request_id' => $requestId, 'secondary_email_id' => $emailId]
         );
     }
@@ -123,7 +129,10 @@ class SecondaryEmailService
         $this->repository->markValid($emailId);
 
         $this->journalService->log(
-            'registration', 'registration_secondary_email_confirmed', 'info', 'Adresse email secondaire confirmée',
+            'registration',
+            'registration_secondary_email_confirmed',
+            'info',
+            'Adresse email secondaire confirmée',
             ['request_id' => $row->registrationRequestId, 'secondary_email_id' => $emailId]
         );
 
@@ -189,8 +198,12 @@ class SecondaryEmailService
         $email = $this->emailTemplateRenderer->render('registration.secondary_email_confirmation', $context);
 
         try {
-            $this->mailService->send(to: $to, subject: $email->subject, bodyHtml: $email->bodyHtml,
-                bodyText: $email->bodyText);
+            $this->mailService->send(
+                to: $to,
+                subject: $email->subject,
+                bodyHtml: $email->bodyHtml,
+                bodyText: $email->bodyText
+            );
         } catch (MailException) {
             // Best-effort, same rationale as the module's other emails —
             // the row is kept either way so the parent can be re-sent one.

--- a/modules/registration/src/Service/SlotService.php
+++ b/modules/registration/src/Service/SlotService.php
@@ -82,8 +82,11 @@ class SlotService
         $seeded = 0;
         foreach ($this->ageBracketRepository->findAllOrdered() as $bracket) {
             for ($yearInBranch = 1; $yearInBranch <= $bracket->durationYears; $yearInBranch++) {
-                if ($this->slotCapacityRepository->insertIfMissing($bracket->ageBranchId, $yearInBranch,
-                    self::DEFAULT_CAPACITY)) {
+                if ($this->slotCapacityRepository->insertIfMissing(
+                    $bracket->ageBranchId,
+                    $yearInBranch,
+                    self::DEFAULT_CAPACITY
+                )) {
                     $seeded++;
                 }
             }
@@ -136,10 +139,16 @@ class SlotService
         int $currentScoutYearId
     ): array
     {
-        $availableThreshold = (float) $this->settingService->get('registration_waitlist_threshold_available',
-            'registration', '0.5');
-        $limitedThreshold = (float) $this->settingService->get('registration_waitlist_threshold_limited',
-            'registration', '0.1');
+        $availableThreshold = (float) $this->settingService->get(
+            'registration_waitlist_threshold_available',
+            'registration',
+            '0.5'
+        );
+        $limitedThreshold = (float) $this->settingService->get(
+            'registration_waitlist_threshold_limited',
+            'registration',
+            '0.1'
+        );
 
         $brackets = $this->ageBracketRepository->findAllOrdered();
         $capacities = $this->slotCapacityRepository->findAllAsMap();
@@ -278,10 +287,16 @@ class SlotService
         int $currentScoutYearId
     ): array
     {
-        $availableThreshold = (float) $this->settingService->get('registration_waitlist_threshold_available',
-            'registration', '0.5');
-        $limitedThreshold = (float) $this->settingService->get('registration_waitlist_threshold_limited',
-            'registration', '0.1');
+        $availableThreshold = (float) $this->settingService->get(
+            'registration_waitlist_threshold_available',
+            'registration',
+            '0.5'
+        );
+        $limitedThreshold = (float) $this->settingService->get(
+            'registration_waitlist_threshold_limited',
+            'registration',
+            '0.1'
+        );
 
         $brackets = $this->ageBracketRepository->findAllOrdered();
         $capacities = $this->slotCapacityRepository->findAllAsMap();
@@ -311,8 +326,12 @@ class SlotService
                     'projected' => $projectedCount,
                     'accepted' => $acceptedCount,
                     'remaining' => $remaining,
-                    'tier' => SlotMath::tierForRemaining($capacity, $remaining ?? 0, $availableThreshold,
-                        $limitedThreshold),
+                    'tier' => SlotMath::tierForRemaining(
+                        $capacity,
+                        $remaining ?? 0,
+                        $availableThreshold,
+                        $limitedThreshold
+                    ),
                 ];
             }
         }

--- a/modules/registration/src/Service/TrackingService.php
+++ b/modules/registration/src/Service/TrackingService.php
@@ -51,8 +51,10 @@ class TrackingService
      */
     public function isLinkedByEmail(int $requestId, string $email): bool
     {
-        $blindIndex = $this->encryption->blindIndex(RegistrationRequestRepository::normalizeEmail($email),
-            'registration_email');
+        $blindIndex = $this->encryption->blindIndex(
+            RegistrationRequestRepository::normalizeEmail($email),
+            'registration_email'
+        );
 
         foreach ($this->requestRepository->findAllByEmailBlindIndex($blindIndex) as $request) {
             if ($request->id === $requestId) {
@@ -76,8 +78,10 @@ class TrackingService
      */
     public function findAllLinkedByEmail(string $email): array
     {
-        $blindIndex = $this->encryption->blindIndex(RegistrationRequestRepository::normalizeEmail($email),
-            'registration_email');
+        $blindIndex = $this->encryption->blindIndex(
+            RegistrationRequestRepository::normalizeEmail($email),
+            'registration_email'
+        );
 
         $all = $this->requestRepository->findAllByEmailBlindIndex($blindIndex);
         $seenIds = array_map(static fn(RegistrationRequest $r) => $r->id, $all);

--- a/modules/registration/src/Task/PurgeRegistrationRequestsHandler.php
+++ b/modules/registration/src/Task/PurgeRegistrationRequestsHandler.php
@@ -56,7 +56,11 @@ class PurgeRegistrationRequestsHandler implements TaskHandlerInterface
         }
 
         $schedulerService = new SchedulerService(new SchedulerRepository($pdo));
-        $schedulerService->rearmAfter('registration', 'purge_registration_requests', self::REFERENCE,
-            self::INTERVAL_SECONDS);
+        $schedulerService->rearmAfter(
+            'registration',
+            'purge_registration_requests',
+            self::REFERENCE,
+            self::INTERVAL_SECONDS
+        );
     }
 }

--- a/modules/registration/src/Task/ReenrollmentCampaignHandler.php
+++ b/modules/registration/src/Task/ReenrollmentCampaignHandler.php
@@ -181,8 +181,10 @@ class ReenrollmentCampaignHandler implements TaskHandlerInterface
             $context->encryption,
             new \Core\Badge\MemberBadgeRepository($pdo)
         );
-        $requestRepository = new \Modules\Registration\Repository\RegistrationRequestRepository($pdo,
-            $context->encryption);
+        $requestRepository = new \Modules\Registration\Repository\RegistrationRequestRepository(
+            $pdo,
+            $context->encryption
+        );
 
         return new ReenrollmentCampaignService(
             $context->settings,

--- a/modules/rental/src/Availability/AvailabilityCalculator.php
+++ b/modules/rental/src/Availability/AvailabilityCalculator.php
@@ -250,21 +250,30 @@ class AvailabilityCalculator
         }
 
         if ($constraints->minNights > 0 && $nights < $constraints->minNights) {
-            $errors[] = sprintf('La durée minimum est de %d nuit%s.', $constraints->minNights,
-                $constraints->minNights > 1 ? 's' : '');
+            $errors[] = sprintf(
+                'La durée minimum est de %d nuit%s.',
+                $constraints->minNights,
+                $constraints->minNights > 1 ? 's' : ''
+            );
         }
 
         if ($constraints->maxNights > 0 && $nights > $constraints->maxNights) {
-            $errors[] = sprintf('La durée maximum est de %d nuit%s.', $constraints->maxNights,
-                $constraints->maxNights > 1 ? 's' : '');
+            $errors[] = sprintf(
+                'La durée maximum est de %d nuit%s.',
+                $constraints->maxNights,
+                $constraints->maxNights > 1 ? 's' : ''
+            );
         }
 
         if ($start < $constraints->earliestArrival($today)) {
             // Deliberately phrased as "too early to ask", never as
             // "unavailable": the asset may well be free.
             $errors[] = $constraints->minNoticeDays > 0
-                ? sprintf('Une demande doit être introduite au moins %d jour%s à l\'avance.',
-                    $constraints->minNoticeDays, $constraints->minNoticeDays > 1 ? 's' : '')
+                ? sprintf(
+                    'Une demande doit être introduite au moins %d jour%s à l\'avance.',
+                    $constraints->minNoticeDays,
+                    $constraints->minNoticeDays > 1 ? 's' : ''
+                )
                 : 'Cette date est déjà passée.';
         }
 
@@ -284,12 +293,24 @@ class AvailabilityCalculator
         if ($units < 1) {
             $errors[] = 'La quantité demandée doit valoir au moins 1.';
         } elseif ($units > $totalUnits) {
-            $errors[] = sprintf('Seul%s %d exemplaire%s existe%s.', $totalUnits > 1 ? 's' : '', $totalUnits,
-                $totalUnits > 1 ? 's' : '', $totalUnits > 1 ? 'nt' : '');
+            $errors[] = sprintf(
+                'Seul%s %d exemplaire%s existe%s.',
+                $totalUnits > 1 ? 's' : '',
+                $totalUnits,
+                $totalUnits > 1 ? 's' : '',
+                $totalUnits > 1 ? 'nt' : ''
+            );
         } elseif (
             $this->daysCoveredByStay($start, $end, $billingUnit) !== []
-            && !$this->isRangeAvailable($start, $end, $units, $totalUnits, $occupancies, $billingUnit,
-                $constraints->bufferNights)
+            && !$this->isRangeAvailable(
+                $start,
+                $end,
+                $units,
+                $totalUnits,
+                $occupancies,
+                $billingUnit,
+                $constraints->bufferNights
+            )
         ) {
             // Says nothing about WHY the period is taken. Skipped outright
             // for a range covering no day: the duration rules above have
@@ -514,7 +535,14 @@ class AvailabilityCalculator
         BillingUnit $billingUnit,
         int $bufferNights = 0
     ): bool {
-        return !$this->isRangeAvailable($arrival, $departure, $units, $totalUnits, $occupancies, $billingUnit,
-            $bufferNights);
+        return !$this->isRangeAvailable(
+            $arrival,
+            $departure,
+            $units,
+            $totalUnits,
+            $occupancies,
+            $billingUnit,
+            $bufferNights
+        );
     }
 }

--- a/modules/rental/src/Controller/RentalConfigController.php
+++ b/modules/rental/src/Controller/RentalConfigController.php
@@ -233,11 +233,14 @@ class RentalConfigController extends AbstractController
             $scoutYearId
         );
 
-        return $this->json(array_map(static fn(MemberDirectoryEntry $entry) => [
-            'id' => $entry->memberId,
-            'label' => $entry->label(),
-            'sublabel' => $entry->sublabel(),
-        ], $matches));
+        return $this->json(array_map(
+            static fn(MemberDirectoryEntry $entry) => [
+                'id' => $entry->memberId,
+                'label' => $entry->label(),
+                'sublabel' => $entry->sublabel(),
+            ],
+            $matches
+        ));
     }
 
     /**

--- a/modules/rental/src/Controller/RentalManagementController.php
+++ b/modules/rental/src/Controller/RentalManagementController.php
@@ -735,7 +735,10 @@ class RentalManagementController extends AbstractController
             // /api/audit/{type}/{id}, which is why the entity type has to be
             // registered in AuditAccessResolver.
             'audit_page' => $this->audit->page(
-                BookingAudit::ENTITY_TYPE, $booking->id, 1, AuditService::DEFAULT_PER_PAGE
+                BookingAudit::ENTITY_TYPE,
+                $booking->id,
+                1,
+                AuditService::DEFAULT_PER_PAGE
             ),
             'audit_labels' => BookingAudit::FIELD_LABELS,
             'change_requests' => $this->changeRequestRepository->findForBooking($booking->id),

--- a/modules/rental/src/Controller/RentalPricingController.php
+++ b/modules/rental/src/Controller/RentalPricingController.php
@@ -320,8 +320,10 @@ class RentalPricingController extends AbstractController
      */
     private function guarded(Request $request, array $params, string $anchor, callable $operation): Response
     {
-        if (($guard = $this->guardCsrf($request,
-            '/mes-locations/' . rawurlencode((string) ($params['slug'] ?? '')) . '/reglages#' . $anchor)) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            '/mes-locations/' . rawurlencode((string) ($params['slug'] ?? '')) . '/reglages#' . $anchor
+        )) !== null) {
             return $guard;
         }
 

--- a/modules/rental/src/Controller/RentalPublicController.php
+++ b/modules/rental/src/Controller/RentalPublicController.php
@@ -121,15 +121,18 @@ class RentalPublicController extends AbstractController
             $selection
         );
 
-        return $this->render('@rental/public/show.html.twig', array_merge(
-            $this->fragmentContext($asset, $request, $today),
-            [
-                'can_manage' => $canManage,
-                'breadcrumb_current' => $asset->name,
-                'constraints' => $constraints,
-                'editable_prefix' => 'rental_asset_' . $asset->id,
-            ]
-        ));
+        return $this->render(
+            '@rental/public/show.html.twig',
+            array_merge(
+                $this->fragmentContext($asset, $request, $today),
+                [
+                    'can_manage' => $canManage,
+                    'breadcrumb_current' => $asset->name,
+                    'constraints' => $constraints,
+                    'editable_prefix' => 'rental_asset_' . $asset->id,
+                ]
+            )
+        );
     }
 
     /**

--- a/modules/rental/src/Controller/RentalRequestController.php
+++ b/modules/rental/src/Controller/RentalRequestController.php
@@ -364,8 +364,10 @@ class RentalRequestController extends AbstractController
      */
     public function requestChange(Request $request, array $params): Response
     {
-        if (($guard = $this->guardCsrf($request,
-            '/locations/suivi/' . (int) ($params['id'] ?? 0) . '/' . (string) ($params['token'] ?? ''))) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            '/locations/suivi/' . (int) ($params['id'] ?? 0) . '/' . (string) ($params['token'] ?? '')
+        )) !== null) {
             return $guard;
         }
 
@@ -420,8 +422,10 @@ class RentalRequestController extends AbstractController
      */
     public function decideProposal(Request $request, array $params): Response
     {
-        if (($guard = $this->guardCsrf($request,
-            '/locations/suivi/' . (int) ($params['id'] ?? 0) . '/' . (string) ($params['token'] ?? ''))) !== null) {
+        if (($guard = $this->guardCsrf(
+            $request,
+            '/locations/suivi/' . (int) ($params['id'] ?? 0) . '/' . (string) ($params['token'] ?? '')
+        )) !== null) {
             return $guard;
         }
 

--- a/modules/rental/src/Mail/BookingChoiceByModel.php
+++ b/modules/rental/src/Mail/BookingChoiceByModel.php
@@ -76,8 +76,11 @@ class BookingChoiceByModel
         try {
             $response = $this->llm->complete(new LlmRequest(
                 tier: LlmTier::CHEAP,
-                prompt: "Réservations possibles :\n" . $list . "\nMessage :\n" . mb_substr($text, 0,
-                    self::MAX_PROMPT_CHARS),
+                prompt: "Réservations possibles :\n" . $list . "\nMessage :\n" . mb_substr(
+                    $text,
+                    0,
+                    self::MAX_PROMPT_CHARS
+                ),
                 systemPrompt: self::SYSTEM_PROMPT,
                 responseSchema: [
                     'type' => 'object',

--- a/modules/rental/src/Mail/RentalMessageConsumer.php
+++ b/modules/rental/src/Mail/RentalMessageConsumer.php
@@ -413,8 +413,11 @@ class RentalMessageConsumer implements
      */
     private static function isAlive(RentalBooking $booking): bool
     {
-        return !in_array($booking->status, [BookingStatus::REFUSED, BookingStatus::CANCELLED, BookingStatus::EXPIRED],
-            true);
+        return !in_array(
+            $booking->status,
+            [BookingStatus::REFUSED, BookingStatus::CANCELLED, BookingStatus::EXPIRED],
+            true
+        );
     }
 
     /**

--- a/modules/rental/src/Reminder/ReminderPlanner.php
+++ b/modules/rental/src/Reminder/ReminderPlanner.php
@@ -73,11 +73,16 @@ class ReminderPlanner
         // ── While the request is still being handled ──────────────────
         if ($booking->status === BookingStatus::RECEIVED) {
             if ($booking->receivedAt <= $today->modify('-' . self::UNANSWERED_AFTER_DAYS . ' days')) {
-                $due[] = $this->booking($booking, $asset, ReminderKind::UNANSWERED_REQUEST, sprintf(
-                    'La demande %s attend une réponse depuis %d jours.',
-                    $booking->reference,
-                    self::UNANSWERED_AFTER_DAYS
-                ));
+                $due[] = $this->booking(
+                    $booking,
+                    $asset,
+                    ReminderKind::UNANSWERED_REQUEST,
+                    sprintf(
+                        'La demande %s attend une réponse depuis %d jours.',
+                        $booking->reference,
+                        self::UNANSWERED_AFTER_DAYS
+                    )
+                );
             }
         }
 
@@ -88,10 +93,15 @@ class ReminderPlanner
             && $booking->holdUntil !== null
             && $booking->holdUntil <= $today->modify('+' . self::HOLD_EXPIRING_WITHIN_HOURS . ' hours')
         ) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::HOLD_EXPIRING, sprintf(
-                'Le blocage des dates de %s expire bientôt : les dates redeviendront libres.',
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::HOLD_EXPIRING,
+                sprintf(
+                    'Le blocage des dates de %s expire bientôt : les dates redeviendront libres.',
+                    $booking->reference
+                )
+            );
         }
 
         if ($booking->status !== BookingStatus::CONFIRMED && $booking->status !== BookingStatus::CLOSED) {
@@ -107,41 +117,66 @@ class ReminderPlanner
             && $arrival <= $midnight->modify('+' . self::CONTRACT_MISSING_DAYS_BEFORE . ' days')
             && $arrival >= $midnight
         ) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::CONTRACT_MISSING, sprintf(
-                "Aucun contrat n'a encore été établi pour %s, dont le séjour approche.",
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::CONTRACT_MISSING,
+                sprintf(
+                    "Aucun contrat n'a encore été établi pour %s, dont le séjour approche.",
+                    $booking->reference
+                )
+            );
         }
 
         // The renter's own reminder — email, never the notification centre
         // (§6.29). Sent from the day it comes into range rather than
         // exactly on J-7, so a scheduler that missed a day still sends it.
         if ($arrival <= $midnight->modify('+' . self::PRACTICAL_INFO_DAYS_BEFORE . ' days') && $arrival >= $midnight) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::PRACTICAL_INFO, sprintf(
-                'Votre séjour à %s approche.',
-                $asset->name
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::PRACTICAL_INFO,
+                sprintf(
+                    'Votre séjour à %s approche.',
+                    $asset->name
+                )
+            );
         }
 
         if (!$inventory['arrival'] && $midnight >= $arrival && $midnight <= $departure) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::ARRIVAL_INVENTORY, sprintf(
-                "L'état des lieux d'entrée de %s n'a pas été enregistré.",
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::ARRIVAL_INVENTORY,
+                sprintf(
+                    "L'état des lieux d'entrée de %s n'a pas été enregistré.",
+                    $booking->reference
+                )
+            );
         }
 
         if (!$inventory['departure'] && $midnight > $departure) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::DEPARTURE_INVENTORY, sprintf(
-                "L'état des lieux de sortie de %s n'a pas été enregistré.",
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::DEPARTURE_INVENTORY,
+                sprintf(
+                    "L'état des lieux de sortie de %s n'a pas été enregistré.",
+                    $booking->reference
+                )
+            );
         }
 
         if (!$hasSettlement && $midnight >= $departure->modify('+' . self::SETTLEMENT_AFTER_DAYS . ' days')) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::SETTLEMENT_DUE, sprintf(
-                'Le décompte final de %s reste à établir.',
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::SETTLEMENT_DUE,
+                sprintf(
+                    'Le décompte final de %s reste à établir.',
+                    $booking->reference
+                )
+            );
         }
 
         return $due;
@@ -167,18 +202,28 @@ class ReminderPlanner
 
         $depositDue = self::dateOrNull($payment['deposit_due_date'] ?? null);
         if ($depositDue !== null && $depositDue < $midnight && ($payment['deposit_received'] ?? false) !== true) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::DEPOSIT_MISSING, sprintf(
-                "L'acompte de %s n'a pas été reçu à la date prévue.",
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::DEPOSIT_MISSING,
+                sprintf(
+                    "L'acompte de %s n'a pas été reçu à la date prévue.",
+                    $booking->reference
+                )
+            );
         }
 
         $balanceDue = self::dateOrNull($payment['balance_due_date'] ?? null);
         if ($balanceDue !== null && $balanceDue < $midnight && ($payment['fully_paid'] ?? false) !== true) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::BALANCE_MISSING, sprintf(
-                "Le solde de %s n'a pas été reçu à la date prévue.",
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::BALANCE_MISSING,
+                sprintf(
+                    "Le solde de %s n'a pas été reçu à la date prévue.",
+                    $booking->reference
+                )
+            );
         }
 
         $security = is_array($payment['security_deposit'] ?? null) ? $payment['security_deposit'] : [];
@@ -191,10 +236,15 @@ class ReminderPlanner
             && $securityAmount !== null
             && $securityReceived < (int) $securityAmount
         ) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::SECURITY_DEPOSIT_MISSING, sprintf(
-                "La caution de %s n'a pas été reçue à la date prévue.",
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::SECURITY_DEPOSIT_MISSING,
+                sprintf(
+                    "La caution de %s n'a pas été reçue à la date prévue.",
+                    $booking->reference
+                )
+            );
         }
 
         // A security deposit still held some time after the stay. The
@@ -205,10 +255,15 @@ class ReminderPlanner
             && ($security['returned_at'] ?? null) === null
             && $midnight >= $departure->modify('+' . self::DEPOSIT_RETURN_AFTER_DAYS . ' days')
         ) {
-            $due[] = $this->booking($booking, $asset, ReminderKind::SECURITY_DEPOSIT_TO_RETURN, sprintf(
-                'La caution de %s est toujours détenue par l\'unité.',
-                $booking->reference
-            ));
+            $due[] = $this->booking(
+                $booking,
+                $asset,
+                ReminderKind::SECURITY_DEPOSIT_TO_RETURN,
+                sprintf(
+                    'La caution de %s est toujours détenue par l\'unité.',
+                    $booking->reference
+                )
+            );
         }
 
         return $due;

--- a/modules/rental/src/Repository/RentalBookingRepository.php
+++ b/modules/rental/src/Repository/RentalBookingRepository.php
@@ -872,8 +872,10 @@ class RentalBookingRepository
             renterName: $this->encryption->decrypt((string) $row['renter_name_encrypted'], self::CTX_NAME),
             renterEmail: $this->encryption->decrypt((string) $row['renter_email_encrypted'], self::CTX_EMAIL),
             renterPhone: $this->decryptOptional($row['renter_phone_encrypted'] ?? null, self::CTX_PHONE),
-            renterOrganisation: $this->decryptOptional($row['renter_organisation_encrypted'] ?? null,
-                self::CTX_ORGANISATION),
+            renterOrganisation: $this->decryptOptional(
+                $row['renter_organisation_encrypted'] ?? null,
+                self::CTX_ORGANISATION
+            ),
             purpose: $this->decryptOptional($row['purpose_encrypted'] ?? null, self::CTX_PURPOSE),
             renterComment: $this->decryptOptional($row['renter_comment_encrypted'] ?? null, self::CTX_COMMENT),
             status: BookingStatus::tryFrom((string) $row['status']) ?? BookingStatus::RECEIVED,

--- a/modules/rental/src/Service/RentalBookingMailService.php
+++ b/modules/rental/src/Service/RentalBookingMailService.php
@@ -557,14 +557,17 @@ class RentalBookingMailService
         array $context
     ): RenderedEmail
     {
-        $email = $this->emailTemplateRenderer->render($templateId, $context + [
-            'reference' => $booking->reference,
-            'asset_name' => $asset->name,
-            'renter_name' => $booking->renterName,
-            'arrival_date' => self::dateFr($booking->arrivalDate),
-            'departure_date' => self::dateFr($booking->departureDate),
-            'site_name' => $this->settingService->get('site_name') ?: 'Notre unité',
-        ]);
+        $email = $this->emailTemplateRenderer->render(
+            $templateId,
+            $context + [
+                'reference' => $booking->reference,
+                'asset_name' => $asset->name,
+                'renter_name' => $booking->renterName,
+                'arrival_date' => self::dateFr($booking->arrivalDate),
+                'departure_date' => self::dateFr($booking->departureDate),
+                'site_name' => $this->settingService->get('site_name') ?: 'Notre unité',
+            ]
+        );
 
         return new RenderedEmail(
             subject: $this->subjectFor($booking, $email->subject),

--- a/modules/rental/src/Service/RentalCommunicationService.php
+++ b/modules/rental/src/Service/RentalCommunicationService.php
@@ -281,8 +281,11 @@ class RentalCommunicationService
         }
 
         $target = $this->bookingRepository->findById($targetBookingId);
-        if ($target === null || !$this->authorizationService->canManageAssetId($actorEmail, $scoutYearId,
-            $target->assetId)) {
+        if ($target === null || !$this->authorizationService->canManageAssetId(
+            $actorEmail,
+            $scoutYearId,
+            $target->assetId
+        )) {
             // Deliberately the same answer for "no such booking" and "not
             // yours": otherwise this is an oracle for which bookings exist.
             throw new RentalException("Cette réservation n'est pas accessible.");

--- a/modules/rental/src/Service/RentalDocumentService.php
+++ b/modules/rental/src/Service/RentalDocumentService.php
@@ -468,7 +468,10 @@ class RentalDocumentService
     public function delete(RentalDocument $document, ?int $actorMemberId = null): void
     {
         $this->fileRemover->remove(
-            $this->documentRepository, $document->id, $document->fileId, $document->ownsItsFile()
+            $this->documentRepository,
+            $document->id,
+            $document->fileId,
+            $document->ownsItsFile()
         );
 
         $this->journal->log(

--- a/modules/rental/src/Service/RentalOperationsService.php
+++ b/modules/rental/src/Service/RentalOperationsService.php
@@ -730,14 +730,17 @@ class RentalOperationsService
      */
     private function quoteFor(RentalBooking $booking, RentalAsset $asset): PriceQuote
     {
-        return $this->pricingService->quoteForAsset($asset->id, new PricingRequest(
-            arrivalDate: $booking->arrivalDate,
-            departureDate: $booking->departureDate,
-            persons: $booking->estimatedPersons ?? 0,
-            units: $booking->units,
-            rooms: 1,
-            renterCategoryId: $booking->renterCategoryId
-        ));
+        return $this->pricingService->quoteForAsset(
+            $asset->id,
+            new PricingRequest(
+                arrivalDate: $booking->arrivalDate,
+                departureDate: $booking->departureDate,
+                persons: $booking->estimatedPersons ?? 0,
+                units: $booking->units,
+                rooms: 1,
+                renterCategoryId: $booking->renterCategoryId
+            )
+        );
     }
 
     /**

--- a/modules/retro/src/Controller/RetroBoardController.php
+++ b/modules/retro/src/Controller/RetroBoardController.php
@@ -146,15 +146,22 @@ class RetroBoardController extends AbstractController
             ? $this->voteService->remainingBudget($board, $voterIdentifier)
             : null;
         $votedCommentIds = $voterIdentifier !== null
-            ? $this->voteService->votedCommentIds($board->id, array_map(fn(Comment $c) => $c->id, $comments),
-                $voterIdentifier)
+            ? $this->voteService->votedCommentIds(
+                $board->id,
+                array_map(fn(Comment $c) => $c->id, $comments),
+                $voterIdentifier
+            )
             : [];
         $votedSet = array_flip($votedCommentIds);
 
         $byColumn = ['good' => [], 'improve' => [], 'suggestion' => []];
         foreach ($comments as $comment) {
-            $byColumn[$comment->columnKey][] = $this->serializeComment($comment, $isUnitChief, $revealVotes,
-                isset($votedSet[$comment->id]));
+            $byColumn[$comment->columnKey][] = $this->serializeComment(
+                $comment,
+                $isUnitChief,
+                $revealVotes,
+                isset($votedSet[$comment->id])
+            );
         }
 
         return $this->render('@retro/board.html.twig', [
@@ -226,8 +233,11 @@ class RetroBoardController extends AbstractController
         $canVote = $this->canVote($board, $viewerRole);
         $voterIdentifier = $canVote ? $this->resolveVoterIdentifier($request, $board) : null;
         $votedSet = $voterIdentifier !== null
-            ? array_flip($this->voteService->votedCommentIds($board->id, array_map(fn(Comment $c) => $c->id, $comments),
-                $voterIdentifier))
+            ? array_flip($this->voteService->votedCommentIds(
+                $board->id,
+                array_map(fn(Comment $c) => $c->id, $comments),
+                $voterIdentifier
+            ))
             : [];
 
         return $this->json([
@@ -256,8 +266,11 @@ class RetroBoardController extends AbstractController
             return $this->json(['success' => false, 'error' => 'Requête invalide.'], 400);
         }
 
-        $rateLimitHash = $this->rateLimitService->identifierHash((string) $request->getServer('REMOTE_ADDR', ''),
-            $this->readVoterCookie($request), session_id());
+        $rateLimitHash = $this->rateLimitService->identifierHash(
+            (string) $request->getServer('REMOTE_ADDR', ''),
+            $this->readVoterCookie($request),
+            session_id()
+        );
         $moderationMode = $this->resolveModerationMode();
         $acceptedWarning = (bool) ($data['accepted_warning'] ?? false);
 
@@ -325,8 +338,11 @@ class RetroBoardController extends AbstractController
 
         try {
             $this->rateLimitService->checkAndRecord(
-                $this->rateLimitService->identifierHash((string) $request->getServer('REMOTE_ADDR', ''),
-                    $this->readVoterCookie($request), session_id()),
+                $this->rateLimitService->identifierHash(
+                    (string) $request->getServer('REMOTE_ADDR', ''),
+                    $this->readVoterCookie($request),
+                    session_id()
+                ),
                 'shorten'
             );
             $shortened = $this->moderationService->shorten($body, $board->maxCommentLength);
@@ -358,12 +374,14 @@ class RetroBoardController extends AbstractController
         }
 
         try {
-            $this->rateLimitService->checkAndRecord($this->rateLimitService->identifierHash(
-                (string) $request->getServer('REMOTE_ADDR', ''),
-                $this->readVoterCookie($request),
-                session_id()
-            ),
-                'vote');
+            $this->rateLimitService->checkAndRecord(
+                $this->rateLimitService->identifierHash(
+                    (string) $request->getServer('REMOTE_ADDR', ''),
+                    $this->readVoterCookie($request),
+                    session_id()
+                ),
+                'vote'
+            );
             $liked = $this->voteService->toggleLike($board, $comment, $voterIdentifier);
         } catch (RetroException $e) {
             return $this->json(['success' => false, 'error' => $e->getMessage()], 422);
@@ -430,12 +448,14 @@ class RetroBoardController extends AbstractController
 
         try {
             if ($add) {
-                $this->rateLimitService->checkAndRecord($this->rateLimitService->identifierHash(
-                    (string) $request->getServer('REMOTE_ADDR', ''),
-                    $this->readVoterCookie($request),
-                    session_id()
-                ),
-                    'vote');
+                $this->rateLimitService->checkAndRecord(
+                    $this->rateLimitService->identifierHash(
+                        (string) $request->getServer('REMOTE_ADDR', ''),
+                        $this->readVoterCookie($request),
+                        session_id()
+                    ),
+                    'vote'
+                );
                 $remaining = $this->voteService->addPoint($board, $comment, $voterIdentifier);
             } else {
                 $remaining = $this->voteService->removePoint($board, $comment, $voterIdentifier);

--- a/modules/retro/src/Controller/RetroChiefController.php
+++ b/modules/retro/src/Controller/RetroChiefController.php
@@ -66,8 +66,10 @@ class RetroChiefController extends AbstractController
 
         return $this->render('@retro/list.html.twig', [
             'boards' => array_map($toEntry, $this->boardRepository->findUnarchivedOrderedByCreated()),
-            'archived_boards' => array_map($toEntry,
-                $this->boardRepository->findRecentArchived(self::ARCHIVED_BOARDS_SHOWN)),
+            'archived_boards' => array_map(
+                $toEntry,
+                $this->boardRepository->findRecentArchived(self::ARCHIVED_BOARDS_SHOWN)
+            ),
             'archived_total' => $archivedTotal,
             'can_create' => $this->hasRequiredRole('retro_role_min_create_board', 'intendant'),
             'can_close' => $this->hasRequiredRole('retro_role_min_close_board', 'chief'),
@@ -315,8 +317,10 @@ class RetroChiefController extends AbstractController
             'board' => $board,
             'events' => $events,
             'calendar_enabled' => in_array('calendar', $this->moduleManager->getEnabledModuleIds(), true),
-            'default_max_comment_length' => (int) ($this->settingService->get('retro_default_max_comment_length',
-                'retro') ?: 140),
+            'default_max_comment_length' => (int) ($this->settingService->get(
+                'retro_default_max_comment_length',
+                'retro'
+            ) ?: 140),
             'default_vote_budget' => (int) ($this->settingService->get('retro_default_vote_budget', 'retro') ?: 5),
             'public_url' => $board !== null ? $baseUrl . $this->boardService->publicUrl($board) : null,
             // Create-form default only — "the email address is the one

--- a/modules/retro/src/Controller/RetroConfigController.php
+++ b/modules/retro/src/Controller/RetroConfigController.php
@@ -126,8 +126,12 @@ class RetroConfigController extends AbstractController
         $this->settingService->set('retro_moderation_mode', $moderationMode, 'retro');
 
         $this->journalService->log(
-            'retro', 'config_updated', 'info', 'Configuration des rétrospectives modifiée',
-            [], (int) AuthSession::getUserAccountId()
+            'retro',
+            'config_updated',
+            'info',
+            'Configuration des rétrospectives modifiée',
+            [],
+            (int) AuthSession::getUserAccountId()
         );
 
         return $this->redirect('/config/retro');
@@ -160,14 +164,18 @@ class RetroConfigController extends AbstractController
                 'retro_role_min_close_board',
                 'retro'
             ) ?: 'chief'),
-            'retro_default_max_comment_length' => (int) ($this->settingService->get('retro_default_max_comment_length',
-                'retro') ?: 140),
+            'retro_default_max_comment_length' => (int) ($this->settingService->get(
+                'retro_default_max_comment_length',
+                'retro'
+            ) ?: 140),
             'retro_default_vote_budget' => (int) ($this->settingService->get(
                 'retro_default_vote_budget',
                 'retro'
             ) ?: 5),
-            'retro_polling_interval_seconds' => (int) ($this->settingService->get('retro_polling_interval_seconds',
-                'retro') ?: 8),
+            'retro_polling_interval_seconds' => (int) ($this->settingService->get(
+                'retro_polling_interval_seconds',
+                'retro'
+            ) ?: 8),
             'retro_moderation_mode' => (string) ($this->settingService->get(
                 'retro_moderation_mode',
                 'retro'

--- a/modules/retro/src/Service/BoardService.php
+++ b/modules/retro/src/Service/BoardService.php
@@ -125,8 +125,12 @@ class BoardService implements RetroEventLinkLookupInterface
         $windowStart = $today->modify('-' . self::EVENT_WINDOW_DAYS_BEFORE . ' days');
         $windowEnd = $today->modify('+' . self::EVENT_WINDOW_DAYS_AFTER . ' days');
 
-        return $this->calendarEventLookup->findEventsInWindow($windowStart, $windowEnd, $isAdmin ? null : $sectionId,
-            $viewerRole);
+        return $this->calendarEventLookup->findEventsInWindow(
+            $windowStart,
+            $windowEnd,
+            $isAdmin ? null : $sectionId,
+            $viewerRole
+        );
     }
 
     /**
@@ -151,7 +155,12 @@ class BoardService implements RetroEventLinkLookupInterface
     ): Board {
         $title = $this->resolveTitle($calendarEventId, $title, $viewerRole);
         [$title, $voteBudget, $maxCommentLength] = $this->validateCommon(
-            $title, $voteMode, $antiDuplicateMode, $maxCommentLength, $autoCloseDelay, $voteBudget
+            $title,
+            $voteMode,
+            $antiDuplicateMode,
+            $maxCommentLength,
+            $autoCloseDelay,
+            $voteBudget
         );
         $linkVisibility = $this->validateLinkVisibility($linkVisibility);
 
@@ -165,17 +174,37 @@ class BoardService implements RetroEventLinkLookupInterface
         $autoCloseAt = $this->computeAutoCloseAt($autoCloseDelay);
 
         $id = $this->boardRepository->create(
-            $title, $boardDate, $calendarEventId, $token, $shortCode, $listed, $voteMode, $voteBudget,
-            $votesVisible, $antiDuplicateMode, $maxCommentLength, $autoCloseDelay, $autoCloseAt, $createdBy,
-            $closeNotifyEnabled, $this->normalizeEmail($closeNotifyEmail), $linkVisibility
+            $title,
+            $boardDate,
+            $calendarEventId,
+            $token,
+            $shortCode,
+            $listed,
+            $voteMode,
+            $voteBudget,
+            $votesVisible,
+            $antiDuplicateMode,
+            $maxCommentLength,
+            $autoCloseDelay,
+            $autoCloseAt,
+            $createdBy,
+            $closeNotifyEnabled,
+            $this->normalizeEmail($closeNotifyEmail),
+            $linkVisibility
         );
 
         if ($autoCloseAt !== null) {
             $this->scheduleAutoClose($id, $autoCloseAt);
         }
 
-        $this->journalService->log('retro', 'board_created', 'info', 'Rétrospective créée', ['board_id' => $id],
-            $createdBy);
+        $this->journalService->log(
+            'retro',
+            'board_created',
+            'info',
+            'Rétrospective créée',
+            ['board_id' => $id],
+            $createdBy
+        );
 
         $board = $this->boardRepository->findById($id);
         \assert($board !== null);
@@ -211,7 +240,12 @@ class BoardService implements RetroEventLinkLookupInterface
 
         $title = $this->resolveTitle($calendarEventId, $title, $viewerRole);
         [$title, $voteBudget, $maxCommentLength] = $this->validateCommon(
-            $title, $voteMode, $antiDuplicateMode, $maxCommentLength, $autoCloseDelay, $voteBudget
+            $title,
+            $voteMode,
+            $antiDuplicateMode,
+            $maxCommentLength,
+            $autoCloseDelay,
+            $voteBudget
         );
         $linkVisibility = $this->validateLinkVisibility($linkVisibility);
         $boardDate = $this->resolveBoardDate($calendarEventId, $manualDate, $viewerRole);
@@ -223,9 +257,21 @@ class BoardService implements RetroEventLinkLookupInterface
         $autoCloseAt = $this->computeAutoCloseAt($autoCloseDelay);
 
         $this->boardRepository->update(
-            $id, $title, $boardDate, $calendarEventId, $listed, $voteMode, $voteBudget,
-            $votesVisible, $antiDuplicateMode, $maxCommentLength, $autoCloseDelay, $autoCloseAt,
-            $closeNotifyEnabled, $this->normalizeEmail($closeNotifyEmail), $linkVisibility
+            $id,
+            $title,
+            $boardDate,
+            $calendarEventId,
+            $listed,
+            $voteMode,
+            $voteBudget,
+            $votesVisible,
+            $antiDuplicateMode,
+            $maxCommentLength,
+            $autoCloseDelay,
+            $autoCloseAt,
+            $closeNotifyEnabled,
+            $this->normalizeEmail($closeNotifyEmail),
+            $linkVisibility
         );
 
         if ($existing->isOpen()) {
@@ -256,8 +302,14 @@ class BoardService implements RetroEventLinkLookupInterface
 
         $this->boardRepository->close($id);
         $this->schedulerService->cancelPending('retro', 'auto_close_board', 'board_' . $id);
-        $this->journalService->log('retro', 'board_closed', 'info', 'Rétrospective clôturée', ['board_id' => $id],
-            $closedBy);
+        $this->journalService->log(
+            'retro',
+            'board_closed',
+            'info',
+            'Rétrospective clôturée',
+            ['board_id' => $id],
+            $closedBy
+        );
 
         $visible = array_values(array_filter(
             $this->commentRepository->findByBoardId($id),
@@ -307,8 +359,14 @@ class BoardService implements RetroEventLinkLookupInterface
             $this->scheduleAutoClose($id, $autoCloseAt);
         }
 
-        $this->journalService->log('retro', 'board_reopened', 'info', 'Rétrospective réouverte', ['board_id' => $id],
-            $reopenedBy);
+        $this->journalService->log(
+            'retro',
+            'board_reopened',
+            'info',
+            'Rétrospective réouverte',
+            ['board_id' => $id],
+            $reopenedBy
+        );
 
         $refreshed = $this->boardRepository->findById($id);
         \assert($refreshed !== null);
@@ -330,8 +388,14 @@ class BoardService implements RetroEventLinkLookupInterface
         }
 
         $this->boardRepository->archive($id);
-        $this->journalService->log('retro', 'board_archived', 'info', 'Rétrospective archivée', ['board_id' => $id],
-            $archivedBy);
+        $this->journalService->log(
+            'retro',
+            'board_archived',
+            'info',
+            'Rétrospective archivée',
+            ['board_id' => $id],
+            $archivedBy
+        );
 
         $refreshed = $this->boardRepository->findById($id);
         \assert($refreshed !== null);
@@ -353,8 +417,14 @@ class BoardService implements RetroEventLinkLookupInterface
         }
 
         $this->boardRepository->unarchive($id);
-        $this->journalService->log('retro', 'board_unarchived', 'info', 'Rétrospective désarchivée',
-            ['board_id' => $id], $unarchivedBy);
+        $this->journalService->log(
+            'retro',
+            'board_unarchived',
+            'info',
+            'Rétrospective désarchivée',
+            ['board_id' => $id],
+            $unarchivedBy
+        );
 
         $refreshed = $this->boardRepository->findById($id);
         \assert($refreshed !== null);
@@ -379,8 +449,14 @@ class BoardService implements RetroEventLinkLookupInterface
         $shortCode = $this->tryCreateShortLink($token, $regeneratedBy);
         $this->boardRepository->regenerateLink($id, $token, $shortCode);
 
-        $this->journalService->log('retro', 'board_link_regenerated', 'info', 'Lien de rétrospective régénéré',
-            ['board_id' => $id], $regeneratedBy);
+        $this->journalService->log(
+            'retro',
+            'board_link_regenerated',
+            'info',
+            'Lien de rétrospective régénéré',
+            ['board_id' => $id],
+            $regeneratedBy
+        );
 
         $refreshed = $this->boardRepository->findById($id);
         \assert($refreshed !== null);

--- a/modules/retro/src/Service/RateLimitService.php
+++ b/modules/retro/src/Service/RateLimitService.php
@@ -75,8 +75,10 @@ class RateLimitService
         $since = (new \DateTimeImmutable('-' . self::WINDOW_MINUTES . ' minutes'))->format('Y-m-d H:i:s');
 
         if ($this->repository->countSince($identifierHash, $actionType, $since) >= $limit) {
-            throw new RetroException('Trop d\'actions récentes — merci de patienter quelques instants.',
-                RetroException::TYPE_RATE_LIMITED);
+            throw new RetroException(
+                'Trop d\'actions récentes — merci de patienter quelques instants.',
+                RetroException::TYPE_RATE_LIMITED
+            );
         }
 
         $this->repository->record($identifierHash, $actionType);

--- a/modules/retro/src/Task/AutoCloseHandler.php
+++ b/modules/retro/src/Task/AutoCloseHandler.php
@@ -55,8 +55,13 @@ class AutoCloseHandler implements TaskHandlerInterface
         }
 
         $boardRepository->close($boardId);
-        $context->journal->log('retro', 'board_auto_closed', 'info', 'Rétrospective clôturée automatiquement',
-            ['board_id' => $boardId]);
+        $context->journal->log(
+            'retro',
+            'board_auto_closed',
+            'info',
+            'Rétrospective clôturée automatiquement',
+            ['board_id' => $boardId]
+        );
 
         $llmConnector = $context->getOptional(LlmConnectorInterface::class);
         $summaryService = $llmConnector !== null ? new SummaryService($llmConnector) : null;
@@ -70,8 +75,13 @@ class AutoCloseHandler implements TaskHandlerInterface
                     $boardRepository->setAiSummary($boardId, $summary);
                 }
             } catch (RetroException $e) {
-                $context->journal->log('retro', 'board_summary_failed', 'info', 'Échec de la synthèse IA',
-                    ['board_id' => $boardId, 'error' => $e->getMessage()]);
+                $context->journal->log(
+                    'retro',
+                    'board_summary_failed',
+                    'info',
+                    'Échec de la synthèse IA',
+                    ['board_id' => $boardId, 'error' => $e->getMessage()]
+                );
             }
         }
 

--- a/modules/sos_staff/src/Controller/SosAdminController.php
+++ b/modules/sos_staff/src/Controller/SosAdminController.php
@@ -438,8 +438,11 @@ class SosAdminController extends AbstractController
             if (!is_array($cell) || !isset($cell['member_id'], $cell['date'], $cell['state'])) {
                 continue;
             }
-            if (!in_array((string) $cell['state'],
-                [OnCallAssignment::STATE_ONCALL, OnCallAssignment::STATE_UNAVAILABLE], true)) {
+            if (!in_array(
+                (string) $cell['state'],
+                [OnCallAssignment::STATE_ONCALL, OnCallAssignment::STATE_UNAVAILABLE],
+                true
+            )) {
                 continue;
             }
 

--- a/modules/sos_staff/src/Service/OnCallService.php
+++ b/modules/sos_staff/src/Service/OnCallService.php
@@ -106,8 +106,11 @@ class OnCallService
         $lastOfMonth = $firstOfMonth->modify('last day of this month');
 
         $assignments = array_map(
-            fn(array $cell) => new OnCallAssignment((int) $cell['member_id'], (string) $cell['date'],
-                (string) $cell['state']),
+            fn(array $cell) => new OnCallAssignment(
+                (int) $cell['member_id'],
+                (string) $cell['date'],
+                (string) $cell['state']
+            ),
             $cells
         );
         $this->repository->replaceRange($firstOfMonth->format('Y-m-d'), $lastOfMonth->format('Y-m-d'), $assignments);
@@ -224,8 +227,10 @@ class OnCallService
         $lastOfMonth = $firstOfMonth->modify('last day of this month');
         $prevMonthLastDay = $firstOfMonth->modify('-1 day');
 
-        $monthAssignments = $this->repository->findForRange($firstOfMonth->format('Y-m-d'),
-            $lastOfMonth->format('Y-m-d'));
+        $monthAssignments = $this->repository->findForRange(
+            $firstOfMonth->format('Y-m-d'),
+            $lastOfMonth->format('Y-m-d')
+        );
         $byDate = [];
         foreach ($monthAssignments as $assignment) {
             $byDate[$assignment->date][] = $assignment;

--- a/modules/support_dashboard/src/Controller/SupportTicketController.php
+++ b/modules/support_dashboard/src/Controller/SupportTicketController.php
@@ -210,8 +210,11 @@ class SupportTicketController extends AbstractController
             ->setHeader('Content-Type', 'text/plain; charset=utf-8')
             ->setHeader(
                 'Content-Disposition',
-                'attachment; filename="sondes-' . preg_replace('/[^A-Za-z0-9_-]/', '',
-                    (string) ($ticket['reference'] ?? 'ticket')) . '.txt"'
+                'attachment; filename="sondes-' . preg_replace(
+                    '/[^A-Za-z0-9_-]/',
+                    '',
+                    (string) ($ticket['reference'] ?? 'ticket')
+                ) . '.txt"'
             )
             ->setHeader('Content-Length', (string) strlen($report));
     }

--- a/modules/support_dashboard/src/Repository/SupportMailProbeRepository.php
+++ b/modules/support_dashboard/src/Repository/SupportMailProbeRepository.php
@@ -166,8 +166,10 @@ class SupportMailProbeRepository
         $authentication = null;
         if (($row['authentication_encrypted'] ?? null) !== null) {
             $decoded = json_decode(
-                $this->encryption->decrypt((string) $row['authentication_encrypted'],
-                    'support_mail_probes.authentication'),
+                $this->encryption->decrypt(
+                    (string) $row['authentication_encrypted'],
+                    'support_mail_probes.authentication'
+                ),
                 true
             );
             $authentication = is_array($decoded) ? $decoded : null;

--- a/modules/support_dashboard/src/Repository/SupportTicketRepository.php
+++ b/modules/support_dashboard/src/Repository/SupportTicketRepository.php
@@ -604,18 +604,24 @@ class SupportTicketRepository
             'reference' => (string) $row['reference'],
             'installation_id' => (int) $row['installation_id'],
             'category' => TicketCategory::tryFromValue((string) $row['category']),
-            'description' => $this->encryption->decrypt((string) $row['description_encrypted'],
-                'support_tickets.description'),
-            'contact_email' => $this->encryption->decrypt((string) $row['contact_email_encrypted'],
-                'support_tickets.contact_email'),
+            'description' => $this->encryption->decrypt(
+                (string) $row['description_encrypted'],
+                'support_tickets.description'
+            ),
+            'contact_email' => $this->encryption->decrypt(
+                (string) $row['contact_email_encrypted'],
+                'support_tickets.contact_email'
+            ),
             'site_version' => $row['site_version'] !== null ? (string) $row['site_version'] : null,
             'php_version' => $row['php_version'] !== null ? (string) $row['php_version'] : null,
             'status' => (string) $row['status'],
             'created_at' => (string) $row['created_at'],
             'closed_at' => $row['closed_at'] !== null ? (string) $row['closed_at'] : null,
             'resolution_note' => ($row['resolution_note_encrypted'] ?? null) !== null
-                ? $this->encryption->decrypt((string) $row['resolution_note_encrypted'],
-                    'support_tickets.resolution_note')
+                ? $this->encryption->decrypt(
+                    (string) $row['resolution_note_encrypted'],
+                    'support_tickets.resolution_note'
+                )
                 : null,
             'archive_file_id' => ($row['archive_file_id'] ?? null) !== null ? (int) $row['archive_file_id'] : null,
             'archive_received_at' => ($row['archive_received_at'] ?? null) !== null

--- a/modules/support_dashboard/src/Service/SupportDashboardService.php
+++ b/modules/support_dashboard/src/Service/SupportDashboardService.php
@@ -87,8 +87,11 @@ class SupportDashboardService
 
         $pageCount = max(1, (int) ceil(count($filtered) / SupportDashboardFilters::PER_PAGE));
         $page = min($filters->page, $pageCount);
-        $pageRows = array_slice($filtered, ($page - 1) * SupportDashboardFilters::PER_PAGE,
-            SupportDashboardFilters::PER_PAGE);
+        $pageRows = array_slice(
+            $filtered,
+            ($page - 1) * SupportDashboardFilters::PER_PAGE,
+            SupportDashboardFilters::PER_PAGE
+        );
 
         return [
             'rows' => $pageRows,

--- a/modules/trombinoscope/src/Controller/TrombinoscopeController.php
+++ b/modules/trombinoscope/src/Controller/TrombinoscopeController.php
@@ -195,8 +195,10 @@ class TrombinoscopeController extends AbstractController
 
         return (new Response($pdf))
             ->setHeader('Content-Type', 'application/pdf')
-            ->setHeader('Content-Disposition',
-                'attachment; filename="' . $this->pdfService->fileName($effectiveYear->label) . '"')
+            ->setHeader(
+                'Content-Disposition',
+                'attachment; filename="' . $this->pdfService->fileName($effectiveYear->label) . '"'
+            )
             // A document of names and portraits is never kept by a shared
             // cache, and never restored into another session's back
             // button — the header the section roster already sets.

--- a/modules/trombinoscope/src/Service/TrombinoscopePdfService.php
+++ b/modules/trombinoscope/src/Service/TrombinoscopePdfService.php
@@ -185,19 +185,25 @@ class TrombinoscopePdfService
         $layout = (string) realpath(__DIR__ . '/../Pdf/TrombinoscopeHtmlBuilder.php');
         $layoutStat = $layout !== '' ? @stat($layout) : false;
 
-        $signature = hash('sha256', json_encode([
-            $scoutYearId,
-            $yearLabel,
-            $unitName,
-            $siteUrl,
-            $showContacts,
-            array_map(static fn(array $s): array => [
-                (int) $s['id'], $s['name'] ?? null, $s['desk_code'] ?? null, $s['branch_name'] ?? null,
-                $s['color'] ?? null, $s['email'] ?? null, $s['sort_order'] ?? null,
-            ], $sections),
-            $people,
-            $layoutStat !== false ? [$layoutStat['mtime'], $layoutStat['size']] : null,
-        ]));
+        $signature = hash(
+            'sha256',
+            json_encode([
+                $scoutYearId,
+                $yearLabel,
+                $unitName,
+                $siteUrl,
+                $showContacts,
+                array_map(
+                    static fn(array $s): array => [
+                        (int) $s['id'], $s['name'] ?? null, $s['desk_code'] ?? null, $s['branch_name'] ?? null,
+                        $s['color'] ?? null, $s['email'] ?? null, $s['sort_order'] ?? null,
+                    ],
+                    $sections
+                ),
+                $people,
+                $layoutStat !== false ? [$layoutStat['mtime'], $layoutStat['size']] : null,
+            ])
+        );
 
         return $this->cacheDirectory . '/trombinoscope/' . $scoutYearId . '-' . $signature . '.pdf';
     }


### PR DESCRIPTION
## Description

Quatrième lot du solde des anomalies SonarCloud, et le deuxième des quatre qui traitent `php:S1808` : **676 anomalies de mise en forme dans `modules/`**, sur 152 fichiers de vingt modules.

Même règle, même remède et même méthode que pour `core/` ([#311](https://github.com/xdubois-57/scoutmagic/pull/311)) : une liste d'arguments tient **sur une ligne**, ou bien **chaque argument a la sienne**, alignés d'un niveau, parenthèse fermante sur une ligne à elle. La forme intermédiaire que ce dépôt écrivait — quelques arguments sur la ligne d'appel, le reste replié dessous pour tenir sous 120 caractères — est celle que la règle refuse.

```php
-                $due[] = $this->booking($booking, $asset, ReminderKind::HOLD_EXPIRING, sprintf(
-                    'Le blocage des dates de %s expire bientôt : les dates redeviendront libres.',
-                    $booking->reference
-                ));
+                $due[] = $this->booking(
+                    $booking,
+                    $asset,
+                    ReminderKind::HOLD_EXPIRING,
+                    sprintf(
+                        'Le blocage des dates de %s expire bientôt : les dates redeviendront libres.',
+                        $booking->reference
+                    )
+                );
```

### Comment

1. `friendsofphp/php-cs-fixer`, règle `method_argument_space` (`on_multiline: ensure_fully_multiline`) **seule**, couvre 118 fichiers.
2. Les 34 autres sont repris par un script ciblé **sur les seules lignes que SonarCloud signale**, pour les cas que cette règle ne voit pas : ceux où c'est *un argument* qui s'étale sur plusieurs lignes (un `sprintf`, un tableau, une fonction fléchée) plutôt que la liste elle-même. Le script laisse intacte toute liste contenant un heredoc — l'indentation du marqueur de fin y fait partie de la chaîne.

Aucun outil n'entre dans le dépôt : installé hors de l'arbre, utilisé une fois ; `composer.json` et `composer.lock` ne bougent pas.

### Les deux seules lignes réécrites autrement

Indentées d'un niveau de plus, elles dépassaient 120 caractères :

- `CampaignController` : la phrase d'erreur change de point de coupure entre ses deux morceaux concaténés. Le texte produit est identique au caractère près.
- `LeadershipController` : l'appel des anniversaires passe à la ligne sur sa flèche.

Rien d'autre ne change : aucun argument ajouté, retiré ou réordonné, aucune valeur touchée, aucun texte modifié. Les **17 008 tests passent sans qu'un seul ait été retouché**.

Vérifié localement : `vendor/bin/phpstan analyse` (0 erreur), `vendor/bin/phpunit` (17 008 tests, OK), `php -l` sur les 152 fichiers, aucune ligne de plus de 120 caractères.

### La suite

`public/` (542), puis `bootstrap/` + `scripts/` (37 de mise en forme et 185 de nommage `php:S100`). Ce dernier lot pose une question de couverture du code neuf — `bootstrap/bootstrap.php` est mesuré à 0 % et `scripts/` à 27 % — que je poserai avec lui.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] This PR's title and description, and every commit message in it, are in French (`AGENTS.md` § Language)
- [x] Automated tests are written/updated for this change — aucun test n'est nécessaire ni possible pour un changement à comportement nul ; la suite existante non modifiée est ce qui le prouve
- [x] Tests pass locally (`vendor/bin/phpunit`)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [x] If this PR changes `public/assets/js/` behavior: sans objet, aucun fichier JavaScript touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcpzpreZ2NU5kxcdGYdrtE


---
_Generated by [Claude Code](https://claude.ai/code/session_01BcpzpreZ2NU5kxcdGYdrtE)_