### PR TITLE
Reprendre les listes d'arguments que le premier passage avait laissées

### DIFF
--- a/core/Http/Controller/EmailTemplateController.php
+++ b/core/Http/Controller/EmailTemplateController.php
@@ -299,11 +299,14 @@ class EmailTemplateController extends AbstractController
             // visitor can act on. UserFacingMessage is the helper that
             // decides whether an exception claims to be showable, and
             // this one does not.
-            FlashMessage::set('error', UserFacingMessage::from(
-                $e,
-                "L'envoi de test a échoué — vérifiez la configuration d'envoi du site "
-                    . "(Configuration > Email), puis réessayez."
-            ));
+            FlashMessage::set(
+                'error',
+                UserFacingMessage::from(
+                    $e,
+                    "L'envoi de test a échoué — vérifiez la configuration d'envoi du site "
+                        . "(Configuration > Email), puis réessayez."
+                )
+            );
 
             return $this->redirect($this->editUrl($template->id));
         }

--- a/core/Http/Controller/MemberController.php
+++ b/core/Http/Controller/MemberController.php
@@ -74,15 +74,21 @@ class MemberController extends AbstractController
             Role::fromString($userRole)
         );
 
-        return $this->render('members/show.html.twig', array_merge($pageData, [
-            'member' => $profile,
-            'is_self' => $isSelf,
-            'show_contact' => $isSelf || $isChiefOrAbove,
-            'show_addresses' => $isSelf || $isChiefOrAbove,
-            // Replaces the route's static breadcrumb label ("Membre") with
-            // this member's own display name (partials/breadcrumb_bar.html.twig).
-            'breadcrumb_current' => $profile->getDisplayName(),
-        ]));
+        return $this->render(
+            'members/show.html.twig',
+            array_merge(
+                $pageData,
+                [
+                    'member' => $profile,
+                    'is_self' => $isSelf,
+                    'show_contact' => $isSelf || $isChiefOrAbove,
+                    'show_addresses' => $isSelf || $isChiefOrAbove,
+                    // Replaces the route's static breadcrumb label ("Membre") with
+                    // this member's own display name (partials/breadcrumb_bar.html.twig).
+                    'breadcrumb_current' => $profile->getDisplayName(),
+                ]
+            )
+        );
     }
 
     /**

--- a/core/Http/Controller/MemberEmailAddressController.php
+++ b/core/Http/Controller/MemberEmailAddressController.php
@@ -65,8 +65,11 @@ class MemberEmailAddressController extends AbstractController
         } catch (MemberEmailException $e) {
             FlashMessage::set('error', $e->getMessage());
         } catch (MailException) {
-            FlashMessage::set('error', "L'adresse a été enregistrée, mais l'email de confirmation n'a pas pu être "
-                . "envoyé. Réessayez avec « Renvoyer ».");
+            FlashMessage::set(
+                'error',
+                "L'adresse a été enregistrée, mais l'email de confirmation n'a pas pu être "
+                    . "envoyé. Réessayez avec « Renvoyer »."
+            );
         }
 
         return $this->redirect('/members/' . $memberYearId);

--- a/core/Http/Controller/SetupController.php
+++ b/core/Http/Controller/SetupController.php
@@ -1445,11 +1445,14 @@ class SetupController extends AbstractController
             // would throw a second exception inside this catch block and turn
             // a flash message into a fatal.
             error_log('ScoutMagic setup failed: ' . $e->getMessage());
-            FlashMessage::set('error', 'Erreur lors de l\'installation : ' . UserFacingMessage::from(
-                $e,
-                'l\'installation n\'a pas pu être terminée. Vérifiez les paramètres de la base de données et '
-                . 'les droits d\'écriture sur storage/, puis réessayez.'
-            ));
+            FlashMessage::set(
+                'error',
+                'Erreur lors de l\'installation : ' . UserFacingMessage::from(
+                    $e,
+                    'l\'installation n\'a pas pu être terminée. Vérifiez les paramètres de la base de données et '
+                    . 'les droits d\'écriture sur storage/, puis réessayez.'
+                )
+            );
             return $this->redirect('/setup');
         }
     }
@@ -1544,11 +1547,14 @@ class SetupController extends AbstractController
             // reported is frequently the database, so the detail goes to the
             // PHP error log rather than through a journal INSERT.
             error_log('ScoutMagic setup configuration save failed: ' . $e->getMessage());
-            FlashMessage::set('error', 'Erreur lors de la sauvegarde : ' . UserFacingMessage::from(
-                $e,
-                'la configuration n\'a pas pu être enregistrée. Vérifiez les paramètres de la base de données '
-                . 'et les droits d\'écriture sur storage/, puis réessayez.'
-            ));
+            FlashMessage::set(
+                'error',
+                'Erreur lors de la sauvegarde : ' . UserFacingMessage::from(
+                    $e,
+                    'la configuration n\'a pas pu être enregistrée. Vérifiez les paramètres de la base de données '
+                    . 'et les droits d\'écriture sur storage/, puis réessayez.'
+                )
+            );
             return $this->redirect('/setup');
         }
     }

--- a/core/Http/Controller/StaffsController.php
+++ b/core/Http/Controller/StaffsController.php
@@ -243,8 +243,11 @@ class StaffsController extends AbstractController
 
         // Intendant: filter to linked sections only
         $linkedSectionCodes = $this->getLinkedSectionCodes($linkedMembers);
-        return array_values(array_filter($allSections, fn(array $s) =>
-            in_array($s['desk_code'], $linkedSectionCodes, true)));
+        return array_values(array_filter(
+            $allSections,
+            fn(array $s) =>
+                in_array($s['desk_code'], $linkedSectionCodes, true)
+        ));
     }
 
     /**

--- a/core/Http/Controller/SupportController.php
+++ b/core/Http/Controller/SupportController.php
@@ -441,10 +441,13 @@ class SupportController extends AbstractController
         );
 
         if ($result->sent) {
-            FlashMessage::set('success', sprintf(
-                'Archive transmise et rattachée au ticket %s.',
-                $last['reference']
-            ));
+            FlashMessage::set(
+                'success',
+                sprintf(
+                    'Archive transmise et rattachée au ticket %s.',
+                    $last['reference']
+                )
+            );
         } else {
             FlashMessage::set('error', self::archiveFailureMessage((string) $result->failureReason));
         }
@@ -553,11 +556,14 @@ class SupportController extends AbstractController
         $result = $this->statisticsSender->sendTest();
 
         if ($result->isSent()) {
-            FlashMessage::set('success', sprintf(
-                'Rapport de test transmis (réponse HTTP %d en %d ms).',
-                (int) $result->statusCode,
-                (int) $result->durationMs
-            ));
+            FlashMessage::set(
+                'success',
+                sprintf(
+                    'Rapport de test transmis (réponse HTTP %d en %d ms).',
+                    (int) $result->statusCode,
+                    (int) $result->durationMs
+                )
+            );
         } elseif ($result->isSkipped()) {
             FlashMessage::set('warning', self::skipMessage((string) $result->reason));
         } else {
@@ -650,12 +656,15 @@ class SupportController extends AbstractController
             $this->probeAfterTicket(),
         ]);
 
-        FlashMessage::set('success', trim(sprintf(
-            'Ticket envoyé. Référence : %s. Le mainteneur répondra par e-mail à %s. %s',
-            $reference,
-            $contactEmail,
-            implode(' ', $followUp)
-        )));
+        FlashMessage::set(
+            'success',
+            trim(sprintf(
+                'Ticket envoyé. Référence : %s. Le mainteneur répondra par e-mail à %s. %s',
+                $reference,
+                $contactEmail,
+                implode(' ', $followUp)
+            ))
+        );
 
         return $this->redirect('/config/support');
     }

--- a/core/Maintenance/Task/InstallUpdateHandler.php
+++ b/core/Maintenance/Task/InstallUpdateHandler.php
@@ -356,11 +356,14 @@ class InstallUpdateHandler implements TaskHandlerInterface
             // it goes through the gate: \Throwable is caught, and a
             // ZipArchive/PDO/filesystem message must not reach that page.
             // The journal entry immediately below keeps the real text.
-            $updateHistoryRepository->markFailed($historyId, UserFacingMessage::from(
-                $e,
-                'La sauvegarde de sécurité préalable a échoué — aucune modification n\'a été effectuée. '
-                . 'Vérifiez l\'espace disque et les droits d\'écriture sur storage/, puis relancez la mise à jour.'
-            ));
+            $updateHistoryRepository->markFailed(
+                $historyId,
+                UserFacingMessage::from(
+                    $e,
+                    'La sauvegarde de sécurité préalable a échoué — aucune modification n\'a été effectuée. '
+                    . 'Vérifiez l\'espace disque et les droits d\'écriture sur storage/, puis relancez la mise à jour.'
+                )
+            );
             $context->journal->log(
                 'core',
                 'update_failed',
@@ -847,11 +850,14 @@ class InstallUpdateHandler implements TaskHandlerInterface
             $backupService->restoreFiles($filesZipPath);
             // Same write-site rule as markFailed() above: this string is
             // rendered as a title="" tooltip on the maintenance page.
-            $updateHistoryRepository->markRolledBack($historyId, UserFacingMessage::from(
-                $error,
-                'L\'installation de la mise à jour a échoué — la version précédente a été restaurée '
-                . 'automatiquement. Le détail est dans le journal des événements.'
-            ));
+            $updateHistoryRepository->markRolledBack(
+                $historyId,
+                UserFacingMessage::from(
+                    $error,
+                    'L\'installation de la mise à jour a échoué — la version précédente a été restaurée '
+                    . 'automatiquement. Le détail est dans le journal des événements.'
+                )
+            );
             // The technical detail goes HERE and nowhere else. The
             // user-facing message above deliberately says only "the detail
             // is in the event journal" (UserFacingMessage's rule: no class

--- a/core/Maintenance/Task/RestoreBackupHandler.php
+++ b/core/Maintenance/Task/RestoreBackupHandler.php
@@ -859,27 +859,34 @@ class RestoreBackupHandler implements TaskHandlerInterface
     ): void
     {
         $schedulerService = new SchedulerService(new SchedulerRepository($context->connection->getPdo()));
-        $schedulerService->scheduleAfter('core', 'restore_backup', 0, $extraPayload + [
-            'resume_migration' => true,
-            // **The paths, not only the id.** The restore that just ran
-            // replaced the database — `backups` and `files` included — so
-            // by the time this payload is read, the row recording the
-            // safety copy is whatever the RESTORED database has under
-            // that id, which is another backup or nothing at all. The
-            // rollback then reports « aucune sauvegarde de sécurité n'a pu
-            // être restaurée automatiquement, une intervention manuelle
-            // est nécessaire » with a perfectly usable copy sitting on
-            // disk beside it.
-            //
-            // The two files outlive any database, so they are what the
-            // resume pass is given. The id stays for the pass queued by an
-            // installation upgraded mid-restore, whose payload predates
-            // this and has nothing else to go on.
-            'safety_backup_id' => $safetyBackupId,
-            'safety_db_dump_path' => $safetyDbDump,
-            'safety_zip_path' => $safetyZip,
-            'source' => $source,
-        ], null, $requestedBy);
+        $schedulerService->scheduleAfter(
+            'core',
+            'restore_backup',
+            0,
+            $extraPayload + [
+                'resume_migration' => true,
+                // **The paths, not only the id.** The restore that just ran
+                // replaced the database — `backups` and `files` included — so
+                // by the time this payload is read, the row recording the
+                // safety copy is whatever the RESTORED database has under
+                // that id, which is another backup or nothing at all. The
+                // rollback then reports « aucune sauvegarde de sécurité n'a pu
+                // être restaurée automatiquement, une intervention manuelle
+                // est nécessaire » with a perfectly usable copy sitting on
+                // disk beside it.
+                //
+                // The two files outlive any database, so they are what the
+                // resume pass is given. The id stays for the pass queued by an
+                // installation upgraded mid-restore, whose payload predates
+                // this and has nothing else to go on.
+                'safety_backup_id' => $safetyBackupId,
+                'safety_db_dump_path' => $safetyDbDump,
+                'safety_zip_path' => $safetyZip,
+                'source' => $source,
+            ],
+            null,
+            $requestedBy
+        );
     }
 
     /**

--- a/core/Member/Export/MemberExportRowBuilder.php
+++ b/core/Member/Export/MemberExportRowBuilder.php
@@ -116,11 +116,14 @@ final class MemberExportRowBuilder
         // Synthetic sectionless entries (buildForMemberYears()) carry
         // sectionId 0 — never fed to the classifier, whose input is a real
         // (section, branch) placement; they fall back to UNKNOWN below.
-        $currentRoster = array_map(fn(SectionRosterEntry $e) => [
-            'member_id' => $e->memberId,
-            'section_id' => $e->sectionId,
-            'age_branch_id' => $e->ageBranchId,
-        ], array_values(array_filter($entries, fn(SectionRosterEntry $e) => $e->sectionId > 0)));
+        $currentRoster = array_map(
+            fn(SectionRosterEntry $e) => [
+                'member_id' => $e->memberId,
+                'section_id' => $e->sectionId,
+                'age_branch_id' => $e->ageBranchId,
+            ],
+            array_values(array_filter($entries, fn(SectionRosterEntry $e) => $e->sectionId > 0))
+        );
         $movementByMemberId = $this->movementClassifier->classifyBatch($scoutYearId, $currentRoster);
 
         $sectionIdsNeeded = array_values(array_filter(array_unique(array_merge(

--- a/core/Member/SectionRosterService.php
+++ b/core/Member/SectionRosterService.php
@@ -60,11 +60,14 @@ final class SectionRosterService
         $memberYearRows = $this->repository->findMemberYearRows($memberYearIds);
         $validEmailsByMember = $this->memberEmailRepository->findValidByMemberIds($memberIds);
 
-        $currentRoster = array_map(fn(SectionRosterEntry $e) => [
-            'member_id' => $e->memberId,
-            'section_id' => $e->sectionId,
-            'age_branch_id' => $e->ageBranchId,
-        ], $entries);
+        $currentRoster = array_map(
+            fn(SectionRosterEntry $e) => [
+                'member_id' => $e->memberId,
+                'section_id' => $e->sectionId,
+                'age_branch_id' => $e->ageBranchId,
+            ],
+            $entries
+        );
         $movementByMemberId = $this->movementClassifier->classifyBatch($scoutYearId, $currentRoster);
 
         foreach ($entries as $entry) {
@@ -82,10 +85,13 @@ final class SectionRosterService
 
         foreach ($bySection as $sectionId => $buckets) {
             foreach ($buckets as $bucket => $rows) {
-                usort($rows, fn(MemberRosterRow $a, MemberRosterRow $b) => strcasecmp(
-                    $a->lastName . ' ' . $a->firstName,
-                    $b->lastName . ' ' . $b->firstName
-                ));
+                usort(
+                    $rows,
+                    fn(MemberRosterRow $a, MemberRosterRow $b) => strcasecmp(
+                        $a->lastName . ' ' . $a->firstName,
+                        $b->lastName . ' ' . $b->firstName
+                    )
+                );
                 $bySection[$sectionId][$bucket] = $rows;
             }
         }

--- a/core/Member/SectionStaffAuthorizationService.php
+++ b/core/Member/SectionStaffAuthorizationService.php
@@ -122,8 +122,11 @@ class SectionStaffAuthorizationService
         // multi-section chief/animateur would see their sections in
         // arbitrary DB order instead of matching every other section
         // picker on the site.
-        usort($sections, static fn(array $a, array $b): int
-            => [$a['branch_sort_order'], $a['desk_code']] <=> [$b['branch_sort_order'], $b['desk_code']]);
+        usort(
+            $sections,
+            static fn(array $a, array $b): int
+                => [$a['branch_sort_order'], $a['desk_code']] <=> [$b['branch_sort_order'], $b['desk_code']]
+        );
 
         return $sections;
     }

--- a/core/Scheduler/SchedulerRunner.php
+++ b/core/Scheduler/SchedulerRunner.php
@@ -200,11 +200,14 @@ class SchedulerRunner
                 // gate any library's own English — a PDO error naming a
                 // column, an SMTP transcript — lands on that page. The
                 // journal entry below still carries the real text.
-                $this->repository->markFailed((int) $task['id'], UserFacingMessage::from(
-                    $e,
-                    "La tâche « {$task['task_key']} » a échoué. Le détail technique est dans le journal des "
-                    . 'événements (Configuration > Journal).'
-                ));
+                $this->repository->markFailed(
+                    (int) $task['id'],
+                    UserFacingMessage::from(
+                        $e,
+                        "La tâche « {$task['task_key']} » a échoué. Le détail technique est dans le journal des "
+                        . 'événements (Configuration > Journal).'
+                    )
+                );
                 $durationMs = (int) round((microtime(true) - $taskStart) * 1000);
                 RequestTimeline::mark(
                     'scheduler_task_failed:' . $handlerKey,

--- a/modules/calendar/src/Service/CalendarService.php
+++ b/modules/calendar/src/Service/CalendarService.php
@@ -283,14 +283,17 @@ class CalendarService implements
         );
         $labels = $this->labelsByCalendarId();
 
-        return array_map(fn(CalendarEvent $e) => new EventSummary(
-            id: $e->id,
-            title: $e->title,
-            calendarName: $labels[$e->calendarId] ?? 'Calendrier',
-            startDate: $e->startDate,
-            endDate: $e->endDate ?? $e->startDate,
-            description: $e->description
-        ), $events);
+        return array_map(
+            fn(CalendarEvent $e) => new EventSummary(
+                id: $e->id,
+                title: $e->title,
+                calendarName: $labels[$e->calendarId] ?? 'Calendrier',
+                startDate: $e->startDate,
+                endDate: $e->endDate ?? $e->startDate,
+                description: $e->description
+            ),
+            $events
+        );
     }
 
     /**

--- a/modules/finance/src/Controller/ConfigCategoryController.php
+++ b/modules/finance/src/Controller/ConfigCategoryController.php
@@ -87,8 +87,15 @@ class ConfigCategoryController extends AbstractController
                         (string) ($data['name'] ?? ''),
                         (string) ($data['description'] ?? '')
                     );
-                    $this->journalService->log('finance', 'category_created', 'info', "Catégorie « {$category->name} "
-                        . "» créée", ['category_id' => $category->id], AuthSession::getUserAccountId());
+                    $this->journalService->log(
+                        'finance',
+                        'category_created',
+                        'info',
+                        "Catégorie « {$category->name} "
+                            . "» créée",
+                        ['category_id' => $category->id],
+                        AuthSession::getUserAccountId()
+                    );
                     return $this->json(['success' => true, 'category_id' => $category->id]);
 
                 case 'update':

--- a/modules/finance/src/Controller/DashboardController.php
+++ b/modules/finance/src/Controller/DashboardController.php
@@ -145,18 +145,21 @@ class DashboardController extends AbstractController
         $firstReceiptsByMovementId = $this->firstReceiptResolver->resolve(
             array_map(fn(Transaction $movement) => $movement->id, $recentMovements)
         );
-        $recentMovementRows = array_map(fn(Transaction $movement) => [
-            'movement' => $movement,
-            'counterparty' => MovementPresenter::counterparty(
-                $movement,
-                $firstReceiptsByMovementId[$movement->id] ?? null,
-                $account->name
-            ),
-            'description' => MovementPresenter::description(
-                $movement,
-                $firstReceiptsByMovementId[$movement->id] ?? null
-            ),
-        ], $recentMovements);
+        $recentMovementRows = array_map(
+            fn(Transaction $movement) => [
+                'movement' => $movement,
+                'counterparty' => MovementPresenter::counterparty(
+                    $movement,
+                    $firstReceiptsByMovementId[$movement->id] ?? null,
+                    $account->name
+                ),
+                'description' => MovementPresenter::description(
+                    $movement,
+                    $firstReceiptsByMovementId[$movement->id] ?? null
+                ),
+            ],
+            $recentMovements
+        );
 
         $bilan = ['income' => 0.0, 'expense' => 0.0, 'total' => 0.0];
         foreach ($categorySummary as $row) {

--- a/modules/finance/src/Controller/MovementController.php
+++ b/modules/finance/src/Controller/MovementController.php
@@ -380,16 +380,19 @@ class MovementController extends AbstractController
 
         return $this->json([
             'success' => true,
-            'attachments' => array_map(fn(Attachment $attachment) => [
-                'id' => $attachment->id,
-                'file_id' => $attachment->fileId,
-                'original_filename' => $attachment->originalFilename,
-                'mime_type' => $attachment->mimeType,
-                'suggested_amount' => $attachment->suggestedAmount,
-                'suggested_date' => $attachment->suggestedDate,
-                'suggested_label' => $attachment->suggestedLabel,
-                'suggested_description' => $attachment->suggestedDescription,
-            ], $attachments),
+            'attachments' => array_map(
+                fn(Attachment $attachment) => [
+                    'id' => $attachment->id,
+                    'file_id' => $attachment->fileId,
+                    'original_filename' => $attachment->originalFilename,
+                    'mime_type' => $attachment->mimeType,
+                    'suggested_amount' => $attachment->suggestedAmount,
+                    'suggested_date' => $attachment->suggestedDate,
+                    'suggested_label' => $attachment->suggestedLabel,
+                    'suggested_description' => $attachment->suggestedDescription,
+                ],
+                $attachments
+            ),
         ]);
     }
 
@@ -540,20 +543,26 @@ class MovementController extends AbstractController
 
         return $this->json([
             'success' => true,
-            'movements' => array_map(fn(Transaction $transaction) => [
-                'id' => $transaction->id,
-                'date' => $transaction->transactionDate,
-                'label' => $transaction->label,
-                'amount' => $transaction->amount,
-                'counterparty' => MovementPresenter::counterparty(
-                    $transaction,
-                    $firstReceipts[
-                        $transaction->id
-                    ] ?? null,
-                    $accountNamesById[$transaction->accountId] ?? ''
-                ),
-                'description' => MovementPresenter::description($transaction, $firstReceipts[$transaction->id] ?? null),
-            ], $matches),
+            'movements' => array_map(
+                fn(Transaction $transaction) => [
+                    'id' => $transaction->id,
+                    'date' => $transaction->transactionDate,
+                    'label' => $transaction->label,
+                    'amount' => $transaction->amount,
+                    'counterparty' => MovementPresenter::counterparty(
+                        $transaction,
+                        $firstReceipts[
+                            $transaction->id
+                        ] ?? null,
+                        $accountNamesById[$transaction->accountId] ?? ''
+                    ),
+                    'description' => MovementPresenter::description(
+                        $transaction,
+                        $firstReceipts[$transaction->id] ?? null
+                    ),
+                ],
+                $matches
+            ),
         ]);
     }
 

--- a/modules/finance/src/Controller/ReceiptController.php
+++ b/modules/finance/src/Controller/ReceiptController.php
@@ -219,13 +219,16 @@ class ReceiptController extends AbstractController
         $search = trim((string) $request->getQuery('q', ''));
         $page = max(1, (int) $request->getQuery('page', 1));
 
-        $totalPages = max(1, (int) ceil(
-            $this->attachmentRepository->countFilteredForAccount(
-                $accountId,
-                $pendingOnly,
-                $search !== '' ? $search : null
-            ) / self::PER_PAGE
-        ));
+        $totalPages = max(
+            1,
+            (int) ceil(
+                $this->attachmentRepository->countFilteredForAccount(
+                    $accountId,
+                    $pendingOnly,
+                    $search !== '' ? $search : null
+                ) / self::PER_PAGE
+            )
+        );
         $page = min($page, $totalPages);
 
         return $this->render('@finance/receipts/list.html.twig', [
@@ -319,21 +322,24 @@ class ReceiptController extends AbstractController
             'page' => $page,
             'total_pages' => $totalPages,
             'total' => $total,
-            'receipts' => array_map(fn(array $row) => [
-                'id' => $row['attachment']->id,
-                'file_id' => $row['attachment']->fileId,
-                'mime_type' => $row['attachment']->mimeType,
-                'original_filename' => $row['attachment']->originalFilename,
-                'uploaded_at' => $row['attachment']->uploadedAt,
-                'suggested_amount' => $row['attachment']->suggestedAmount,
-                'suggested_date' => $row['attachment']->suggestedDate,
-                'suggested_label' => $row['attachment']->suggestedLabel,
-                'suggested_description' => $row['attachment']->suggestedDescription,
-                'suggested_source' => $row['attachment']->suggestedSource,
-                'matching_ai_attempted' => $row['attachment']->matchingAiAttemptedAt !== null,
-                'is_pending' => $row['is_pending'],
-                'movement_count' => $row['movement_count'],
-            ], $rows),
+            'receipts' => array_map(
+                fn(array $row) => [
+                    'id' => $row['attachment']->id,
+                    'file_id' => $row['attachment']->fileId,
+                    'mime_type' => $row['attachment']->mimeType,
+                    'original_filename' => $row['attachment']->originalFilename,
+                    'uploaded_at' => $row['attachment']->uploadedAt,
+                    'suggested_amount' => $row['attachment']->suggestedAmount,
+                    'suggested_date' => $row['attachment']->suggestedDate,
+                    'suggested_label' => $row['attachment']->suggestedLabel,
+                    'suggested_description' => $row['attachment']->suggestedDescription,
+                    'suggested_source' => $row['attachment']->suggestedSource,
+                    'matching_ai_attempted' => $row['attachment']->matchingAiAttemptedAt !== null,
+                    'is_pending' => $row['is_pending'],
+                    'movement_count' => $row['movement_count'],
+                ],
+                $rows
+            ),
         ]);
     }
 
@@ -367,13 +373,16 @@ class ReceiptController extends AbstractController
 
         return $this->json([
             'success' => true,
-            'movements' => array_map(fn(Transaction $t) => [
-                'id' => $t->id,
-                'date' => $t->transactionDate,
-                'label' => $t->label,
-                'amount' => $t->amount,
-                'description' => MovementPresenter::description($t, $firstReceipts[$t->id] ?? null),
-            ], $transactions),
+            'movements' => array_map(
+                fn(Transaction $t) => [
+                    'id' => $t->id,
+                    'date' => $t->transactionDate,
+                    'label' => $t->label,
+                    'amount' => $t->amount,
+                    'description' => MovementPresenter::description($t, $firstReceipts[$t->id] ?? null),
+                ],
+                $transactions
+            ),
         ]);
     }
 
@@ -390,11 +399,14 @@ class ReceiptController extends AbstractController
             ($page - 1) * self::PER_PAGE
         );
 
-        return array_map(fn(array $row) => [
-            'attachment' => $row['attachment'],
-            'movement_count' => $row['movement_count'],
-            'is_pending' => $row['movement_count'] === 0,
-        ], $results);
+        return array_map(
+            fn(array $row) => [
+                'attachment' => $row['attachment'],
+                'movement_count' => $row['movement_count'],
+                'is_pending' => $row['movement_count'] === 0,
+            ],
+            $results
+        );
     }
 
     /**

--- a/modules/finance/src/Service/BulkCategorizationService.php
+++ b/modules/finance/src/Service/BulkCategorizationService.php
@@ -244,20 +244,44 @@ class BulkCategorizationService
         // value whichever type that row happens to carry — only a timestamp
         // would fail validation on a `boolean` row, which is precisely why
         // the timestamp lives under its own key.
-        $this->settingService->register(self::LEGACY_RUNNING_SETTING_KEY, '0', 'boolean', 'Exécution des règles en '
-            . 'cours (obsolète)', 'Indicateur interne — ne pas modifier.', 'finance', null, null, false);
+        $this->settingService->register(
+            self::LEGACY_RUNNING_SETTING_KEY,
+            '0',
+            'boolean',
+            'Exécution des règles en '
+                . 'cours (obsolète)',
+            'Indicateur interne — ne pas modifier.',
+            'finance',
+            null,
+            null,
+            false
+        );
         $this->settingService->setInternal(self::LEGACY_RUNNING_SETTING_KEY, '0', 'finance');
     }
 
     private function storeLastResult(BulkCategorizationResult $result): void
     {
-        $this->settingService->register(self::LAST_RESULT_SETTING_KEY, '', 'text', 'Résultat de la dernière exécution '
-            . 'des règles', 'Indicateur interne — ne pas modifier.', 'finance', null, null, false);
-        $this->settingService->setInternal(self::LAST_RESULT_SETTING_KEY, json_encode([
-            'categorized_by_rules' => $result->categorizedByRules,
-            'categorized_by_ai' => $result->categorizedByAi,
-            'still_uncategorized' => $result->stillUncategorized,
-        ]), 'finance');
+        $this->settingService->register(
+            self::LAST_RESULT_SETTING_KEY,
+            '',
+            'text',
+            'Résultat de la dernière exécution '
+                . 'des règles',
+            'Indicateur interne — ne pas modifier.',
+            'finance',
+            null,
+            null,
+            false
+        );
+        $this->settingService->setInternal(
+            self::LAST_RESULT_SETTING_KEY,
+            json_encode([
+                'categorized_by_rules' => $result->categorizedByRules,
+                'categorized_by_ai' => $result->categorizedByAi,
+                'still_uncategorized' => $result->stillUncategorized,
+            ]),
+            'finance'
+        );
     }
 
     public function runOnUncategorized(): BulkCategorizationResult

--- a/modules/gallery/src/Controller/GalleryController.php
+++ b/modules/gallery/src/Controller/GalleryController.php
@@ -136,11 +136,14 @@ class GalleryController extends AbstractController
         [$unavailable, $unavailableReason] = $this->availability($album);
 
         $mediaRows = $this->mediaRepository->findByAlbumId($album->id);
-        $media = $unavailable ? [] : array_map(fn(Media $m) => [
-            'media' => $m,
-            'thumb_url' => $this->mediaService->resolveUrl($m, $album, 'thumb'),
-            'medium_url' => $this->mediaService->resolveUrl($m, $album, 'medium'),
-        ], $mediaRows);
+        $media = $unavailable ? [] : array_map(
+            fn(Media $m) => [
+                'media' => $m,
+                'thumb_url' => $this->mediaService->resolveUrl($m, $album, 'thumb'),
+                'medium_url' => $this->mediaService->resolveUrl($m, $album, 'medium'),
+            ],
+            $mediaRows
+        );
 
         return $this->render('@gallery/album.html.twig', [
             'album' => $album,

--- a/modules/groups/src/Controller/GroupController.php
+++ b/modules/groups/src/Controller/GroupController.php
@@ -633,11 +633,14 @@ class GroupController extends AbstractController
         if ($sectionId === 0 && $this->membershipService !== null
             && !$this->membershipService->canCreateAnotherGroup($creatorMemberId)
         ) {
-            FlashMessage::set('error', sprintf(
-                'Vous avez déjà %d groupes ouverts, soit le maximum autorisé. Clôturez-en un avant d\'en créer un '
-                    . 'nouveau.',
-                $this->membershipService->creationQuota()
-            ));
+            FlashMessage::set(
+                'error',
+                sprintf(
+                    'Vous avez déjà %d groupes ouverts, soit le maximum autorisé. Clôturez-en un avant d\'en créer un '
+                        . 'nouveau.',
+                    $this->membershipService->creationQuota()
+                )
+            );
 
             return $this->redirect('/groups');
         }
@@ -856,25 +859,28 @@ class GroupController extends AbstractController
      */
     private function decorate(array $items, GroupSessionContext $context): array
     {
-        return array_map(fn(GroupListItem $item) => [
-            'group' => $item->group,
-            // "Louveteaux (2025-2026)" for a group tied to the year in
-            // effect, the bare name otherwise — one implementation,
-            // Support\GroupLabel.
-            'label' => GroupLabel::withYear(
-                $item->group,
-                $context->effectiveScoutYearId,
-                $context->effectiveScoutYearLabel
-            ),
-            'is_moderator' => $item->isModerator,
-            'is_archived' => $item->isArchived,
-            'section_names' => $this->sectionNames($item->sectionIds),
-            'member_count' => $item->memberCount,
-            // Never on the archives tab: a past-year group is a read-only
-            // archive, so "you have not caught up" is not a call to
-            // action there, just noise on something already finished.
-            'has_unread' => $item->hasUnread && !$item->isArchived,
-        ], $items);
+        return array_map(
+            fn(GroupListItem $item) => [
+                'group' => $item->group,
+                // "Louveteaux (2025-2026)" for a group tied to the year in
+                // effect, the bare name otherwise — one implementation,
+                // Support\GroupLabel.
+                'label' => GroupLabel::withYear(
+                    $item->group,
+                    $context->effectiveScoutYearId,
+                    $context->effectiveScoutYearLabel
+                ),
+                'is_moderator' => $item->isModerator,
+                'is_archived' => $item->isArchived,
+                'section_names' => $this->sectionNames($item->sectionIds),
+                'member_count' => $item->memberCount,
+                // Never on the archives tab: a past-year group is a read-only
+                // archive, so "you have not caught up" is not a call to
+                // action there, just noise on something already finished.
+                'has_unread' => $item->hasUnread && !$item->isArchived,
+            ],
+            $items
+        );
     }
 
     /**

--- a/modules/mass_mail/src/Controller/MassMailController.php
+++ b/modules/mass_mail/src/Controller/MassMailController.php
@@ -489,11 +489,14 @@ class MassMailController extends AbstractController
             return $this->redirect('/mass-mail/' . $id);
         }
 
-        FlashMessage::set('success', match ($action) {
-            'to_test' => 'Email passé en mode test.',
-            'to_draft' => 'Email repassé en brouillon.',
-            default => "L'envoi est lancé : les emails partent par lots en arrière-plan.",
-        });
+        FlashMessage::set(
+            'success',
+            match ($action) {
+                'to_test' => 'Email passé en mode test.',
+                'to_draft' => 'Email repassé en brouillon.',
+                default => "L'envoi est lancé : les emails partent par lots en arrière-plan.",
+            }
+        );
 
         return $this->redirect('/mass-mail/' . $id);
     }
@@ -530,11 +533,14 @@ class MassMailController extends AbstractController
             // time, which is why it is not a Core\Exception\UserFacingException
             // and why this goes through the helper rather than being
             // concatenated.
-            FlashMessage::set('error', UserFacingMessage::from(
-                $e,
-                "L'email de test n'a pas pu être envoyé — vérifiez la configuration d'envoi du site (Configuration > "
-                    . "Email), puis réessayez."
-            ));
+            FlashMessage::set(
+                'error',
+                UserFacingMessage::from(
+                    $e,
+                    "L'email de test n'a pas pu être envoyé — vérifiez la configuration d'envoi du site "
+                    . "(Configuration > Email), puis réessayez."
+                )
+            );
 
             return $this->redirect('/mass-mail/' . $id);
         }

--- a/modules/news/src/Controller/NewsController.php
+++ b/modules/news/src/Controller/NewsController.php
@@ -957,13 +957,16 @@ class NewsController extends AbstractController
      */
     private function fieldsForPreview(array $fields, array $memberOptions): array
     {
-        return array_map(fn(FormField $field) => [
-            'field' => $field,
-            'options' => $field->optionsSource === FormField::OPTIONS_SOURCE_MEMBERS
-                ? array_values($memberOptions)
-                : $field->manualOptions(),
-            'remaining_capacity' => $field->capacityMax,
-        ], $fields);
+        return array_map(
+            fn(FormField $field) => [
+                'field' => $field,
+                'options' => $field->optionsSource === FormField::OPTIONS_SOURCE_MEMBERS
+                    ? array_values($memberOptions)
+                    : $field->manualOptions(),
+                'remaining_capacity' => $field->capacityMax,
+            ],
+            $fields
+        );
     }
 
     /**
@@ -1104,27 +1107,30 @@ class NewsController extends AbstractController
             return [];
         }
 
-        return array_map(fn(array $f) => [
-            'id' => isset($f['id']) && $f['id'] !== null ? (int) $f['id'] : null,
-            'field_type' => (string) ($f['field_type'] ?? ''),
-            'label' => isset($f['label']) && $f['label'] !== '' ? (string) $f['label'] : null,
-            'is_required' => (bool) ($f['is_required'] ?? false),
-            'options_source' => isset($f['options_source']) && $f['options_source'] !== ''
-                ? (string) $f['options_source']
-                : null,
-            'options_manual' => isset($f['options_manual']) && $f['options_manual'] !== ''
-                ? (string) $f['options_manual']
-                : null,
-            'capacity_max' => isset($f['capacity_max']) && $f['capacity_max'] !== '' && $f['capacity_max'] !== null
-                ? (int) $f['capacity_max']
-                : null,
-            'price_per_unit' => isset($f['price_per_unit'])
-                && $f['price_per_unit'] !== ''
-                && $f['price_per_unit'] !== null ? (float) $f['price_per_unit'] : null,
-            'confirmation_text' => isset($f['confirmation_text']) && $f['confirmation_text'] !== ''
-                ? (string) $f['confirmation_text']
-                : null,
-        ], $raw);
+        return array_map(
+            fn(array $f) => [
+                'id' => isset($f['id']) && $f['id'] !== null ? (int) $f['id'] : null,
+                'field_type' => (string) ($f['field_type'] ?? ''),
+                'label' => isset($f['label']) && $f['label'] !== '' ? (string) $f['label'] : null,
+                'is_required' => (bool) ($f['is_required'] ?? false),
+                'options_source' => isset($f['options_source']) && $f['options_source'] !== ''
+                    ? (string) $f['options_source']
+                    : null,
+                'options_manual' => isset($f['options_manual']) && $f['options_manual'] !== ''
+                    ? (string) $f['options_manual']
+                    : null,
+                'capacity_max' => isset($f['capacity_max']) && $f['capacity_max'] !== '' && $f['capacity_max'] !== null
+                    ? (int) $f['capacity_max']
+                    : null,
+                'price_per_unit' => isset($f['price_per_unit'])
+                    && $f['price_per_unit'] !== ''
+                    && $f['price_per_unit'] !== null ? (float) $f['price_per_unit'] : null,
+                'confirmation_text' => isset($f['confirmation_text']) && $f['confirmation_text'] !== ''
+                    ? (string) $f['confirmation_text']
+                    : null,
+            ],
+            $raw
+        );
     }
 
     /**

--- a/modules/news/src/Service/ArticleService.php
+++ b/modules/news/src/Service/ArticleService.php
@@ -105,15 +105,18 @@ class ArticleService implements HomeNewsProvider
     {
         $visibilities = $this->listableVisibilities(Role::fromString($role));
 
-        return array_map(fn(Article $article) => [
-            'id' => $article->id,
-            'title' => $article->title,
-            'summary' => $article->summary,
-            // The 192px thumb, not the original: the homepage card renders
-            // this in a 56px box, and originals can weigh several MB.
-            'image_url' => $article->imageFileId !== null ? '/files/' . $article->imageFileId . '/thumb' : null,
-            'created_at' => $article->createdAt,
-        ], $this->articleRepository->findLatestByVisibilities($visibilities, $limit));
+        return array_map(
+            fn(Article $article) => [
+                'id' => $article->id,
+                'title' => $article->title,
+                'summary' => $article->summary,
+                // The 192px thumb, not the original: the homepage card renders
+                // this in a 56px box, and originals can weigh several MB.
+                'image_url' => $article->imageFileId !== null ? '/files/' . $article->imageFileId . '/thumb' : null,
+                'created_at' => $article->createdAt,
+            ],
+            $this->articleRepository->findLatestByVisibilities($visibilities, $limit)
+        );
     }
 
     /**

--- a/modules/registration/src/Controller/RegistrationConfigController.php
+++ b/modules/registration/src/Controller/RegistrationConfigController.php
@@ -113,11 +113,14 @@ class RegistrationConfigController extends AbstractController
 
         [$requestedYearId, $statusFilter, $search] = $this->readListFilters($request);
 
-        return $this->render('@registration/config.html.twig', $this->buildPageContext(
-            $requestedYearId,
-            $statusFilter,
-            $search
-        ));
+        return $this->render(
+            '@registration/config.html.twig',
+            $this->buildPageContext(
+                $requestedYearId,
+                $statusFilter,
+                $search
+            )
+        );
     }
 
     /**

--- a/modules/registration/src/Repository/RegistrationRequestRepository.php
+++ b/modules/registration/src/Repository/RegistrationRequestRepository.php
@@ -53,11 +53,14 @@ class RegistrationRequestRepository
         $trackingToken = CapabilityToken::generate();
         $trackingTokenHash = password_hash($trackingToken, PASSWORD_DEFAULT);
 
-        $nameDobBlind = $this->encryption->blindIndex(self::normalizeForNameDobBlindIndex(
-            $fields['child_last_name'],
-            $fields['child_first_name'],
-            $fields['birth_date']
-        ), 'registration_name_dob');
+        $nameDobBlind = $this->encryption->blindIndex(
+            self::normalizeForNameDobBlindIndex(
+                $fields['child_last_name'],
+                $fields['child_first_name'],
+                $fields['birth_date']
+            ),
+            'registration_name_dob'
+        );
 
         $addressNormalized = AddressNormalizer::normalize(
             $fields['street'],

--- a/modules/rental/src/Controller/RentalManagementController.php
+++ b/modules/rental/src/Controller/RentalManagementController.php
@@ -932,15 +932,18 @@ class RentalManagementController extends AbstractController
                 $found[] = $report['proposed'] . ' proposition' . ($report['proposed'] > 1 ? 's' : '');
             }
 
-            FlashMessage::set('success', $report['examined'] === 0
-                ? 'Aucun message en attente : tout ce qui est conservé est déjà rattaché.'
-                : sprintf(
-                    '%d message%s réexaminé%s : %s.',
-                    $report['examined'],
-                    $report['examined'] > 1 ? 's' : '',
-                    $report['examined'] > 1 ? 's' : '',
-                    $found === [] ? 'rien de neuf pour l\'instant' : implode(' et ', $found)
-                ));
+            FlashMessage::set(
+                'success',
+                $report['examined'] === 0
+                    ? 'Aucun message en attente : tout ce qui est conservé est déjà rattaché.'
+                    : sprintf(
+                        '%d message%s réexaminé%s : %s.',
+                        $report['examined'],
+                        $report['examined'] > 1 ? 's' : '',
+                        $report['examined'] > 1 ? 's' : '',
+                        $found === [] ? 'rien de neuf pour l\'instant' : implode(' et ', $found)
+                    )
+            );
         });
     }
 

--- a/modules/rental/src/Controller/RentalPricingController.php
+++ b/modules/rental/src/Controller/RentalPricingController.php
@@ -283,22 +283,25 @@ class RentalPricingController extends AbstractController
                 );
             }
 
-            $this->paymentService->saveManagedSettings($asset->id, new PaymentSettings(
-                enabled: $request->getBody('payments_enabled') !== null,
-                depositMode: DepositMode::tryFrom((string) $request->getBody('deposit_mode', 'none'))
-                    ?? DepositMode::NONE,
-                depositAmountCents: RentalPricingService::parseAmountToCents(
-                    (string) $request->getBody('deposit_amount', '')
-                ),
-                depositPercentage: self::optionalInt($request->getBody('deposit_percentage')),
-                depositDueDays: self::optionalInt($request->getBody('deposit_due_days')),
-                balanceDueDays: self::optionalInt($request->getBody('balance_due_days')),
-                securityDepositEnabled: $request->getBody('security_deposit_enabled') !== null,
-                securityDepositAmountCents: RentalPricingService::parseAmountToCents(
-                    (string) $request->getBody('security_deposit_amount', '')
-                ),
-                securityDepositDueDays: self::optionalInt($request->getBody('security_deposit_due_days'))
-            ));
+            $this->paymentService->saveManagedSettings(
+                $asset->id,
+                new PaymentSettings(
+                    enabled: $request->getBody('payments_enabled') !== null,
+                    depositMode: DepositMode::tryFrom((string) $request->getBody('deposit_mode', 'none'))
+                        ?? DepositMode::NONE,
+                    depositAmountCents: RentalPricingService::parseAmountToCents(
+                        (string) $request->getBody('deposit_amount', '')
+                    ),
+                    depositPercentage: self::optionalInt($request->getBody('deposit_percentage')),
+                    depositDueDays: self::optionalInt($request->getBody('deposit_due_days')),
+                    balanceDueDays: self::optionalInt($request->getBody('balance_due_days')),
+                    securityDepositEnabled: $request->getBody('security_deposit_enabled') !== null,
+                    securityDepositAmountCents: RentalPricingService::parseAmountToCents(
+                        (string) $request->getBody('security_deposit_amount', '')
+                    ),
+                    securityDepositDueDays: self::optionalInt($request->getBody('security_deposit_due_days'))
+                )
+            );
 
             return 'Configuration des paiements enregistrée.';
         });

--- a/modules/rental/src/Controller/RentalRequestController.php
+++ b/modules/rental/src/Controller/RentalRequestController.php
@@ -240,14 +240,17 @@ class RentalRequestController extends AbstractController
         // hold at submission, or the unit spends the first email walking a
         // number back. Null means "no price yet", which is the truth.
         $quote = $pricing->hasAnyRate()
-            ? $this->pricingService->quoteWithSettings($pricing, new PricingRequest(
-                arrivalDate: $arrival,
-                departureDate: $departure,
-                persons: $persons,
-                units: $units,
-                rooms: 1,
-                renterCategoryId: $categoryId !== '' ? (int) $categoryId : null
-            ))
+            ? $this->pricingService->quoteWithSettings(
+                $pricing,
+                new PricingRequest(
+                    arrivalDate: $arrival,
+                    departureDate: $departure,
+                    persons: $persons,
+                    units: $units,
+                    rooms: 1,
+                    renterCategoryId: $categoryId !== '' ? (int) $categoryId : null
+                )
+            )
             : null;
 
         try {

--- a/modules/rental/src/Mail/RentalMessageConsumer.php
+++ b/modules/rental/src/Mail/RentalMessageConsumer.php
@@ -371,8 +371,11 @@ class RentalMessageConsumer implements
         }
         $picked = $this->modelChoice?->choose($message->subject . "\n" . $message->bodyText, $options);
         if ($picked !== null) {
-            usort($shortlist, static fn(RentalBooking $a, RentalBooking $b): int
-                => ($a->reference === $picked ? 0 : 1) <=> ($b->reference === $picked ? 0 : 1));
+            usort(
+                $shortlist,
+                static fn(RentalBooking $a, RentalBooking $b): int
+                    => ($a->reference === $picked ? 0 : 1) <=> ($b->reference === $picked ? 0 : 1)
+            );
         }
 
         $candidates = [];

--- a/modules/support_dashboard/src/Service/SupportDashboardService.php
+++ b/modules/support_dashboard/src/Service/SupportDashboardService.php
@@ -186,8 +186,11 @@ class SupportDashboardService
             ];
         }
 
-        usort($modules, static fn(array $a, array $b): int =>
-            $b['enabled'] <=> $a['enabled'] ?: ($b['used'] <=> $a['used'] ?: strcmp($a['id'], $b['id'])));
+        usort(
+            $modules,
+            static fn(array $a, array $b): int =>
+                $b['enabled'] <=> $a['enabled'] ?: ($b['used'] <=> $a['used'] ?: strcmp($a['id'], $b['id']))
+        );
 
         // The actionable finding, isolated: enabled somewhere, measured
         // somewhere, opened nowhere. A module nobody measures is NOT in
@@ -484,12 +487,18 @@ class SupportDashboardService
             // label. Deliberately NOT email: there is no email anywhere in
             // a report, so offering the search would promise a capability
             // that cannot exist.
-            $haystack = mb_strtolower(implode(' ', array_filter([
-                $row['instance_url'],
-                $row['installation_id'],
-                $row['version_label'],
-                $row['scout_year_label'],
-            ], static fn(mixed $value): bool => is_string($value))));
+            $haystack = mb_strtolower(implode(
+                ' ',
+                array_filter(
+                    [
+                        $row['instance_url'],
+                        $row['installation_id'],
+                        $row['version_label'],
+                        $row['scout_year_label'],
+                    ],
+                    static fn(mixed $value): bool => is_string($value)
+                )
+            ));
 
             if (!str_contains($haystack, mb_strtolower($filters->search))) {
                 return false;

--- a/public/scheduler-bootstrap.php
+++ b/public/scheduler-bootstrap.php
@@ -549,8 +549,11 @@ function scoutmagicBootstrapScheduler(
                         // throwable's message is not bounded. An id and a
                         // mime type, never the filename — personal data
                         // (§7.9).
-                        static function (\Throwable $e, string $mimeType, int $attachmentId)
-                        use ($journalService): void {
+                        static function (
+                            \Throwable $e,
+                            string $mimeType,
+                            int $attachmentId
+                        ) use ($journalService): void {
                             $journalService->log(
                                 'finance',
                                 'inbound_receipt_not_filed',

--- a/tests/Modules/Finance/Mail/InboundReceiptIsNotSilentTest.php
+++ b/tests/Modules/Finance/Mail/InboundReceiptIsNotSilentTest.php
@@ -69,8 +69,14 @@ final class InboundReceiptIsNotSilentTest extends TestCase
         );
         // The closure, not merely the string: an event type in a comment
         // would satisfy the assertion above and report nothing.
+        //
+        // Whitespace-tolerant between the parameters, and only there: on
+        // one line that signature plus its `use` clause is 122 characters
+        // at the indentation it sits at, so php:S103 and php:S1808 leave
+        // it no single-line form. What is pinned is the closure and its
+        // three typed parameters, which is what the reporter is.
         $this->assertMatchesRegularExpression(
-            '/function \(\\\\Throwable \$e, string \$mimeType, int \$attachmentId\)/',
+            '/function \(\s*\\\\Throwable \$e,\s*string \$mimeType,\s*int \$attachmentId\s*\)/',
             $contents,
             $root . ' no longer installs the reporter FinanceMessageConsumer calls'
         );


### PR DESCRIPTION
## Description

Sixième et dernier lot de la campagne SonarCloud, et une correction de
méthode plutôt qu'un nouveau domaine : **65 anomalies `php:S1808`
restaient dans `core/`, `modules/` et `public/`** après les lots #311,
#313 et #314.

La raison est nette, et elle tient à la façon dont les lots précédents
ont été menés. Pour chacun, `php-cs-fixer` traitait la forme courante —
quelques arguments sur la ligne d'appel, le reste replié dessous — et un
script ciblé reprenait ensuite les cas qu'il ne voit pas, ceux où c'est
un argument qui s'étale lui-même sur plusieurs lignes. Mais ce script
n'était lancé que sur les fichiers que `php-cs-fixer` n'avait **pas**
touchés, pour éviter de repasser derrière lui. Un fichier reformaté par
l'outil pouvait donc conserver un `array_map(fn (...) => [ … ], $rows)`
à l'intérieur d'un `json([…])`, et personne ne le reprenait. Ce lot
passe le même script sur les 65 lignes que SonarCloud signale encore,
où qu'elles soient et quel que soit l'outil qui a touché le fichier.

Deux lignes dépassaient 120 caractères une fois indentées d'un niveau de
plus, et sont repliées : un appel à `MovementPresenter::description()`
et une phrase d'erreur de `MassMailController`, dont le texte concaténé
ne change pas d'un caractère.

La dernière anomalie du lot est d'une autre forme. Dans
`public/scheduler-bootstrap.php`, la fermeture qui signale au journal un
reçu que le module finances a refusé portait son `use` sur la ligne
suivante, ce que la règle refuse. Sur une seule ligne, cette signature
et son `use` font 122 caractères à l'indentation où ils se trouvent :
`php:S103` refuserait exactement ce que `php:S1808` demande. La liste de
paramètres est donc dépliée, ce qui satisfait les deux règles. Le test
d'architecture qui épingle cette fermeture
(`InboundReceiptIsNotSilentTest`, #175) tolère désormais les espaces
entre ses paramètres — et rien d'autre : la fermeture et ses trois
paramètres typés doivent toujours être là, une signature amputée, un
paramètre renommé ou un simple commentaire continuent de le faire
échouer (vérifié en fabriquant chacun de ces trois cas).

Aucun comportement n'est modifié dans ce lot : ce sont des retours à la
ligne, plus le dépliage d'une liste de paramètres.

## Checklist
- [x] I have read `ARCHITECTURE.md` and my changes conform to it
- [x] I have read `SECURITY.md` and applied the security checklist
- [x] All code and comments are in English
- [x] All UI-facing text is in French
- [x] This PR's title and description, and every commit message in it, are in French (`AGENTS.md` § Language)
- [x] Automated tests are written/updated for this change
- [x] Tests pass locally (`vendor/bin/phpunit` — 17 064 tests, 0 échec)
- [x] PHPStan passes (`vendor/bin/phpstan analyse` — couvre `core/`, `modules/` et `public/`)
- [x] If this PR changes `public/assets/js/` behavior : sans objet, aucun fichier de `public/assets/js/` n'est touché

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcpzpreZ2NU5kxcdGYdrtE

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcpzpreZ2NU5kxcdGYdrtE)_