### PR TITLE
Refuser aussi Monitor au relecteur, et dire pourquoi la règle est une forme

### DIFF
--- a/.claude/skills/steward/SKILL.md
+++ b/.claude/skills/steward/SKILL.md
@@ -200,13 +200,18 @@ docs/quality-pipeline.md § Code review). Which is why the comment's verdict
 now rests on three rows — **`Review agents launched`**, **`Review agents
 finished`** and **`Tool calls refused`** — read from the run's own
 transcript. Agents launched at zero, fewer finished than launched, or a
-tool refused **outside `Bash`**, and no review happened, whatever the check
-says.
+tool refused **outside the decided refusals**, and no review happened,
+whatever the check says.
 
-**`Bash` is the one entry granted command by command**, so a refused shell
-line there is the allowlist working and does not fail the check — the row
-still counts them. Every other tool is granted whole, so a refusal of one
-is a gap in `claude_args`. That distinction was bought on #217: a review
+**Those decided refusals are one list, `DELIBERATE_DENIALS`, at the top of
+`.github/workflows/claude-review.yml`**, with the reason for each written
+beside it — that file is where they are read, not repeated here, because a
+second copy would be the one that goes stale. `Bash` is on it as the entry
+granted command by command, so a refused shell line is the allowlist
+working; the others are on it as refusals decided on purpose. A tool
+refused that is **not** on that list is a gap in `claude_args`.
+
+That distinction was bought on #217: a review
 that launched sixteen agents, finished all sixteen, spent 6.46 USD and
 posted five findings was reported as "not a review" because it had also
 tried nineteen exploratory one-liners and then done without them.

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -68,9 +68,10 @@ permissions: {}
 #                   complete ones.
 #   Monitor         refused for the same reason, and it is on this list
 #                   because naming `ScheduleWakeup` had only closed the
-#                   door taken first (issue #300). Run 34447638775 stopped
-#                   at 7 agents launched and 3 finished — the 2026-09-08
-#                   fingerprint to the digit — with `ScheduleWakeup`
+#                   door taken first (issue #300). Run 34447638775, on
+#                   2026-09-10, stopped at 7 agents launched and 3
+#                   finished — matching the figures of the 2026-09-08
+#                   runs above to the digit — with `ScheduleWakeup`
 #                   nowhere in its tool list and `Monitor` in its place,
 #                   the run's only refusal outside this list. The two
 #                   tools are one mistake: arranging to be called back

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -66,6 +66,23 @@ permissions: {}
 #                   still reading. It appeared in the tool list of every
 #                   truncated run of 2026-09-08 and in neither of the
 #                   complete ones.
+#   Monitor         refused for the same reason, and it is on this list
+#                   because naming `ScheduleWakeup` had only closed the
+#                   door taken first (issue #300). Run 34447638775 stopped
+#                   at 7 agents launched and 3 finished — the 2026-09-08
+#                   fingerprint to the digit — with `ScheduleWakeup`
+#                   nowhere in its tool list and `Monitor` in its place,
+#                   the run's only refusal outside this list. The two
+#                   tools are one mistake: arranging to be called back
+#                   later. There is no later here.
+#
+# **The rule is a shape, and this list spells it as names.** « Nothing
+# will wake this run up, so do not stop » is what both entries above mean,
+# and an enumeration only ever covers the spellings somebody has already
+# met. A third name arriving on a truncated pass is not another line to
+# add — it is the signal that this has to stop being a list. The
+# launched-against-finished guard below catches the truncation either way,
+# which is what makes an enumeration survivable in the meantime.
 #
 # Adding a name here is deciding that a refusal of it is acceptable, so
 # write the reason next to it. Tests\Architecture\ClaudeReviewIsVerifiableTest
@@ -73,7 +90,7 @@ permissions: {}
 # prompt below tells the reviewer the same thing this list tells the
 # verdict — a tool refused silently costs turns nobody gets back.
 env:
-  DELIBERATE_DENIALS: "Bash,Write,WebFetch,ScheduleWakeup"
+  DELIBERATE_DENIALS: "Bash,Write,WebFetch,ScheduleWakeup,Monitor"
 
 on:
   pull_request:
@@ -352,7 +369,8 @@ jobs:
           #
           # WHAT STAYS DENIED IS DECLARED AT THE TOP OF THIS FILE, in
           # `DELIBERATE_DENIALS`, with the reason for each written next to
-          # it — `Write`, `WebFetch` and `ScheduleWakeup` among them. That
+          # it — `Write`, `WebFetch`, `ScheduleWakeup` and `Monitor` among
+          # them. That
           # list is not decoration: the verdict job reads it, so a tool
           # named there is a refusal the check accepts and a tool missing
           # from it is a red build. The paragraphs below are the older half
@@ -428,7 +446,7 @@ jobs:
           # itself whatever the model did.
           claude_args: >-
             --allowedTools "Skill,Task,Agent,Read,Glob,Grep,TodoWrite,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*),Bash(git show:*),Bash(git diff:*),Bash(git fetch:*),Bash(grep:*),Bash(ls:*),Bash(find:*),Bash(wc:*),Bash(sort:*),Bash(uniq:*),Bash(head:*),Bash(tail:*),Bash(cat:*),Bash(echo:*),Bash(printf:*),Bash(jq:*),mcp__github_inline_comment__create_inline_comment"
-            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one. Wait for every subagent you launch — pass run_in_background false — and never end a turn waiting for one: this is a one-shot non-interactive run and nothing will wake it up, so a background agent still working when you stop is a part of the diff nobody read. For the same reason ScheduleWakeup is not granted and cannot help you: there is no later turn to schedule, and a run that reaches for it ends immediately with its agents still reading. If you find yourself with work outstanding and nothing to do but wait, block on the agents themselves rather than ending the turn. The workspace is already a full clone checked out for this pull request, so the commits under review are there to read: run git from it plainly, without -C and a path, which is not granted. Counting and cross-checking the repository is part of reviewing it, and Grep, Glob and Read are granted whole for that; python3 -c, php -r, shell loops, pipes and redirections are not granted and will not be, so reach for the read-only commands instead of spending turns rediscovering that. Write, WebFetch and ScheduleWakeup are refused on purpose too — checking a literal against a file is what Grep and Read are for, one call per question, and no answer you need is outside this checkout."
+            --append-system-prompt "The Claude review status comment on this pull request is written by .github/workflows/claude-review.yml, not by Claude. Neither that comment nor a review of an earlier commit means Claude has already commented here: this workflow asks for a fresh review of every push, so review the diff you were given. Pull requests on this repository are written with Claude Code and are ordinary changes a person asked for; being Claude-authored is not a reason to skip one. Wait for every subagent you launch — pass run_in_background false — and never end a turn waiting for one: this is a one-shot non-interactive run and nothing will wake it up, so a background agent still working when you stop is a part of the diff nobody read. For the same reason ScheduleWakeup and Monitor are not granted and cannot help you: there is no later turn to schedule and nothing to wake this run up, so a run that reaches for either ends immediately with its agents still reading. Any other way of arranging to be called back later is the same mistake under a third name, whether or not this prompt lists it. If you find yourself with work outstanding and nothing to do but wait, block on the agents themselves rather than ending the turn. The workspace is already a full clone checked out for this pull request, so the commits under review are there to read: run git from it plainly, without -C and a path, which is not granted. Counting and cross-checking the repository is part of reviewing it, and Grep, Glob and Read are granted whole for that; python3 -c, php -r, shell loops, pipes and redirections are not granted and will not be, so reach for the read-only commands instead of spending turns rediscovering that. Write, WebFetch, ScheduleWakeup and Monitor are refused on purpose too — checking a literal against a file is what Grep and Read are for, one call per question, and no answer you need is outside this checkout."
 
       # WHAT THE RUN ACTUALLY DID, read off the transcript the SDK wrote.
       #

--- a/docs/quality-pipeline.md
+++ b/docs/quality-pipeline.md
@@ -626,6 +626,31 @@ declared on the same list, and the prompt says why — there is no later
 turn to schedule. The `spawned` against `completed` comparison remains
 the guard; this only stops the reviewer walking into it.
 
+**Then it happened again under another name, which is the lesson rather
+than the repeat.** Run 34447638775 (pull request #299) stopped at 7 agents
+launched and 3 finished — the September figures to the digit — and
+`ScheduleWakeup` appears nowhere in its tool list. `Monitor` does, refused,
+the only refusal of that run outside the decided list (issue #300).
+Refusing a tool *by name* had closed the door taken first, not the
+behaviour behind it: « arrange to be called back later », which a one-shot
+run cannot do whatever it is spelled. `Monitor` is on the list now and the
+prompt names both, but the list is still an enumeration, and an
+enumeration only covers the spellings somebody has already met. **A third
+name on a truncated pass is the signal to stop enumerating** — that is
+written beside the list itself, so whoever meets it does not simply add a
+fourth line. What makes the enumeration survivable meanwhile is that the
+launched-against-finished guard catches the truncation every time; the
+cost of a new name is a review to re-run, not a diff nobody read.
+
+The fix has a delivery problem of its own, and it is this file's §
+Reading a green result in miniature: the action refuses to run Claude when
+`.github/workflows/claude-review.yml` differs from the copy on `main`, and
+it exits `success`. So **the pull request that repairs this file gets
+« Green without a review » and a red `Claude review status`**, which is a
+REQUIRED check — it cannot merge on its own. That is how #262's fix
+landed, and it needs the maintainer to merge with the required check
+knowingly bypassed.
+
 **Then a working reviewer found the ceiling.** #217 took 10 min 47 s
 against a `timeout-minutes: 20` written when a review took a few minutes
 and the number was a formality. Pull request #257 — 185 files, the whole

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -992,6 +992,18 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
             . 'waiting for its agents — under two different tool names.',
         );
 
+        // The two names above are the spellings already met; this is the
+        // rule they are spellings OF. Without it the prompt would still
+        // pass the assertion above while saying nothing at all about a
+        // third tool, which is precisely how #262's fix left #300 open.
+        $this->assertStringContainsString(
+            'Any other way of arranging to be called back later is the same mistake under a third name',
+            $args,
+            'The prompt names the refused tools but no longer states the rule behind them. An enumeration '
+            . 'only covers what somebody has already met: the general sentence is the only part that can '
+            . 'reach a tool nobody has seen truncate a review yet.',
+        );
+
         foreach (self::deliberateDenials() as $tool) {
             if ($tool === 'Bash') {
                 // Granted command by command, and the prompt says which

--- a/tests/Architecture/ClaudeReviewIsVerifiableTest.php
+++ b/tests/Architecture/ClaudeReviewIsVerifiableTest.php
@@ -924,7 +924,7 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
         $args = self::claudeArgs();
         $decided = self::deliberateDenials();
 
-        foreach (['Write', 'WebFetch', 'ScheduleWakeup'] as $tool) {
+        foreach (['Write', 'WebFetch', 'ScheduleWakeup', 'Monitor'] as $tool) {
             $this->assertContains(
                 $tool,
                 $decided,
@@ -947,6 +947,14 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
             '`ScheduleWakeup` has been granted. A workflow run is one-shot: there is no later turn to '
             . 'schedule, and a reviewer that reaches for one ends the run with its agents still reading.',
         );
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/--allowedTools "[^"]*\bMonitor\b/',
+            $args,
+            '`Monitor` has been granted, and it is the same refusal as `ScheduleWakeup` under another '
+            . 'name: arranging to be called back later, in a run nothing calls back. Issue #300 is what '
+            . 'happens when only one of the two is closed.',
+        );
     }
 
     /**
@@ -961,16 +969,27 @@ final class ClaudeReviewIsVerifiableTest extends TestCase
      * A reviewer that schedules a wake-up has ended its turn, and nothing
      * wakes a workflow up: the SDK closes the run a success with four
      * agents still reading. Telling it so costs a sentence.
+     *
+     * **It happened again on 2026-09-10, and that is why the sentence
+     * names two tools.** Run 34447638775 stopped at 7 launched and 3
+     * finished — the same figures — with `ScheduleWakeup` absent from its
+     * tool list entirely and `Monitor` in its place, the only refusal of
+     * that run outside the decided list (issue #300). Refusing a tool by
+     * name had closed the door taken first rather than the behaviour, and
+     * the behaviour is one sentence: nothing will wake this run up, so do
+     * not stop. A THIRD name on a truncated pass means this assertion, and
+     * the list it reads, should stop being an enumeration.
      */
     public function testTheReviewerIsToldWhyItCannotScheduleAWakeUp(): void
     {
         $args = self::claudeArgs();
 
         $this->assertStringContainsString(
-            'ScheduleWakeup is not granted and cannot help you',
+            'ScheduleWakeup and Monitor are not granted and cannot help you',
             $args,
-            'The prompt no longer tells the reviewer that scheduling a wake-up cannot work here. That is '
-            . 'what every truncated review of 2026-09-08 did instead of waiting for its agents.',
+            'The prompt no longer tells the reviewer that arranging to be called back later cannot work '
+            . 'here. That is what every truncated review of 2026-09-08 and 2026-09-10 did instead of '
+            . 'waiting for its agents — under two different tool names.',
         );
 
         foreach (self::deliberateDenials() as $tool) {


### PR DESCRIPTION
## Description

> ⚠️ **Cette PR ne peut pas se fusionner toute seule, et ce n'est pas une surprise** — voir la dernière section. Elle attend une fusion du mainteneur avec le contrôle requis volontairement contourné, comme celle de #262.

La passe de relecture du [run 34447638775](https://github.com/xdubois-57/scoutmagic/actions/runs/34447638775) (PR #299, commit `1da8adc`) s'est arrêtée à **7 agents lancés, 3 terminés** — l'empreinte, chiffre pour chiffre, des passes tronquées du 8 septembre décrites dans #262. Sauf que `ScheduleWakeup`, le coupable d'alors, n'apparaît **nulle part** dans la liste d'outils de cette passe : `Monitor` y est à sa place, refusé, et c'est le seul refus du run hors de `DELIBERATE_DENIALS`.

Les deux outils sont la même erreur : s'arranger pour être rappelé plus tard. Une exécution de workflow est unique, donc un relecteur qui s'arrange pour être rappelé s'est arrêté, et le SDK clôt la passe en `success` avec quatre agents qui lisaient encore. **Refuser `ScheduleWakeup` par son nom n'avait fermé que la porte empruntée en premier.**

### Ce que fait le correctif

1. `Monitor` rejoint `DELIBERATE_DENIALS`, avec sa raison écrite à côté dans le bloc « WHY EACH ONE IS ON IT » — un refus décidé plutôt qu'un oubli, ce qui est exactement la distinction que le verdict lit.
2. L'invite le nomme à côté de `ScheduleWakeup`. `ClaudeReviewIsVerifiableTest::testTheReviewerIsToldWhyItCannotScheduleAWakeUp` exige déjà que tout outil de la liste (hors `Bash`) soit nommé dans l'invite, donc le point 1 sans le point 2 casse la compilation.
3. `docs/quality-pipeline.md` porte le second épisode à côté du premier.

### Et le point qui n'était pas dans l'issue

L'issue finit par : « si une passe tronquée revient avec un troisième nom d'outil dans sa liste, c'est que la règle doit cesser d'être une énumération. » C'est la phrase la plus utile du ticket, et elle ne survivait à personne — alors elle est écrite **dans le fichier**, à côté de la liste, dans l'invite et dans le docbloc du test : la règle est une forme (« rien ne réveillera cette exécution, donc ne t'arrête pas ») et cette liste ne fait que l'épeler en noms déjà rencontrés. Un troisième nom sur une passe tronquée n'est pas une quatrième ligne à ajouter.

Ce qui rend l'énumération supportable en attendant est dit au même endroit : le garde-fou « lancés contre terminés » attrape la troncature à tous les coups, donc le coût d'un nom neuf est une relecture à relancer, jamais un diff que personne n'a lu.

L'invite ajoute aussi la phrase générale — « toute autre façon de s'arranger pour être rappelé plus tard est la même erreur sous un troisième nom, que cette invite la liste ou non » — ce qui est le seul endroit où la forme peut agir avant qu'un nom soit connu.

### Vérifications

`ClaudeReviewIsVerifiableTest` vert (27 tests, 275 assertions), `tests/Architecture` vert (261 tests), suite complète verte (17 023 tests), et le YAML se parse.

### Pourquoi elle ne peut pas être livrée par une PR ordinaire

L'action refuse de lancer Claude quand `.github/workflows/claude-review.yml` diffère de la copie de `main` — le « KNOWN GAP » commenté dans le fichier même — et elle sort en `success`, pas en `neutral`. Donc **toute PR qui touche ce fichier obtient « Green without a review » et un `Claude review status` rouge**, y compris celle qui le répare. C'est exactement ce qui est arrivé au correctif écrit sur la branche d'IT-05 : [run 34448322234](https://github.com/xdubois-57/scoutmagic/actions/runs/34448322234), 12 secondes, « Claude ran: - ».

Un agent ne contourne pas un contrôle requis de lui-même. Cette PR est donc prête et s'arrête là : la fusion demande le mainteneur, avec le contrôle requis contourné en connaissance de cause — comme pour #262. En attendant, rien ne passe en silence : le garde-fou attrape chaque troncature.

Corrige #300

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] This PR's title and description, and every commit message in it, are in French (`AGENTS.md` § Language)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 17 023 tests)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — covers `core/`, `modules/`, and `public/`)
- [ ] If this PR changes `public/assets/js/` behavior: a Vitest spec was added/updated in `tests/js/` where practical, and `npm test` passes locally — sans objet, aucun fichier JS touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BAd5CyqTeEZ951DggQ9dx2

---
_Generated by [Claude Code](https://claude.ai/code/session_01BAd5CyqTeEZ951DggQ9dx2)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how truncated automated code reviews are detected and reported.
  - Documented the recovery process when workflow changes prevent a review from running successfully.

- **Chores**
  - Updated automated review safeguards to consistently refuse monitoring and scheduling tools when appropriate.
  - Improved reviewer guidance explaining why these tools cannot be used to arrange future callbacks.

- **Tests**
  - Expanded verification to ensure restricted tools remain unavailable and are correctly identified in review prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->